### PR TITLE
fix: improves email finding and adds mx verifier

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  experimental: {
+    optimizePackageImports: ["lucide-react"],
+  },
 };
 
 export default nextConfig;

--- a/src/__tests__/email-pattern.test.ts
+++ b/src/__tests__/email-pattern.test.ts
@@ -1,0 +1,648 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyPattern,
+  emailMatchesName,
+  inferPattern,
+  isRolePrefix,
+  KNOWN_PATTERNS,
+  mxCheck,
+  recordBounce,
+  recordVerifiedEmail,
+  splitName,
+  type EmailSource,
+  type VerifiedEmail,
+} from "@/lib/services/email-pattern";
+
+// ─── Fake Supabase ────────────────────────────────────────────────────────
+//
+// Minimal in-memory stub of the SupabaseClient surface used by
+// recordVerifiedEmail / recordBounce / recomputeOrgPattern. Implements:
+//   .from(table).select(cols).eq(...).maybeSingle()       → { data, error }
+//   .from(table).select(cols).eq(...).not(...).then(...) → { data: row[], error }
+//   .from(table).update(values).eq(...)                  → mutates in-memory rows
+
+interface PersonRow {
+  id: string;
+  name: string;
+  organization_id: string | null;
+  work_email: string | null;
+  work_email_source: EmailSource | null;
+  work_email_confidence: number | null;
+  work_email_verified_at: string | null;
+}
+interface OrgRow {
+  id: string;
+  email_pattern: string | null;
+  email_pattern_confidence: number | null;
+  email_pattern_evidence_count: number;
+  email_pattern_bounce_count: number;
+  email_pattern_updated_at: string | null;
+}
+
+function createFakeSupabase(initial: {
+  people?: Partial<PersonRow>[];
+  organizations?: Partial<OrgRow>[];
+}) {
+  const tables = {
+    people: (initial.people ?? []).map((p) => ({
+      id: "",
+      name: "",
+      organization_id: null,
+      work_email: null,
+      work_email_source: null,
+      work_email_confidence: null,
+      work_email_verified_at: null,
+      ...p,
+    })) as PersonRow[],
+    organizations: (initial.organizations ?? []).map((o) => ({
+      id: "",
+      email_pattern: null,
+      email_pattern_confidence: null,
+      email_pattern_evidence_count: 0,
+      email_pattern_bounce_count: 0,
+      email_pattern_updated_at: null,
+      ...o,
+    })) as OrgRow[],
+  };
+
+  function chain(table: keyof typeof tables) {
+    type Mode = "select" | "update";
+    let mode: Mode = "select";
+    let single = false;
+    let updates: Record<string, unknown> = {};
+    const preds: Array<(r: Record<string, unknown>) => boolean> = [];
+
+    const c: Record<string, unknown> & PromiseLike<unknown> = {
+      select(_cols?: string) {
+        mode = "select";
+        return c;
+      },
+      update(values: Record<string, unknown>) {
+        mode = "update";
+        updates = values;
+        return c;
+      },
+      eq(col: string, val: unknown) {
+        preds.push((r) => r[col] === val);
+        return c;
+      },
+      not(col: string, _op: string, val: unknown) {
+        preds.push((r) => r[col] !== val);
+        return c;
+      },
+      limit(_n: number) {
+        return c;
+      },
+      order(_col: string, _opts?: unknown) {
+        return c;
+      },
+      maybeSingle() {
+        single = true;
+        return c;
+      },
+      then(onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) {
+        const rows = tables[table] as unknown as Record<string, unknown>[];
+        if (mode === "update") {
+          for (const r of rows) {
+            if (preds.every((p) => p(r))) Object.assign(r, updates);
+          }
+          return Promise.resolve({ data: null, error: null }).then(onF, onR);
+        }
+        const matches = rows.filter((r) => preds.every((p) => p(r)));
+        const data = single ? (matches[0] ?? null) : matches;
+        return Promise.resolve({ data, error: null }).then(onF, onR);
+      },
+    } as unknown as Record<string, unknown> & PromiseLike<unknown>;
+    return c;
+  }
+
+  const client = {
+    from: (table: string) => chain(table as keyof typeof tables),
+  } as unknown as SupabaseClient;
+  return { client, tables };
+}
+
+// ─── splitName ────────────────────────────────────────────────────────────
+
+describe("splitName", () => {
+  it("splits a normal two-word name", () => {
+    expect(splitName("Jane Doe")).toEqual({ first: "jane", last: "doe" });
+  });
+  it("returns last as null for a single-word name", () => {
+    expect(splitName("Madonna")).toEqual({ first: "madonna", last: null });
+  });
+  it("treats the last whitespace-separated token as the last name", () => {
+    expect(splitName("Mary Jane Watson")).toEqual({
+      first: "mary",
+      last: "watson",
+    });
+  });
+  it("returns nulls for empty input", () => {
+    expect(splitName("")).toEqual({ first: null, last: null });
+  });
+});
+
+// ─── isRolePrefix ─────────────────────────────────────────────────────────
+
+describe("isRolePrefix", () => {
+  it.each([
+    ["it", true],
+    ["info", true],
+    ["support", true],
+    ["it.dept", true],
+    ["support_team", true],
+    ["sales-eu", true],
+    ["press+pitches", true],
+    ["jane", false],
+    ["jdoe", false],
+    ["jane.doe", false],
+    ["italian.person", false], // doesn't start with "it" + separator
+    ["informal", false], // doesn't start with "info" + separator
+  ])("isRolePrefix(%s) → %s", (local, expected) => {
+    expect(isRolePrefix(local)).toBe(expected);
+  });
+});
+
+// ─── emailMatchesName ─────────────────────────────────────────────────────
+
+describe("emailMatchesName", () => {
+  it("rejects role-style addresses for a real person", () => {
+    expect(emailMatchesName("it@acme.com", "Jane", "Doe")).toBe(false);
+    expect(emailMatchesName("support@acme.com", "Jane", "Doe")).toBe(false);
+  });
+  it.each([
+    ["jane@acme.com", "Jane", "Doe"],
+    ["doe@acme.com", "Jane", "Doe"],
+    ["jane.doe@acme.com", "Jane", "Doe"],
+    ["jdoe@acme.com", "Jane", "Doe"],
+    ["janed@acme.com", "Jane", "Doe"],
+    ["doe.jane@acme.com", "Jane", "Doe"],
+    ["jane_doe@acme.com", "Jane", "Doe"],
+    ["jay.sahnan@browserbase.com", "Jay", "Sahnan"],
+  ])("accepts %s for %s %s", (email, first, last) => {
+    expect(emailMatchesName(email, first, last)).toBe(true);
+  });
+  it("rejects unrelated names", () => {
+    expect(emailMatchesName("bob@acme.com", "Jane", "Doe")).toBe(false);
+  });
+  it("handles missing last name gracefully", () => {
+    expect(emailMatchesName("madonna@acme.com", "Madonna", null)).toBe(true);
+    expect(emailMatchesName("admin@acme.com", "Madonna", null)).toBe(false);
+  });
+});
+
+// ─── applyPattern ─────────────────────────────────────────────────────────
+
+describe("applyPattern", () => {
+  const cases: Array<[string, string, string, string, string]> = [
+    ["{first}.{last}", "Jane", "Doe", "acme.com", "jane.doe@acme.com"],
+    ["{first}{last}", "Jane", "Doe", "acme.com", "janedoe@acme.com"],
+    ["{f}{last}", "Jane", "Doe", "acme.com", "jdoe@acme.com"],
+    ["{first}_{last}", "Jane", "Doe", "acme.com", "jane_doe@acme.com"],
+    ["{first}-{last}", "Jane", "Doe", "acme.com", "jane-doe@acme.com"],
+    ["{f}.{last}", "Jane", "Doe", "acme.com", "j.doe@acme.com"],
+    ["{first}.{l}", "Jane", "Doe", "acme.com", "jane.d@acme.com"],
+    ["{first}", "Jane", "Doe", "acme.com", "jane@acme.com"],
+    ["{last}", "Jane", "Doe", "acme.com", "doe@acme.com"],
+  ];
+  it.each(cases)(
+    "applyPattern(%s, %s, %s, %s) → %s",
+    (pattern, first, last, domain, expected) => {
+      expect(applyPattern(pattern, first, last, domain)).toBe(expected);
+    },
+  );
+
+  it("strips non-alphanumeric from name parts", () => {
+    expect(
+      applyPattern("{first}.{last}", "Marie-Claire", "O'Brien", "acme.com"),
+    ).toBe("marieclaire.obrien@acme.com");
+  });
+
+  it("returns null when last name needed but missing", () => {
+    expect(
+      applyPattern("{first}.{last}", "Madonna", null, "acme.com"),
+    ).toBeNull();
+  });
+
+  it("works with single-name + first-only pattern", () => {
+    expect(applyPattern("{first}", "Madonna", null, "acme.com")).toBe(
+      "madonna@acme.com",
+    );
+  });
+
+  it("lowercases the domain", () => {
+    expect(applyPattern("{first}", "Jane", null, "Acme.COM")).toBe(
+      "jane@acme.com",
+    );
+  });
+});
+
+// ─── inferPattern ─────────────────────────────────────────────────────────
+
+describe("inferPattern", () => {
+  it("returns null pattern when no emails are provided", () => {
+    expect(inferPattern([])).toEqual({
+      pattern: null,
+      confidence: 0,
+      evidenceCount: 0,
+    });
+  });
+
+  it("finds the right pattern from a single team-page email", () => {
+    const emails: VerifiedEmail[] = [
+      {
+        email: "jane.doe@acme.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        source: "team_page",
+      },
+    ];
+    const result = inferPattern(emails);
+    expect(result.pattern).toBe("{first}.{last}");
+    expect(result.confidence).toBeCloseTo(1.0);
+    expect(result.evidenceCount).toBe(1);
+  });
+
+  it("aggregates multiple matching emails", () => {
+    const emails: VerifiedEmail[] = [
+      {
+        email: "jane.doe@acme.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        source: "team_page",
+      },
+      {
+        email: "bob.smith@acme.com",
+        firstName: "Bob",
+        lastName: "Smith",
+        source: "team_page",
+      },
+      {
+        email: "lee.jones@acme.com",
+        firstName: "Lee",
+        lastName: "Jones",
+        source: "send_confirmed",
+      },
+    ];
+    const result = inferPattern(emails);
+    expect(result.pattern).toBe("{first}.{last}");
+    expect(result.evidenceCount).toBe(3);
+    expect(result.confidence).toBeCloseTo(1.0);
+  });
+
+  it("ignores role-prefix addresses entirely", () => {
+    const emails: VerifiedEmail[] = [
+      {
+        email: "it@acme.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        source: "team_page",
+      },
+    ];
+    expect(inferPattern(emails).pattern).toBeNull();
+  });
+
+  it("favors send_confirmed evidence over scraped emails when patterns conflict", () => {
+    const emails: VerifiedEmail[] = [
+      // 1 scraped email matching {first}.{last} (weight 0.7)
+      {
+        email: "jane.doe@acme.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        source: "team_page",
+      },
+      // 1 send-confirmed email matching {first} (weight 0.95)
+      {
+        email: "bob@acme.com",
+        firstName: "Bob",
+        lastName: "Smith",
+        source: "send_confirmed",
+      },
+    ];
+    const result = inferPattern(emails);
+    expect(result.pattern).toBe("{first}");
+    // confidence = 0.95 / (0.7 + 0.95)
+    expect(result.confidence).toBeGreaterThan(0.5);
+    expect(result.confidence).toBeLessThan(1);
+  });
+
+  it("ignores pattern_derived sources (no feedback loop)", () => {
+    const emails: VerifiedEmail[] = [
+      {
+        email: "jane.doe@acme.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        source: "pattern_derived",
+      },
+    ];
+    expect(inferPattern(emails).pattern).toBeNull();
+  });
+
+  it("includes every known pattern in scoring", () => {
+    // Sanity check that KNOWN_PATTERNS hasn't drifted from the test cases above.
+    expect(KNOWN_PATTERNS).toContain("{first}.{last}");
+    expect(KNOWN_PATTERNS).toContain("{first}");
+  });
+});
+
+// ─── mxCheck ──────────────────────────────────────────────────────────────
+
+// ─── recordVerifiedEmail ──────────────────────────────────────────────────
+
+describe("recordVerifiedEmail", () => {
+  it("skips role-prefix addresses (does not write)", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [{ id: "p1", name: "Jane Doe", organization_id: "o1" }],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "it@acme.com",
+      source: "team_page",
+    });
+    expect(tables.people[0].work_email).toBeNull();
+    expect(tables.people[0].work_email_source).toBeNull();
+  });
+
+  it("writes a new email when person has none", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [{ id: "p1", name: "Jane Doe", organization_id: "o1" }],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "Jane.Doe@Acme.com",
+      source: "team_page",
+    });
+    expect(tables.people[0].work_email).toBe("jane.doe@acme.com");
+    expect(tables.people[0].work_email_source).toBe("team_page");
+    expect(tables.people[0].work_email_confidence).toBeCloseTo(0.7);
+    expect(tables.people[0].work_email_verified_at).not.toBeNull();
+  });
+
+  it("does NOT downgrade send_confirmed → team_page on a different email", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "send_confirmed",
+          work_email_confidence: 0.95,
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane.doe@acme.com",
+      source: "team_page",
+    });
+    expect(tables.people[0].work_email).toBe("jane@acme.com");
+    expect(tables.people[0].work_email_source).toBe("send_confirmed");
+  });
+
+  it("upgrades team_page → user_entered for the same email", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "team_page",
+          work_email_confidence: 0.7,
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane@acme.com",
+      source: "user_entered",
+    });
+    expect(tables.people[0].work_email_source).toBe("user_entered");
+    expect(tables.people[0].work_email_confidence).toBeCloseTo(1.0);
+  });
+
+  it("keeps the stronger source on a same-email refresh with weaker source", async () => {
+    // Same email, weaker incoming source: refresh verified_at, keep stronger source.
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "send_confirmed",
+          work_email_confidence: 0.95,
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane@acme.com",
+      source: "team_page",
+    });
+    expect(tables.people[0].work_email_source).toBe("send_confirmed");
+    expect(tables.people[0].work_email_confidence).toBeCloseTo(0.95);
+    expect(tables.people[0].work_email_verified_at).not.toBeNull();
+  });
+});
+
+// ─── recordBounce ─────────────────────────────────────────────────────────
+
+describe("recordBounce", () => {
+  it("no-ops when person not found", async () => {
+    const { client, tables } = createFakeSupabase({});
+    await recordBounce(client, { personId: "missing", email: "x@y.com" });
+    expect(tables.people).toHaveLength(0);
+  });
+
+  it("no-ops when bounced email differs from stored work_email", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "send_confirmed",
+          work_email_confidence: 0.95,
+          work_email_verified_at: "2026-04-25T00:00:00Z",
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordBounce(client, {
+      personId: "p1",
+      email: "different@acme.com",
+    });
+    // Untouched
+    expect(tables.people[0].work_email_verified_at).toBe(
+      "2026-04-25T00:00:00Z",
+    );
+    expect(tables.people[0].work_email_confidence).toBeCloseTo(0.95);
+  });
+
+  it("clears verified_at + confidence on the person", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "team_page",
+          work_email_confidence: 0.7,
+          work_email_verified_at: "2026-04-25T00:00:00Z",
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordBounce(client, { personId: "p1", email: "jane@acme.com" });
+    expect(tables.people[0].work_email_verified_at).toBeNull();
+    expect(tables.people[0].work_email_confidence).toBe(0);
+  });
+
+  it("does NOT touch the org pattern when source != pattern_derived", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "team_page",
+          work_email_confidence: 0.7,
+        },
+      ],
+      organizations: [
+        {
+          id: "o1",
+          email_pattern: "{first}.{last}",
+          email_pattern_confidence: 0.9,
+          email_pattern_evidence_count: 3,
+          email_pattern_bounce_count: 0,
+        },
+      ],
+    });
+    await recordBounce(client, { personId: "p1", email: "jane@acme.com" });
+    expect(tables.organizations[0].email_pattern).toBe("{first}.{last}");
+    expect(tables.organizations[0].email_pattern_confidence).toBeCloseTo(0.9);
+    expect(tables.organizations[0].email_pattern_bounce_count).toBe(0);
+  });
+
+  it("halves the pattern confidence when bounce ratio crosses 0.3", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "pattern_derived",
+        },
+      ],
+      organizations: [
+        {
+          id: "o1",
+          email_pattern: "{first}.{last}",
+          email_pattern_confidence: 0.8,
+          email_pattern_evidence_count: 3,
+          email_pattern_bounce_count: 0,
+        },
+      ],
+    });
+    await recordBounce(client, { personId: "p1", email: "jane@acme.com" });
+    // 1/3 = 0.33 → halve: 0.4
+    expect(tables.organizations[0].email_pattern).toBe("{first}.{last}");
+    expect(tables.organizations[0].email_pattern_confidence).toBeCloseTo(0.4);
+    expect(tables.organizations[0].email_pattern_bounce_count).toBe(1);
+  });
+
+  it("clears the pattern entirely when bounce ratio crosses 0.5", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "pattern_derived",
+        },
+      ],
+      organizations: [
+        {
+          id: "o1",
+          email_pattern: "{first}.{last}",
+          email_pattern_confidence: 0.8,
+          email_pattern_evidence_count: 1,
+          email_pattern_bounce_count: 0,
+        },
+      ],
+    });
+    await recordBounce(client, { personId: "p1", email: "jane@acme.com" });
+    // 1/1 = 1.0 → clear
+    expect(tables.organizations[0].email_pattern).toBeNull();
+    expect(tables.organizations[0].email_pattern_confidence).toBe(0);
+    expect(tables.organizations[0].email_pattern_bounce_count).toBe(1);
+  });
+
+  it("does NOT wipe a pattern when evidence_count is 0 even after recompute", async () => {
+    // Cached pattern exists but evidence_count is 0 (stale cache, no
+    // verifiable people in the org). Bounce should bump count but leave the
+    // pattern intact since recomputeOrgPattern would also see 0 evidence
+    // and write null — meaning we end up not finding any votes for the
+    // existing pattern. Behavior here: don't apply the ratio rule, just
+    // bump the bounce count.
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "pattern_derived",
+        },
+      ],
+      organizations: [
+        {
+          id: "o1",
+          email_pattern: "{first}.{last}",
+          email_pattern_confidence: 0.8,
+          email_pattern_evidence_count: 0,
+          email_pattern_bounce_count: 0,
+        },
+      ],
+    });
+    await recordBounce(client, { personId: "p1", email: "jane@acme.com" });
+    // After recompute: no other verified people in the org, so pattern
+    // becomes null + evidence stays 0. Bounce count bumps to 1, but the
+    // ratio branch is skipped because evidence is still 0.
+    expect(tables.organizations[0].email_pattern_bounce_count).toBe(1);
+  });
+});
+
+describe("mxCheck", () => {
+  it("returns true when DNS returns at least one MX record", async () => {
+    const resolver = vi
+      .fn()
+      .mockResolvedValue([{ exchange: "smtp.example.com", priority: 10 }]);
+    expect(await mxCheck("acme.com", resolver)).toBe(true);
+  });
+
+  it("returns false when DNS lookup throws (NXDOMAIN, etc.)", async () => {
+    const resolver = vi.fn().mockRejectedValue(new Error("NXDOMAIN"));
+    expect(await mxCheck("nope.invalid", resolver)).toBe(false);
+  });
+
+  it("returns false when DNS returns zero MX records", async () => {
+    const resolver = vi.fn().mockResolvedValue([]);
+    expect(await mxCheck("noemail.example.com", resolver)).toBe(false);
+  });
+});

--- a/src/app/api/agentmail/webhook/route.ts
+++ b/src/app/api/agentmail/webhook/route.ts
@@ -1,16 +1,24 @@
 import { NextResponse } from "next/server";
 import { Webhook } from "svix";
 import { getAdminClient } from "@/lib/supabase/admin";
+import {
+  recordBounce,
+  recordVerifiedEmail,
+} from "@/lib/services/email-pattern";
 
 export const runtime = "nodejs";
 
 /**
- * AgentMail webhook receiver. Handles `message.received` to flip a tracked
- * outbound email's status to `replied`. Signature verification uses Svix
- * (AGENTMAIL_WEBHOOK_SECRET, starts with `whsec_`).
+ * AgentMail webhook receiver.
  *
- * Wire format is snake_case; the SDK's camelCase types do not apply here
- * because the payload arrives directly from AgentMail's servers.
+ * - `message.received`  → flip a tracked outbound email's status to `replied`.
+ * - `message.delivered` → promote the recipient's email to `send_confirmed`
+ *                         (ground-truth verification + feeds the org pattern).
+ * - `message.bounced`   → mark the email invalid + dent the org pattern's
+ *                         confidence if the email was pattern-derived.
+ *
+ * Signature verification uses Svix (AGENTMAIL_WEBHOOK_SECRET, starts with `whsec_`).
+ * Wire format is snake_case; the SDK's camelCase types do not apply here.
  */
 
 type InboundEvent = {
@@ -21,10 +29,48 @@ type InboundEvent = {
     thread_id?: string;
     message_id?: string;
     from?: string;
+    to?: string;
     in_reply_to?: string;
   };
   thread?: { thread_id?: string };
 };
+
+interface SentEmailRow {
+  id: string;
+  campaign_people_id: string;
+  status: string;
+  to_email: string | null;
+  person_id: string | null;
+}
+
+async function findSentEmail(
+  supabase: ReturnType<typeof getAdminClient>,
+  args: { threadId: string | null; messageId: string | null },
+): Promise<SentEmailRow | null> {
+  const select = "id, campaign_people_id, status, to_email, person_id";
+
+  if (args.messageId) {
+    const { data } = await supabase
+      .from("sent_emails")
+      .select(select)
+      .eq("agentmail_message_id", args.messageId)
+      .maybeSingle();
+    if (data) return data as SentEmailRow;
+  }
+
+  if (args.threadId) {
+    const { data } = await supabase
+      .from("sent_emails")
+      .select(select)
+      .eq("agentmail_thread_id", args.threadId)
+      .order("sent_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (data) return data as SentEmailRow;
+  }
+
+  return null;
+}
 
 export async function POST(req: Request) {
   const secret = process.env.AGENTMAIL_WEBHOOK_SECRET;
@@ -49,60 +95,102 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  if (event.event_type !== "message.received") {
-    return NextResponse.json({ ok: true, ignored: event.event_type });
-  }
-
-  const threadId = event.message?.thread_id ?? event.thread?.thread_id ?? null;
-  const inReplyTo = event.message?.in_reply_to ?? null;
-
   const supabase = getAdminClient();
+  const threadId = event.message?.thread_id ?? event.thread?.thread_id ?? null;
+  const messageId = event.message?.message_id ?? null;
 
-  let sent: {
-    id: string;
-    campaign_people_id: string;
-    status: string;
-  } | null = null;
+  switch (event.event_type) {
+    case "message.received": {
+      // Reply detected. Match by thread first (typical case), then fall back
+      // to in_reply_to → our stored message_id.
+      const inReplyTo = event.message?.in_reply_to ?? null;
+      const sent = await findSentEmail(supabase, {
+        threadId,
+        messageId: inReplyTo,
+      });
+      if (!sent) {
+        return NextResponse.json({ ok: true, skipped: "untracked thread" });
+      }
+      if (sent.status === "replied") {
+        return NextResponse.json({ ok: true, alreadyReplied: true });
+      }
+      await Promise.all([
+        supabase
+          .from("sent_emails")
+          .update({ status: "replied" })
+          .eq("id", sent.id),
+        supabase
+          .from("campaign_people")
+          .update({ outreach_status: "replied" })
+          .eq("id", sent.campaign_people_id),
+      ]);
+      return NextResponse.json({ ok: true, updated: sent.id });
+    }
 
-  if (threadId) {
-    const { data } = await supabase
-      .from("sent_emails")
-      .select("id, campaign_people_id, status")
-      .eq("agentmail_thread_id", threadId)
-      .order("sent_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    sent = data;
+    case "message.delivered": {
+      const sent = await findSentEmail(supabase, { threadId, messageId });
+      if (!sent) {
+        return NextResponse.json({ ok: true, skipped: "untracked message" });
+      }
+      // Mark as delivered (don't downgrade if already 'replied') AND promote
+      // the recipient's address to `send_confirmed`. Three independent writes
+      // hit different tables and run in parallel.
+      const tasks: PromiseLike<unknown>[] = [];
+      if (sent.status === "sent") {
+        tasks.push(
+          supabase
+            .from("sent_emails")
+            .update({ status: "delivered" })
+            .eq("id", sent.id),
+          // Don't clobber a downstream 'replied' that beat us here.
+          supabase
+            .from("campaign_people")
+            .update({ outreach_status: "delivered" })
+            .eq("id", sent.campaign_people_id)
+            .eq("outreach_status", "sent"),
+        );
+      }
+      if (sent.person_id && sent.to_email) {
+        tasks.push(
+          recordVerifiedEmail(supabase, {
+            personId: sent.person_id,
+            email: sent.to_email,
+            source: "send_confirmed",
+          }),
+        );
+      }
+      await Promise.all(tasks);
+      return NextResponse.json({ ok: true, delivered: sent.id });
+    }
+
+    case "message.bounced": {
+      const sent = await findSentEmail(supabase, { threadId, messageId });
+      if (!sent) {
+        return NextResponse.json({ ok: true, skipped: "untracked message" });
+      }
+      const tasks: PromiseLike<unknown>[] = [
+        supabase
+          .from("sent_emails")
+          .update({ status: "bounced" })
+          .eq("id", sent.id),
+        supabase
+          .from("campaign_people")
+          .update({ outreach_status: "bounced" })
+          .eq("id", sent.campaign_people_id),
+      ];
+      if (sent.person_id && sent.to_email) {
+        tasks.push(
+          recordBounce(supabase, {
+            personId: sent.person_id,
+            email: sent.to_email,
+          }),
+        );
+      }
+      await Promise.all(tasks);
+      return NextResponse.json({ ok: true, bounced: sent.id });
+    }
+
+    default:
+      return NextResponse.json({ ok: true, ignored: event.event_type });
   }
-
-  // Fallback for rows sent before thread_id was captured: match the
-  // inbound message's in_reply_to to our stored message_id.
-  if (!sent && inReplyTo) {
-    const { data } = await supabase
-      .from("sent_emails")
-      .select("id, campaign_people_id, status")
-      .eq("agentmail_message_id", inReplyTo)
-      .maybeSingle();
-    sent = data;
-  }
-
-  if (!sent) {
-    return NextResponse.json({ ok: true, skipped: "untracked thread" });
-  }
-
-  if (sent.status === "replied") {
-    return NextResponse.json({ ok: true, alreadyReplied: true });
-  }
-
-  await supabase
-    .from("sent_emails")
-    .update({ status: "replied" })
-    .eq("id", sent.id);
-
-  await supabase
-    .from("campaign_people")
-    .update({ outreach_status: "replied" })
-    .eq("id", sent.campaign_people_id);
-
-  return NextResponse.json({ ok: true, updated: sent.id });
 }

--- a/src/app/api/email/record-verified/route.ts
+++ b/src/app/api/email/record-verified/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { recordVerifiedEmail } from "@/lib/services/email-pattern";
+
+export const runtime = "nodejs";
+
+/**
+ * Record that a user manually confirmed (typed) an email for a person. The
+ * server-side `recordVerifiedEmail` does role-prefix filtering and recomputes
+ * the org's email pattern. The page calls this in addition to its own
+ * email_drafts update, so the agent (and other contacts) benefit from the
+ * confirmation.
+ */
+export async function POST(req: Request) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase } = ctx;
+
+  let body: { personId?: string; email?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { personId, email } = body;
+  if (!personId || !email) {
+    return NextResponse.json(
+      { error: "personId and email are required" },
+      { status: 400 },
+    );
+  }
+
+  // Ownership: person must be linked to a campaign owned by this user. Without
+  // this check any logged-in user could overwrite anyone's work_email and
+  // poison the org's email_pattern (cross-tenant).
+  const { data: ownership } = await supabase
+    .from("campaign_people")
+    .select("campaign:campaigns!inner(user_id)")
+    .eq("person_id", personId)
+    .limit(1)
+    .maybeSingle();
+
+  const ownerId =
+    (ownership?.campaign as unknown as { user_id?: string } | null)?.user_id ??
+    null;
+
+  if (!ownerId || ownerId !== ctx.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await recordVerifiedEmail(supabase, {
+    personId,
+    email,
+    source: "user_entered",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/enrich-company/route.ts
+++ b/src/app/api/enrich-company/route.ts
@@ -19,6 +19,7 @@ import {
   type CompanyContext,
   type CandidateContact,
 } from "@/lib/services/contact-filter";
+import { recordVerifiedEmail } from "@/lib/services/email-pattern";
 import { parseLinkedInTitle } from "@/lib/utils";
 
 export const maxDuration = 120;
@@ -217,6 +218,14 @@ async function findContactsForCompany(
           organization_id: orgId,
           source: "website",
         });
+
+        if (dp.email) {
+          await recordVerifiedEmail(supabase, {
+            personId: person.id,
+            email: dp.email,
+            source: "team_page",
+          });
+        }
 
         await linkPersonToCampaign(person.id, campaignId);
         if (dp.linkedinUrl) existingUrls.add(dp.linkedinUrl);

--- a/src/app/api/find-contacts/route.ts
+++ b/src/app/api/find-contacts/route.ts
@@ -10,6 +10,7 @@ import {
   filterContactsByCompany,
   type CandidateContact,
 } from "@/lib/services/contact-filter";
+import { recordVerifiedEmail } from "@/lib/services/email-pattern";
 import { parseLinkedInTitle } from "@/lib/utils";
 
 export const maxDuration = 120;
@@ -115,6 +116,14 @@ export async function POST(request: Request) {
             organization_id: orgId,
             source: "website",
           });
+
+          if (dp.email) {
+            await recordVerifiedEmail(supabase, {
+              personId: person.id,
+              email: dp.email,
+              source: "team_page",
+            });
+          }
 
           await linkPersonToCampaign(person.id, campaignId);
           if (dp.linkedinUrl) existingUrls.add(dp.linkedinUrl);

--- a/src/app/api/find-email/bulk/route.ts
+++ b/src/app/api/find-email/bulk/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { findEmailForPerson } from "@/lib/tools/email-tools";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+// Hard cap to bound Exa cost per click. Each call may fire one Exa search
+// (~$0.007) for the first contact at a brand-new org; the rest derive from
+// the now-cached pattern. 50 covers typical mid-sized companies and keeps a
+// runaway click bounded to ~$0.35.
+const MAX_TARGETS_PER_REQUEST = 50;
+
+/**
+ * Bulk "Find emails" — runs `findEmailForPerson` for every contact at one
+ * organization in a campaign that's missing a work_email. Sequential by
+ * design so the first lookup at a brand-new org caches the pattern, and
+ * subsequent ones at the same org derive for free.
+ *
+ * `organizationId` is required: this matches the per-company UI button (one
+ * click = one company) and prevents accidental campaign-wide Exa fanout.
+ */
+export async function POST(req: Request) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase, user } = ctx;
+
+  let body: { campaignId?: string; organizationId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { campaignId, organizationId } = body;
+  if (!campaignId) {
+    return NextResponse.json({ error: "campaignId required" }, { status: 400 });
+  }
+  if (!organizationId) {
+    return NextResponse.json(
+      { error: "organizationId required (one company per request)" },
+      { status: 400 },
+    );
+  }
+
+  // Ownership check on the campaign.
+  const { data: campaign } = await supabase
+    .from("campaigns")
+    .select("user_id")
+    .eq("id", campaignId)
+    .maybeSingle();
+  if (!campaign || campaign.user_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Pull every campaign_person → person where work_email is missing, scoped
+  // to the requested organization.
+  const { data: rows, error } = await supabase
+    .from("campaign_people")
+    .select("person:people!inner(id, work_email, organization_id)")
+    .eq("campaign_id", campaignId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const targets: string[] = [];
+  let pendingTotal = 0;
+  for (const row of rows ?? []) {
+    const person = row.person as unknown as {
+      id: string;
+      work_email: string | null;
+      organization_id: string | null;
+    } | null;
+    if (!person) continue;
+    if (person.work_email) continue;
+    if (person.organization_id !== organizationId) continue;
+    pendingTotal++;
+    if (targets.length < MAX_TARGETS_PER_REQUEST) {
+      targets.push(person.id);
+    }
+  }
+
+  const found: Array<{ personId: string; email: string; confidence?: number }> =
+    [];
+  const notFound: Array<{ personId: string; reason?: string }> = [];
+
+  for (const personId of targets) {
+    try {
+      const result = await findEmailForPerson(personId);
+      if (result.email) {
+        found.push({
+          personId,
+          email: result.email,
+          confidence: result.confidence,
+        });
+      } else {
+        notFound.push({ personId, reason: result.reason });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      notFound.push({ personId, reason: msg });
+    }
+  }
+
+  const remaining = Math.max(0, pendingTotal - targets.length);
+  const truncated = remaining > 0;
+
+  return NextResponse.json({
+    total: targets.length,
+    pendingTotal,
+    remaining,
+    truncated,
+    found,
+    notFound,
+    summary: truncated
+      ? `Found ${found.length} of ${targets.length} (${remaining} more pending — click again).`
+      : `Found ${found.length} of ${targets.length} emails. ${notFound.length} not found.`,
+  });
+}

--- a/src/app/api/find-email/route.ts
+++ b/src/app/api/find-email/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { findEmailForPerson } from "@/lib/tools/email-tools";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * User-triggered "Find email" for a single contact. Wraps the same
+ * findEmailForPerson logic the agent uses, with an ownership check so users
+ * can only resolve emails for people in their own campaigns.
+ */
+export async function POST(req: Request) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase, user } = ctx;
+
+  let body: { personId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const personId = body.personId;
+  if (!personId) {
+    return NextResponse.json({ error: "personId required" }, { status: 400 });
+  }
+
+  // Ownership check: person must be linked to a campaign owned by this user.
+  const { data: ownership } = await supabase
+    .from("campaign_people")
+    .select("campaign:campaigns!inner(user_id)")
+    .eq("person_id", personId)
+    .limit(1)
+    .maybeSingle();
+
+  const ownerId =
+    (ownership?.campaign as unknown as { user_id?: string } | null)?.user_id ??
+    null;
+
+  if (!ownerId || ownerId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await findEmailForPerson(personId);
+  return NextResponse.json(result);
+}

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -58,6 +58,7 @@ interface DraftForReview {
   person_name: string;
   person_title: string | null;
   person_work_email: string | null;
+  person_work_email_confidence: number | null;
   person_personal_email: string | null;
   person_linkedin_url: string | null;
   person_twitter_url: string | null;
@@ -72,6 +73,15 @@ interface DraftForReview {
   total_steps: number;
   delay_days: number | null;
   delay_hours: number | null;
+}
+
+function emailConfidenceLabel(
+  confidence: number | null,
+): { label: string; tone: "verified" | "ok" | "guessed" } | null {
+  if (confidence == null) return null;
+  if (confidence >= 0.9) return { label: "verified", tone: "verified" };
+  if (confidence >= 0.5) return { label: "likely", tone: "ok" };
+  return { label: "guessed", tone: "guessed" };
 }
 
 function formatDelay(days: number | null, hours: number | null): string {
@@ -147,7 +157,8 @@ function ReviewPageInner() {
           people(
             name, title, organization_id, enrichment_data,
             enrichment_status, last_enriched_at,
-            work_email, personal_email, linkedin_url, twitter_url,
+            work_email, work_email_confidence,
+            personal_email, linkedin_url, twitter_url,
             organizations(name, domain, industry)
           ),
           campaign_people(priority_score),
@@ -178,6 +189,7 @@ function ReviewPageInner() {
           enrichment_status: "pending" | "in_progress" | "enriched" | "failed";
           last_enriched_at: string | null;
           work_email: string | null;
+          work_email_confidence: number | null;
           personal_email: string | null;
           linkedin_url: string | null;
           twitter_url: string | null;
@@ -215,6 +227,7 @@ function ReviewPageInner() {
           person_name: person?.name ?? "Unknown",
           person_title: person?.title ?? null,
           person_work_email: person?.work_email ?? null,
+          person_work_email_confidence: person?.work_email_confidence ?? null,
           person_personal_email: person?.personal_email ?? null,
           person_linkedin_url: person?.linkedin_url ?? null,
           person_twitter_url: person?.twitter_url ?? null,
@@ -638,6 +651,15 @@ function ReviewPageInner() {
         .eq("id", personId);
       if (personErr) throw new Error(personErr.message);
 
+      // Promote to user_entered source + recompute the org pattern. Fire-and-
+      // forget so a slow recompute doesn't block the UI; the prior person
+      // update already persisted the email.
+      void fetch("/api/email/record-verified", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ personId, email: next }),
+      });
+
       setDrafts((prev) =>
         prev.map((d) =>
           d.person_id === personId
@@ -793,6 +815,26 @@ function ReviewPageInner() {
                   value={currentContact.to_email}
                   onSave={handleContactEmailEdit}
                 />
+                {(() => {
+                  const chip = emailConfidenceLabel(
+                    currentContact.person_work_email_confidence,
+                  );
+                  if (!chip) return null;
+                  const toneClass =
+                    chip.tone === "verified"
+                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                      : chip.tone === "ok"
+                        ? "bg-muted text-muted-foreground"
+                        : "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400";
+                  return (
+                    <span
+                      className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${toneClass}`}
+                      title={`Confidence: ${(currentContact.person_work_email_confidence! * 100).toFixed(0)}%`}
+                    >
+                      {chip.label}
+                    </span>
+                  );
+                })()}
               </div>
             </div>
 

--- a/src/components/campaign/companies-list.tsx
+++ b/src/components/campaign/companies-list.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   ExternalLink,
   Loader2,
+  Mail,
   Sparkles,
   UserSearch,
 } from "lucide-react";
@@ -80,6 +81,12 @@ export function CompaniesList({
   const [findingContactsIds, setFindingContactsIds] = useState<Set<string>>(
     new Set(),
   );
+  const [findingEmailIds, setFindingEmailIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [findingEmailsCompanyIds, setFindingEmailsCompanyIds] = useState<
+    Set<string>
+  >(new Set());
   const [page, setPage] = useState(0);
   const pageSize = 10;
 
@@ -183,6 +190,47 @@ export function CompaniesList({
     }
   };
 
+  const findEmailForContact = async (contact: CampaignContact) => {
+    setFindingEmailIds((prev) => new Set(prev).add(contact.id));
+    try {
+      await fetch("/api/find-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ personId: contact.person_id }),
+      });
+      onDataChanged();
+    } catch (err) {
+      console.error(`[find-email] Failed:`, err);
+    } finally {
+      setFindingEmailIds((prev) => {
+        const next = new Set(prev);
+        next.delete(contact.id);
+        return next;
+      });
+    }
+  };
+
+  const findEmailsForCompany = async (organizationId: string | null) => {
+    if (!organizationId) return;
+    setFindingEmailsCompanyIds((prev) => new Set(prev).add(organizationId));
+    try {
+      await fetch("/api/find-email/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ campaignId, organizationId }),
+      });
+      onDataChanged();
+    } catch (err) {
+      console.error(`[find-email/bulk] Failed:`, err);
+    } finally {
+      setFindingEmailsCompanyIds((prev) => {
+        const next = new Set(prev);
+        next.delete(organizationId);
+        return next;
+      });
+    }
+  };
+
   const isCompanyEnriched = (company: CampaignCompany) => {
     const data = company.enrichment_data;
     return data && "enrichedAt" in data;
@@ -261,16 +309,20 @@ export function CompaniesList({
               const isExpanded = expandedCompanyIds.has(company.id);
               const companyContacts =
                 contactsByOrgId.get(company.organization_id) ?? [];
-              const enrichedCount = companyContacts.filter(
-                (c) => c.enrichment_status === "enriched",
-              ).length;
-              const scoredContacts = companyContacts.filter(
-                (c) => c.priority_score != null && c.priority_score > 0,
-              );
-              const topScore =
-                scoredContacts.length > 0
-                  ? Math.max(...scoredContacts.map((c) => c.priority_score!))
-                  : null;
+              let enrichedCount = 0;
+              let missingEmailCount = 0;
+              let scoredCount = 0;
+              let topScore: number | null = null;
+              for (const c of companyContacts) {
+                if (c.enrichment_status === "enriched") enrichedCount++;
+                if (!c.work_email) missingEmailCount++;
+                if (c.priority_score != null && c.priority_score > 0) {
+                  scoredCount++;
+                  if (topScore === null || c.priority_score > topScore) {
+                    topScore = c.priority_score;
+                  }
+                }
+              }
               const favicon = company.url ? faviconUrl(company.url) : null;
               const isHighlighted = highlightedIds?.has(company.id);
 
@@ -380,6 +432,32 @@ export function CompaniesList({
                           Enriching
                         </span>
                       )}
+                      {missingEmailCount > 0 &&
+                        company.organization_id &&
+                        !findingEmailsCompanyIds.has(
+                          company.organization_id,
+                        ) && (
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            onClick={() =>
+                              findEmailsForCompany(company.organization_id)
+                            }
+                            title={`Find emails for ${missingEmailCount} contact${missingEmailCount === 1 ? "" : "s"}`}
+                          >
+                            <Mail className="h-3 w-3" />
+                            Find emails ({missingEmailCount})
+                          </Button>
+                        )}
+                      {company.organization_id &&
+                        findingEmailsCompanyIds.has(
+                          company.organization_id,
+                        ) && (
+                          <span className="text-muted-foreground inline-flex items-center gap-1 text-xs">
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            Finding
+                          </span>
+                        )}
                       <ScoreBadge score={company.relevance_score} />
                     </div>
                   </div>
@@ -421,8 +499,10 @@ export function CompaniesList({
                           expandedContactIds={expandedContactIds}
                           highlightedIds={highlightedIds}
                           enrichingIds={enrichingIds}
+                          findingEmailIds={findingEmailIds}
                           onToggle={toggleContact}
                           onEnrich={enrichContact}
+                          onFindEmail={findEmailForContact}
                           onEmailEdit={updateContactEmail}
                           columnSpan={6}
                           showOutreach
@@ -496,9 +576,11 @@ export function CompaniesList({
           expandedContactIds={expandedContactIds}
           highlightedIds={highlightedIds}
           enrichingIds={enrichingIds}
+          findingEmailIds={findingEmailIds}
           onToggleSection={toggleCompany}
           onToggleContact={toggleContact}
           onEnrich={enrichContact}
+          onFindEmail={findEmailForContact}
           onEmailEdit={updateContactEmail}
         />
       )}
@@ -511,8 +593,10 @@ interface ContactsTableProps {
   expandedContactIds: Set<string>;
   highlightedIds?: Set<string>;
   enrichingIds: Set<string>;
+  findingEmailIds: Set<string>;
   onToggle: (id: string) => void;
   onEnrich: (id: string) => void;
+  onFindEmail: (contact: CampaignContact) => void | Promise<void>;
   onEmailEdit: (contact: CampaignContact, next: string) => Promise<void>;
   columnSpan: number;
   showOutreach: boolean;
@@ -523,8 +607,10 @@ function ContactsTable({
   expandedContactIds,
   highlightedIds,
   enrichingIds,
+  findingEmailIds,
   onToggle,
   onEnrich,
+  onFindEmail,
   onEmailEdit,
   columnSpan,
   showOutreach,
@@ -645,6 +731,21 @@ function ContactsTable({
                         </Button>
                       )}
                     {enrichingIds.has(contact.id) && (
+                      <Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+                    )}
+                    {!contact.work_email &&
+                      !findingEmailIds.has(contact.id) && (
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          aria-label={`Find email for ${contact.name}`}
+                          title="Find email"
+                          onClick={() => onFindEmail(contact)}
+                        >
+                          <Mail className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
+                    {findingEmailIds.has(contact.id) && (
                       <Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
                     )}
                   </div>
@@ -818,9 +919,11 @@ interface UnassignedContactsProps {
   expandedContactIds: Set<string>;
   highlightedIds?: Set<string>;
   enrichingIds: Set<string>;
+  findingEmailIds: Set<string>;
   onToggleSection: (id: string) => void;
   onToggleContact: (id: string) => void;
   onEnrich: (id: string) => void;
+  onFindEmail: (contact: CampaignContact) => void | Promise<void>;
   onEmailEdit: (contact: CampaignContact, next: string) => Promise<void>;
 }
 
@@ -830,9 +933,11 @@ function UnassignedContacts({
   expandedContactIds,
   highlightedIds,
   enrichingIds,
+  findingEmailIds,
   onToggleSection,
   onToggleContact,
   onEnrich,
+  onFindEmail,
   onEmailEdit,
 }: UnassignedContactsProps) {
   const isOpen = expandedCompanyIds.has("__unassigned__");
@@ -871,8 +976,10 @@ function UnassignedContacts({
               expandedContactIds={expandedContactIds}
               highlightedIds={highlightedIds}
               enrichingIds={enrichingIds}
+              findingEmailIds={findingEmailIds}
               onToggle={onToggleContact}
               onEnrich={onEnrich}
+              onFindEmail={onFindEmail}
               onEmailEdit={onEmailEdit}
               columnSpan={5}
               showOutreach={false}

--- a/src/components/campaign/contacts-table.tsx
+++ b/src/components/campaign/contacts-table.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { Fragment, useState } from "react";
-import { ChevronRight, ExternalLink, Loader2, Sparkles } from "lucide-react";
+import {
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+  Mail,
+  Sparkles,
+} from "lucide-react";
 
 import { ContactDetail } from "@/components/campaign/contact-detail";
 import {
@@ -21,6 +27,33 @@ export function ContactsTable({
 }: ContactsTableProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [enrichingIds, setEnrichingIds] = useState<Set<string>>(new Set());
+  const [findingEmailIds, setFindingEmailIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const findEmail = async (contact: CampaignContact) => {
+    setFindingEmailIds((prev) => new Set(prev).add(contact.id));
+    try {
+      const res = await fetch("/api/find-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ personId: contact.person_id }),
+      });
+      const result = await res.json();
+      if (result.email) {
+        // Trigger parent re-fetch so the row picks up the new email.
+        onContactEnriched(contact.id, {} as CampaignContact);
+      }
+    } catch (err) {
+      console.error(`[find-email] Failed:`, err);
+    } finally {
+      setFindingEmailIds((prev) => {
+        const next = new Set(prev);
+        next.delete(contact.id);
+        return next;
+      });
+    }
+  };
 
   const toggleExpand = (id: string) => {
     setExpandedIds((prev) => {
@@ -167,6 +200,20 @@ export function ContactsTable({
                           </button>
                         )}
                       {enrichingIds.has(contact.id) && (
+                        <Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+                      )}
+                      {!contact.work_email &&
+                        !findingEmailIds.has(contact.id) && (
+                          <button
+                            onClick={() => findEmail(contact)}
+                            className="text-muted-foreground hover:text-foreground hover:bg-muted rounded-md p-1 transition-colors"
+                            title="Find email"
+                            aria-label={`Find email for ${contact.name}`}
+                          >
+                            <Mail className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      {findingEmailIds.has(contact.id) && (
                         <Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
                       )}
                     </div>

--- a/src/lib/services/email-pattern.ts
+++ b/src/lib/services/email-pattern.ts
@@ -1,0 +1,517 @@
+import { resolveMx } from "node:dns/promises";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export type EmailSource =
+  | "user_entered"
+  | "send_confirmed"
+  | "team_page"
+  | "exa_search"
+  | "pattern_derived";
+
+export interface VerifiedEmail {
+  email: string;
+  firstName: string;
+  lastName: string;
+  source: EmailSource;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────
+
+export const SOURCE_WEIGHT: Record<EmailSource, number> = {
+  user_entered: 1.0,
+  send_confirmed: 0.95,
+  team_page: 0.7,
+  exa_search: 0.3,
+  pattern_derived: 0,
+};
+
+export const KNOWN_PATTERNS = [
+  "{first}.{last}",
+  "{first}{last}",
+  "{f}{last}",
+  "{first}_{last}",
+  "{first}-{last}",
+  "{f}.{last}",
+  "{first}.{l}",
+  "{first}",
+  "{last}",
+] as const;
+
+export type EmailPattern = (typeof KNOWN_PATTERNS)[number];
+
+export const ROLE_PREFIXES = [
+  "it",
+  "info",
+  "support",
+  "hello",
+  "contact",
+  "admin",
+  "team",
+  "sales",
+  "marketing",
+  "hr",
+  "legal",
+  "office",
+  "mail",
+  "webmaster",
+  "postmaster",
+  "abuse",
+  "billing",
+  "accounts",
+  "noreply",
+  "no-reply",
+  "donotreply",
+  "press",
+  "media",
+  "careers",
+  "jobs",
+  "founders",
+  "general",
+  "inquiries",
+  "feedback",
+  "help",
+  "service",
+] as const;
+
+const ROLE_SET: ReadonlySet<string> = new Set(ROLE_PREFIXES);
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────
+
+function localPart(email: string): string {
+  return email.split("@")[0]?.toLowerCase() ?? "";
+}
+
+function domainOf(email: string): string {
+  return email.split("@")[1]?.toLowerCase() ?? "";
+}
+
+function alnum(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Split a person's name into first + last. Returns null parts if unknown. */
+export function splitName(name: string): {
+  first: string | null;
+  last: string | null;
+} {
+  const parts = name.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { first: null, last: null };
+  if (parts.length === 1) return { first: parts[0], last: null };
+  return { first: parts[0], last: parts[parts.length - 1] };
+}
+
+/**
+ * `it`, `it.dept`, `support_team`, etc. → true. Personal addresses → false.
+ * Role prefix may be followed by `.`, `-`, `_`, `+`, or end of local-part.
+ */
+export function isRolePrefix(local: string): boolean {
+  const lower = local.toLowerCase();
+  if (ROLE_SET.has(lower)) return true;
+  for (const prefix of ROLE_PREFIXES) {
+    if (
+      lower.startsWith(prefix + ".") ||
+      lower.startsWith(prefix + "-") ||
+      lower.startsWith(prefix + "_") ||
+      lower.startsWith(prefix + "+")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Does the email's local-part plausibly belong to this person? Used to reject
+ * generic addresses being attached to specific contacts (e.g., `it@acme.com`
+ * latching onto "Jane Doe").
+ *
+ * Accepts if the normalized local-part contains the first name, last name, or
+ * any common combination of initials and names (≥2 chars per token).
+ */
+export function emailMatchesName(
+  email: string,
+  firstName: string | null,
+  lastName: string | null,
+): boolean {
+  const local = alnum(localPart(email));
+  if (!local) return false;
+
+  const first = firstName ? alnum(firstName) : "";
+  const last = lastName ? alnum(lastName) : "";
+  const fInit = first.slice(0, 1);
+  const lInit = last.slice(0, 1);
+
+  const candidates: string[] = [];
+  if (first.length >= 2) candidates.push(first);
+  if (last.length >= 2) candidates.push(last);
+  if (first && last) {
+    candidates.push(first + last); // janedoe
+    candidates.push(last + first); // doejane
+  }
+  if (fInit && last.length >= 2) candidates.push(fInit + last); // jdoe
+  if (first.length >= 2 && lInit) candidates.push(first + lInit); // janed
+  if (lInit && first.length >= 2) candidates.push(lInit + first); // djane
+
+  return candidates.some((c) => c.length >= 2 && local.includes(c));
+}
+
+/** Build the local-part for a given pattern. Returns null if unfillable. */
+function renderPattern(
+  pattern: string,
+  first: string | null,
+  last: string | null,
+): string | null {
+  const f = first ? alnum(first) : "";
+  const l = last ? alnum(last) : "";
+  const needsFirst = pattern.includes("{first}") || pattern.includes("{f}");
+  const needsLast = pattern.includes("{last}") || pattern.includes("{l}");
+  if (needsFirst && !f) return null;
+  if (needsLast && !l) return null;
+  return pattern
+    .replace("{first}", f)
+    .replace("{last}", l)
+    .replace("{f}", f.slice(0, 1))
+    .replace("{l}", l.slice(0, 1));
+}
+
+/** Build the full email for a pattern + person + domain. */
+export function applyPattern(
+  pattern: string,
+  firstName: string | null,
+  lastName: string | null,
+  domain: string,
+): string | null {
+  const local = renderPattern(pattern, firstName, lastName);
+  if (!local) return null;
+  return `${local}@${domain.toLowerCase()}`;
+}
+
+/**
+ * Given a set of verified emails (with names), return the most likely email
+ * pattern + a confidence in [0, 1] + how many emails support it. Ignores
+ * role-prefix addresses.
+ */
+export function inferPattern(emails: VerifiedEmail[]): {
+  pattern: EmailPattern | null;
+  confidence: number;
+  evidenceCount: number;
+} {
+  // Filter out role addresses; they don't reveal a personal pattern.
+  const personal = emails.filter((e) => !isRolePrefix(localPart(e.email)));
+  if (personal.length === 0) {
+    return { pattern: null, confidence: 0, evidenceCount: 0 };
+  }
+
+  // Score each candidate pattern by summing source-weighted votes from
+  // emails whose actual local-part equals what the pattern would produce.
+  let bestPattern: EmailPattern | null = null;
+  let bestScore = 0;
+  let bestEvidence = 0;
+  let totalScore = 0;
+
+  for (const pattern of KNOWN_PATTERNS) {
+    let score = 0;
+    let count = 0;
+    for (const email of personal) {
+      const expectedLocal = renderPattern(
+        pattern,
+        email.firstName,
+        email.lastName,
+      );
+      if (!expectedLocal) continue;
+      const actualLocal = localPart(email.email);
+      if (expectedLocal === actualLocal) {
+        score += SOURCE_WEIGHT[email.source];
+        count++;
+      }
+    }
+    totalScore += score;
+    if (score > bestScore) {
+      bestScore = score;
+      bestPattern = pattern;
+      bestEvidence = count;
+    }
+  }
+
+  if (!bestPattern || bestScore === 0) {
+    return { pattern: null, confidence: 0, evidenceCount: 0 };
+  }
+
+  // Confidence = winner share of all matched-pattern weight. Bounded to 1.
+  const confidence = totalScore > 0 ? Math.min(1, bestScore / totalScore) : 0;
+  return { pattern: bestPattern, confidence, evidenceCount: bestEvidence };
+}
+
+// ─── Network ──────────────────────────────────────────────────────────────
+
+type MxResolver = (
+  domain: string,
+) => Promise<Array<{ exchange: string; priority: number }>>;
+
+/**
+ * True if the domain has at least one MX record. Free DNS-only check.
+ * `resolver` is injectable so tests can substitute it without module mocking.
+ */
+export async function mxCheck(
+  domain: string,
+  resolver: MxResolver = resolveMx,
+): Promise<boolean> {
+  try {
+    const records = await resolver(domain);
+    return records.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// ─── DB-side: pattern recompute + email recording ─────────────────────────
+
+/**
+ * Re-derive `organizations.email_pattern` from all verified, non-derived
+ * emails on people in the org. Cheap; called whenever a verified email is
+ * recorded.
+ */
+export async function recomputeOrgPattern(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<void> {
+  const { data: people } = await supabase
+    .from("people")
+    .select("name, work_email, work_email_source, work_email_verified_at")
+    .eq("organization_id", orgId)
+    .not("work_email", "is", null)
+    .not("work_email_verified_at", "is", null);
+
+  const candidates: VerifiedEmail[] = [];
+  for (const p of people ?? []) {
+    if (!p.work_email || !p.work_email_source) continue;
+    if (p.work_email_source === "pattern_derived") continue; // don't feed guesses back in
+    const { first, last } = splitName(p.name);
+    if (!first || !last) continue; // need both for pattern matching
+    candidates.push({
+      email: p.work_email,
+      firstName: first,
+      lastName: last,
+      source: p.work_email_source,
+    });
+  }
+
+  const { pattern, confidence, evidenceCount } = inferPattern(candidates);
+
+  await supabase
+    .from("organizations")
+    .update({
+      email_pattern: pattern,
+      email_pattern_confidence: confidence,
+      email_pattern_evidence_count: evidenceCount,
+      email_pattern_updated_at: new Date().toISOString(),
+    })
+    .eq("id", orgId);
+}
+
+/**
+ * Record that a person's work_email comes from a verified source.
+ * Sets work_email + source + confidence + verified_at, then recomputes the
+ * org's pattern. NOT for `pattern_derived` — those are written directly by
+ * `findEmailForPerson` since their confidence depends on the org's pattern.
+ *
+ * Skips role-prefix addresses (don't pollute the org's pattern with a role
+ * mailbox attached to a real person). Skips overwrites that would *downgrade*
+ * the source weight — once `send_confirmed` is set, a later `team_page` rescrape
+ * shouldn't replace it.
+ */
+export async function recordVerifiedEmail(
+  supabase: SupabaseClient,
+  args: {
+    personId: string;
+    email: string;
+    source: Exclude<EmailSource, "pattern_derived">;
+  },
+): Promise<void> {
+  const { personId, email, source } = args;
+  const local = localPart(email);
+  if (isRolePrefix(local)) {
+    console.warn(
+      `[recordVerifiedEmail] skipping role-prefix address for person ${personId}: ${email}`,
+    );
+    return;
+  }
+
+  const { data: person } = await supabase
+    .from("people")
+    .select(
+      "organization_id, work_email, work_email_source, work_email_confidence",
+    )
+    .eq("id", personId)
+    .maybeSingle();
+
+  if (!person) return;
+
+  const newEmail = email.toLowerCase();
+  const sameEmail = person.work_email?.toLowerCase() === newEmail;
+  const existingSource = person.work_email_source as EmailSource | null;
+  const existingWeight = existingSource ? SOURCE_WEIGHT[existingSource] : -1;
+  const incomingWeight = SOURCE_WEIGHT[source];
+
+  // Two protections:
+  //   1. Different email + weaker source → skip (don't replace a strong signal).
+  //   2. Same email + weaker source → still refresh verified_at, but keep the
+  //      stronger source (don't downgrade send_confirmed → team_page).
+  let finalSource: EmailSource = source;
+  if (sameEmail) {
+    if (existingSource && existingWeight > incomingWeight) {
+      finalSource = existingSource;
+    }
+  } else if (incomingWeight < existingWeight) {
+    return;
+  }
+
+  await supabase
+    .from("people")
+    .update({
+      work_email: newEmail,
+      work_email_source: finalSource,
+      work_email_confidence: SOURCE_WEIGHT[finalSource],
+      work_email_verified_at: new Date().toISOString(),
+    })
+    .eq("id", personId);
+
+  if (person.organization_id) {
+    await recomputeOrgPattern(supabase, person.organization_id);
+  }
+}
+
+/**
+ * Record a bounce against a person's email. Clears verification and, if the
+ * email was pattern-derived, lowers the org pattern's confidence (or clears
+ * it entirely if bounces dominate).
+ */
+export async function recordBounce(
+  supabase: SupabaseClient,
+  args: { personId: string; email: string },
+): Promise<void> {
+  const { personId, email } = args;
+
+  const { data: person } = await supabase
+    .from("people")
+    .select("id, work_email, work_email_source, organization_id")
+    .eq("id", personId)
+    .maybeSingle();
+
+  if (!person) return;
+
+  // Only act if the bounced email is the one we have on file.
+  if (
+    person.work_email &&
+    person.work_email.toLowerCase() !== email.toLowerCase()
+  ) {
+    return;
+  }
+
+  // Clear verification + lower confidence on the person.
+  await supabase
+    .from("people")
+    .update({
+      work_email_verified_at: null,
+      work_email_confidence: 0,
+    })
+    .eq("id", personId);
+
+  // If the email was derived from the org's pattern, that's evidence the
+  // pattern is wrong. Bump bounce count and reduce / clear confidence.
+  if (
+    person.work_email_source !== "pattern_derived" ||
+    !person.organization_id
+  ) {
+    return;
+  }
+
+  // If a pattern exists but the cached evidence_count is stale (e.g. 0 because
+  // recompute hasn't run yet), refresh it first so the bounce ratio is fair.
+  // Without this, the very first bounce would compute 1/1 > 0.5 and clear a
+  // perfectly-good pattern.
+  let { data: org } = await supabase
+    .from("organizations")
+    .select(
+      "email_pattern, email_pattern_confidence, email_pattern_evidence_count, email_pattern_bounce_count",
+    )
+    .eq("id", person.organization_id)
+    .maybeSingle();
+
+  if (!org) return;
+
+  if (org.email_pattern && (org.email_pattern_evidence_count ?? 0) === 0) {
+    await recomputeOrgPattern(supabase, person.organization_id);
+    const refreshed = await supabase
+      .from("organizations")
+      .select(
+        "email_pattern, email_pattern_confidence, email_pattern_evidence_count, email_pattern_bounce_count",
+      )
+      .eq("id", person.organization_id)
+      .maybeSingle();
+    if (refreshed.data) org = refreshed.data;
+  }
+
+  const newBounces = (org.email_pattern_bounce_count ?? 0) + 1;
+  const evidence = org.email_pattern_evidence_count ?? 0;
+
+  let pattern = org.email_pattern;
+  let confidence = org.email_pattern_confidence ?? 0;
+
+  if (evidence === 0) {
+    // No supporting evidence even after recompute. Just bump the bounce count;
+    // don't touch the pattern (recompute already wrote NULL if there's no
+    // evidence, or kept the original if recompute hasn't been re-triggered).
+  } else {
+    const ratio = newBounces / evidence;
+    if (ratio > 0.5) {
+      pattern = null;
+      confidence = 0;
+    } else if (ratio > 0.3) {
+      confidence = confidence / 2;
+    }
+  }
+
+  await supabase
+    .from("organizations")
+    .update({
+      email_pattern: pattern,
+      email_pattern_confidence: confidence,
+      email_pattern_bounce_count: newBounces,
+      email_pattern_updated_at: new Date().toISOString(),
+    })
+    .eq("id", person.organization_id);
+}
+
+/**
+ * Lookup the org's cached pattern + load its verified-email evidence count.
+ * Used by findEmailForPerson to decide whether to derive vs. fall back to
+ * Exa search.
+ */
+export async function getOrgPattern(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<{
+  pattern: string | null;
+  confidence: number;
+  evidenceCount: number;
+} | null> {
+  const { data } = await supabase
+    .from("organizations")
+    .select(
+      "email_pattern, email_pattern_confidence, email_pattern_evidence_count",
+    )
+    .eq("id", orgId)
+    .maybeSingle();
+  if (!data) return null;
+  return {
+    pattern: data.email_pattern ?? null,
+    confidence: data.email_pattern_confidence ?? 0,
+    evidenceCount: data.email_pattern_evidence_count ?? 0,
+  };
+}
+
+// Re-export for tests + integration callers
+export { localPart, domainOf };

--- a/src/lib/tools/email-tools.ts
+++ b/src/lib/tools/email-tools.ts
@@ -128,7 +128,9 @@ export async function findEmailForPerson(personId: string): Promise<{
       const emails = result.text.match(EMAIL_REGEX) ?? [];
       for (const candidate of emails) {
         const lower = candidate.toLowerCase();
-        if (lower.includes("example.com")) continue;
+        const atIndex = lower.lastIndexOf("@");
+        const candidateDomain = atIndex >= 0 ? lower.slice(atIndex + 1) : "";
+        if (candidateDomain === "example.com") continue;
         const local = lower.split("@")[0];
         if (isRolePrefix(local)) continue;
         if (!emailMatchesName(lower, first, last)) continue;

--- a/src/lib/tools/email-tools.ts
+++ b/src/lib/tools/email-tools.ts
@@ -5,12 +5,32 @@ import { ExaService } from "@/lib/services/exa-service";
 import { sendMessage } from "@/lib/services/agentmail-service";
 import { trackUsage } from "@/lib/services/cost-tracker";
 import { saveDraft } from "@/lib/email-composition/save";
+import {
+  applyPattern,
+  emailMatchesName,
+  getOrgPattern,
+  inferPattern,
+  isRolePrefix,
+  mxCheck,
+  recomputeOrgPattern,
+  recordVerifiedEmail,
+  splitName,
+  SOURCE_WEIGHT,
+  type VerifiedEmail,
+} from "@/lib/services/email-pattern";
 
 // ── Shared findEmail logic ─────────────────────────────────────────────────
+
+const PATTERN_CONFIDENCE_THRESHOLD = 0.5;
+// Cap for pattern-derived confidence. Stays strictly below the UI's
+// "verified" threshold (0.9) so a pattern guess can never display as verified.
+const PATTERN_DERIVED_CONFIDENCE_FACTOR = 0.85;
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 
 export async function findEmailForPerson(personId: string): Promise<{
   email: string | null;
   source?: string;
+  confidence?: number;
   reason?: string;
   personId: string;
 }> {
@@ -18,7 +38,9 @@ export async function findEmailForPerson(personId: string): Promise<{
 
   const { data: person, error: personErr } = await supabase
     .from("people")
-    .select("id, name, title, work_email, personal_email, organization_id")
+    .select(
+      "id, name, title, work_email, personal_email, organization_id, work_email_source, work_email_confidence",
+    )
     .eq("id", personId)
     .single();
 
@@ -27,7 +49,12 @@ export async function findEmailForPerson(personId: string): Promise<{
   }
 
   if (person.work_email) {
-    return { email: person.work_email, source: "existing", personId };
+    return {
+      email: person.work_email,
+      source: person.work_email_source ?? "existing",
+      confidence: person.work_email_confidence ?? undefined,
+      personId,
+    };
   }
   if (person.personal_email) {
     return { email: person.personal_email, source: "existing", personId };
@@ -43,11 +70,51 @@ export async function findEmailForPerson(personId: string): Promise<{
     domain = org?.domain ?? null;
   }
 
+  const { first, last } = splitName(person.name);
+
+  // ── 1) Pattern-first: if the org has a confident pattern, derive + MX-check.
+  if (domain && person.organization_id && first) {
+    const orgPattern = await getOrgPattern(supabase, person.organization_id);
+    if (
+      orgPattern?.pattern &&
+      orgPattern.confidence >= PATTERN_CONFIDENCE_THRESHOLD
+    ) {
+      const derived = applyPattern(orgPattern.pattern, first, last, domain);
+      if (
+        derived &&
+        !isRolePrefix(derived.split("@")[0]) &&
+        emailMatchesName(derived, first, last)
+      ) {
+        const mxOk = await mxCheck(domain);
+        if (mxOk) {
+          const confidence =
+            orgPattern.confidence * PATTERN_DERIVED_CONFIDENCE_FACTOR;
+          await supabase
+            .from("people")
+            .update({
+              work_email: derived,
+              work_email_source: "pattern_derived",
+              work_email_confidence: confidence,
+            })
+            .eq("id", personId);
+          return {
+            email: derived,
+            source: "pattern_derived",
+            confidence,
+            personId,
+          };
+        }
+      }
+    }
+  }
+
+  // ── 2) Exa search — kept as the discovery path when pattern is missing/weak.
   const searchQuery = domain
     ? `"${person.name}" "${domain}" email`
     : `"${person.name}" email contact`;
 
   let foundEmail: string | null = null;
+  let foundDomainMatched = false;
 
   try {
     const exa = new ExaService();
@@ -56,31 +123,23 @@ export async function findEmailForPerson(personId: string): Promise<{
       includeText: true,
     });
 
-    const emailRegex = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
     for (const result of results.results) {
       if (!result.text) continue;
-      const emails = result.text.match(emailRegex) ?? [];
-      for (const email of emails) {
-        const lower = email.toLowerCase();
-        if (
-          lower.includes("noreply") ||
-          lower.includes("info@") ||
-          lower.includes("support@") ||
-          lower.includes("hello@") ||
-          lower.includes("contact@") ||
-          lower.includes("example.com")
-        ) {
-          continue;
-        }
+      const emails = result.text.match(EMAIL_REGEX) ?? [];
+      for (const candidate of emails) {
+        const lower = candidate.toLowerCase();
+        if (lower.includes("example.com")) continue;
+        const local = lower.split("@")[0];
+        if (isRolePrefix(local)) continue;
+        if (!emailMatchesName(lower, first, last)) continue;
         if (domain && lower.endsWith(`@${domain}`)) {
           foundEmail = lower;
+          foundDomainMatched = true;
           break;
         }
-        if (!foundEmail) {
-          foundEmail = lower;
-        }
+        if (!foundEmail) foundEmail = lower;
       }
-      if (foundEmail && domain && foundEmail.endsWith(`@${domain}`)) break;
+      if (foundEmail && foundDomainMatched) break;
     }
 
     trackUsage({
@@ -90,15 +149,94 @@ export async function findEmailForPerson(personId: string): Promise<{
       metadata: { personId, query: searchQuery },
     });
   } catch {
-    // Exa search failed, fall through to pattern guessing
+    // Exa search failed, fall through to on-the-fly pattern inference.
   }
 
-  if (!foundEmail && domain && person.name) {
-    const nameParts = person.name.toLowerCase().split(/\s+/);
-    if (nameParts.length >= 2) {
-      const first = nameParts[0];
-      const last = nameParts[nameParts.length - 1];
-      foundEmail = `${first}.${last}@${domain}`;
+  // ── 3) On-the-fly inference: if Exa whiffed, try inferring the pattern from
+  //       any verified emails on the org RIGHT NOW (covers the case where the
+  //       org has verified emails but the cached pattern hasn't been recomputed
+  //       or sits below the confidence threshold).
+  if (!foundEmail && domain && person.organization_id && first && last) {
+    const { data: orgPeople } = await supabase
+      .from("people")
+      .select("name, work_email, work_email_source, work_email_verified_at")
+      .eq("organization_id", person.organization_id)
+      .not("work_email", "is", null)
+      .not("work_email_verified_at", "is", null);
+
+    const evidence: VerifiedEmail[] = [];
+    for (const p of orgPeople ?? []) {
+      if (!p.work_email || !p.work_email_source) continue;
+      if (p.work_email_source === "pattern_derived") continue;
+      const split = splitName(p.name);
+      if (!split.first || !split.last) continue;
+      evidence.push({
+        email: p.work_email,
+        firstName: split.first,
+        lastName: split.last,
+        source: p.work_email_source,
+      });
+    }
+
+    if (evidence.length > 0) {
+      const inferred = inferPattern(evidence);
+      if (inferred.pattern) {
+        const derived = applyPattern(inferred.pattern, first, last, domain);
+        if (
+          derived &&
+          !isRolePrefix(derived.split("@")[0]) &&
+          emailMatchesName(derived, first, last) &&
+          (await mxCheck(domain))
+        ) {
+          const confidence =
+            inferred.confidence * PATTERN_DERIVED_CONFIDENCE_FACTOR;
+          await supabase
+            .from("people")
+            .update({
+              work_email: derived,
+              work_email_source: "pattern_derived",
+              work_email_confidence: confidence,
+            })
+            .eq("id", personId);
+          // Refresh the org's cached pattern so subsequent lookups in a bulk
+          // run hit step 1 instead of re-doing this query + Exa search.
+          await recomputeOrgPattern(supabase, person.organization_id);
+          return {
+            email: derived,
+            source: "pattern_derived",
+            confidence,
+            personId,
+          };
+        }
+      }
+    }
+  }
+
+  // ── 4) Final fallback: blind {first}.{last}@domain when nothing else worked.
+  // Goes through applyPattern (not raw interpolation) so the alphanumeric
+  // stripping + edge-case handling matches the rest of the file.
+  if (!foundEmail && domain && first && last) {
+    const blind = applyPattern("{first}.{last}", first, last, domain);
+    if (
+      blind &&
+      !isRolePrefix(blind.split("@")[0]) &&
+      emailMatchesName(blind, first, last) &&
+      (await mxCheck(domain))
+    ) {
+      await supabase
+        .from("people")
+        .update({
+          work_email: blind,
+          work_email_source: "pattern_derived",
+          work_email_confidence: 0.2,
+        })
+        .eq("id", personId);
+      return {
+        email: blind,
+        source: "pattern_derived",
+        confidence: 0.2,
+        personId,
+      };
     }
   }
 
@@ -110,12 +248,18 @@ export async function findEmailForPerson(personId: string): Promise<{
     };
   }
 
-  await supabase
-    .from("people")
-    .update({ work_email: foundEmail })
-    .eq("id", personId);
-
-  return { email: foundEmail, source: "exa_search_or_pattern", personId };
+  // Exa hit — record as verified-source with the right weight.
+  await recordVerifiedEmail(supabase, {
+    personId,
+    email: foundEmail,
+    source: "exa_search",
+  });
+  return {
+    email: foundEmail,
+    source: "exa_search",
+    confidence: SOURCE_WEIGHT.exa_search,
+    personId,
+  };
 }
 
 // ── findEmail ──────────────────────────────────────────────────────────────

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -20,6 +20,7 @@ import {
   filterContactsByCompany,
   type CandidateContact,
 } from "@/lib/services/contact-filter";
+import { recordVerifiedEmail } from "@/lib/services/email-pattern";
 
 export const searchPeople = tool({
   description:
@@ -1266,6 +1267,14 @@ export const findContacts = tool({
             organization_id: orgId,
             source: "website",
           });
+
+          if (dp.email) {
+            await recordVerifiedEmail(supabase, {
+              personId: person.id,
+              email: dp.email,
+              source: "team_page",
+            });
+          }
 
           if (input.campaignId) {
             await linkPersonToCampaign(person.id, input.campaignId);

--- a/supabase/migrations/20260426000000_email_pattern.sql
+++ b/supabase/migrations/20260426000000_email_pattern.sql
@@ -1,0 +1,20 @@
+-- Email pattern detection + per-email source/confidence
+-- 2026-04-26
+--
+-- Adds per-organization email-pattern cache so we can derive emails for new
+-- contacts at a company once we've confirmed the pattern from a verified one.
+-- Adds source + confidence columns on people.work_email so the agent (and UI)
+-- knows how much to trust each address.
+
+-- Organizations: per-company email pattern cache
+ALTER TABLE organizations ADD COLUMN email_pattern TEXT;
+ALTER TABLE organizations ADD COLUMN email_pattern_confidence REAL;
+ALTER TABLE organizations ADD COLUMN email_pattern_evidence_count INT NOT NULL DEFAULT 0;
+ALTER TABLE organizations ADD COLUMN email_pattern_bounce_count INT NOT NULL DEFAULT 0;
+ALTER TABLE organizations ADD COLUMN email_pattern_updated_at TIMESTAMPTZ;
+
+-- People: per-email source + confidence
+-- (work_email_verified_at already exists from the initial schema.)
+ALTER TABLE people ADD COLUMN work_email_source TEXT
+  CHECK (work_email_source IN ('user_entered', 'send_confirmed', 'team_page', 'exa_search', 'pattern_derived'));
+ALTER TABLE people ADD COLUMN work_email_confidence REAL;

--- a/supabase/migrations/20260426000001_backfill_email_source.sql
+++ b/supabase/migrations/20260426000001_backfill_email_source.sql
@@ -1,0 +1,14 @@
+-- Backfill: legacy work_email rows have no source/confidence, so they don't
+-- contribute to org pattern inference. Treat them as `team_page` (0.7) — a
+-- moderate-trust default that lets them participate in the pattern but won't
+-- override a real send_confirmed (0.95) or user_entered (1.0) once those land.
+--
+-- Idempotent: only writes rows where the source is still NULL.
+
+UPDATE people
+SET
+  work_email_source = 'team_page',
+  work_email_confidence = 0.7
+WHERE
+  work_email IS NOT NULL
+  AND work_email_source IS NULL;


### PR DESCRIPTION
## Summary

Pattern-based email finder for sales contacts: tiered lookup (cached org pattern → Exa search → on-the-fly inference → blind fallback) with source-weighted confidence, MX verification, and AgentMail webhook hooks for `delivered`/`bounced` to feed verification + bounce signals back into the org's pattern. Adds per-contact and per-company "Find email" UI, an ownership-checked `/api/find-email` + `/bulk` + `/record-verified` API surface, and a confidence chip on the review page. New `email_pattern` service + tests, plus migrations adding `email_pattern*` to organizations and `work_email_source/confidence/verified_at` to people.
