### PR TITLE
perf: lazy-load heavy client deps and parallelize independent queries

### DIFF
--- a/src/app/email-skills/page.tsx
+++ b/src/app/email-skills/page.tsx
@@ -61,11 +61,9 @@ export default function EmailSkillsPage() {
 
   const fetchData = useCallback(async () => {
     const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
 
-    const [skillsRes, campaignsRes, profilesRes] = await Promise.all([
+    const [userRes, skillsRes, campaignsRes, profilesRes] = await Promise.all([
+      supabase.auth.getUser(),
       supabase
         .from("email_skills")
         .select("*")
@@ -82,7 +80,7 @@ export default function EmailSkillsPage() {
     ]);
 
     if (!mountedRef.current) return;
-    setUserId(user?.id ?? null);
+    setUserId(userRes.data.user?.id ?? null);
     setSkills((skillsRes.data as EmailSkill[]) ?? []);
     setCampaigns((campaignsRes.data as Campaign[]) ?? []);
     setProfiles((profilesRes.data as UserProfile[]) ?? []);

--- a/src/app/outreach/page.tsx
+++ b/src/app/outreach/page.tsx
@@ -54,6 +54,7 @@ export default function OutreachPage() {
       enrollmentsRes,
       draftsRes,
       settingsRes,
+      stepRowsRes,
     ] = await Promise.all([
       supabase
         .from("sequences")
@@ -89,6 +90,7 @@ export default function OutreachPage() {
         .order("created_at", { ascending: false })
         .limit(200),
       supabase.from("user_settings").select("agentmail_inbox_id").maybeSingle(),
+      supabase.from("sequence_steps").select("sequence_id, step_number"),
     ]);
 
     if (!mountedRef.current) return;
@@ -120,9 +122,7 @@ export default function OutreachPage() {
 
     // Count total steps per sequence (for Step N/M display)
     const totalStepsBySeq = new Map<string, number>();
-    const { data: stepRows } = await supabase
-      .from("sequence_steps")
-      .select("sequence_id, step_number");
+    const stepRows = stepRowsRes.data;
     for (const s of stepRows ?? []) {
       const cur = totalStepsBySeq.get(s.sequence_id) ?? 0;
       if (s.step_number > cur)

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -148,10 +148,11 @@ function ReviewPageInner() {
 
     const load = async () => {
       const supabase = createClient();
-      const { data: rawDrafts } = await supabase
-        .from("email_drafts")
-        .select(
-          `
+      const [draftsRes, stepsRes] = await Promise.all([
+        supabase
+          .from("email_drafts")
+          .select(
+            `
           id, to_email, subject, body_html, body_text, ai_reasoning,
           review_status, status, sequence_step_id, enrollment_id, person_id,
           people(
@@ -165,19 +166,21 @@ function ReviewPageInner() {
           sequence_enrollments(current_step),
           sequence_steps(step_number, delay_days, delay_hours)
         `,
-        )
-        .eq("sequence_id", sequenceId)
-        .eq("review_status", "pending")
-        .order("person_id")
-        .order("sequence_step_id");
+          )
+          .eq("sequence_id", sequenceId)
+          .eq("review_status", "pending")
+          .order("person_id")
+          .order("sequence_step_id"),
+        supabase
+          .from("sequence_steps")
+          .select("id")
+          .eq("sequence_id", sequenceId),
+      ]);
 
       if (!mountedRef.current) return;
 
-      const { data: steps } = await supabase
-        .from("sequence_steps")
-        .select("id")
-        .eq("sequence_id", sequenceId);
-
+      const rawDrafts = draftsRes.data;
+      const steps = stepsRes.data;
       const totalSteps = steps?.length ?? 1;
 
       const mapped: DraftForReview[] = (rawDrafts ?? []).map((d) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,28 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 
 import { StatCards } from "@/components/dashboard/stat-cards";
-import { OutreachChart } from "@/components/dashboard/outreach-chart";
 import { CampaignTable } from "@/components/dashboard/campaign-table";
 import {
   ListRowsSkeleton,
   PageHeaderSkeleton,
   StatsRowSkeleton,
 } from "@/components/ui/skeleton-presets";
+
+const OutreachChart = dynamic(
+  () =>
+    import("@/components/dashboard/outreach-chart").then(
+      (m) => m.OutreachChart,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="bg-muted/40 h-64 animate-pulse rounded-lg" />
+    ),
+  },
+);
 
 interface DashboardData {
   totals: {

--- a/src/app/tracking/page.tsx
+++ b/src/app/tracking/page.tsx
@@ -86,16 +86,32 @@ function TrackingPageContent() {
       }
     }
 
-    // Fetch readiness tags from campaign_organizations
+    // Fetch readiness tags + latest changes in parallel — both depend on
+    // configs but are independent of each other.
     const uniqueOrgIds = [...new Set(configOrgMap.values())];
-    const { data: orgLinks } = await supabase
-      .from("campaign_organizations")
-      .select("organization_id, readiness_tag")
-      .eq("campaign_id", campaignId)
-      .in(
-        "organization_id",
-        uniqueOrgIds.length > 0 ? uniqueOrgIds : ["__none__"],
-      );
+    const configIds = configs.map(
+      (c: Record<string, unknown>) => c.id as string,
+    );
+    const [orgLinksRes, latestChangesRes] = await Promise.all([
+      supabase
+        .from("campaign_organizations")
+        .select("organization_id, readiness_tag")
+        .eq("campaign_id", campaignId)
+        .in(
+          "organization_id",
+          uniqueOrgIds.length > 0 ? uniqueOrgIds : ["__none__"],
+        ),
+      supabase
+        .from("tracking_changes")
+        .select("tracking_config_id, description, detected_at")
+        .in(
+          "tracking_config_id",
+          configIds.length > 0 ? configIds : ["__none__"],
+        )
+        .order("detected_at", { ascending: false }),
+    ]);
+    const orgLinks = orgLinksRes.data;
+    const latestChanges = latestChangesRes.data;
 
     const readinessMap = new Map<string, string>();
     for (const link of orgLinks ?? []) {
@@ -104,16 +120,6 @@ function TrackingPageContent() {
         (link.readiness_tag as string) || "",
       );
     }
-
-    // Fetch latest changes per config
-    const configIds = configs.map(
-      (c: Record<string, unknown>) => c.id as string,
-    );
-    const { data: latestChanges } = await supabase
-      .from("tracking_changes")
-      .select("tracking_config_id, description, detected_at")
-      .in("tracking_config_id", configIds.length > 0 ? configIds : ["__none__"])
-      .order("detected_at", { ascending: false });
 
     const changeMap = new Map<
       string,

--- a/src/components/chat/chat-message-bubble.tsx
+++ b/src/components/chat/chat-message-bubble.tsx
@@ -1,13 +1,23 @@
 "use client";
 
 import { memo } from "react";
+import dynamic from "next/dynamic";
 
 import type { UIMessage } from "ai";
 import { isToolUIPart, getToolName } from "ai";
 import { Bot, User } from "lucide-react";
 
-import { Markdown } from "@/components/ui/markdown";
 import { ToolCallCard } from "./tool-call-card";
+
+const Markdown = dynamic(
+  () => import("@/components/ui/markdown").then((m) => m.Markdown),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="bg-muted-foreground/10 h-4 w-32 animate-pulse rounded" />
+    ),
+  },
+);
 
 interface ChatMessageBubbleProps {
   message: UIMessage;

--- a/src/lib/campaign-context.tsx
+++ b/src/lib/campaign-context.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useMemo,
   useState,
   type ReactNode,
 } from "react";
@@ -44,21 +45,26 @@ export function CampaignProvider({ children }: { children: ReactNode }) {
     setAgentOpen(true);
   }, []);
 
-  return (
-    <CampaignContext
-      value={{
-        activeCampaignId,
-        setActiveCampaignId,
-        agentOpen,
-        setAgentOpen,
-        pendingPrompt,
-        consumePendingPrompt,
-        openAgentWith,
-      }}
-    >
-      {children}
-    </CampaignContext>
+  const value = useMemo<CampaignContextValue>(
+    () => ({
+      activeCampaignId,
+      setActiveCampaignId,
+      agentOpen,
+      setAgentOpen,
+      pendingPrompt,
+      consumePendingPrompt,
+      openAgentWith,
+    }),
+    [
+      activeCampaignId,
+      agentOpen,
+      pendingPrompt,
+      consumePendingPrompt,
+      openAgentWith,
+    ],
   );
+
+  return <CampaignContext value={value}>{children}</CampaignContext>;
 }
 
 export function useCampaign() {


### PR DESCRIPTION
## Summary

Lazy-loads recharts (`OutreachChart`) and react-markdown (`Markdown`) via `next/dynamic` to remove ~280KB from initial JS on the dashboard and chat pages.
Batches independent Supabase queries into `Promise.all` on the tracking, outreach, outreach/review, and email-skills pages to eliminate sequential waterfalls.
Memoizes the `CampaignContext` value so consumers (sidebar, dashboard shell, agent panel) don't re-render on unrelated state changes.