### PR TITLE
fix: include user_id when AI tool creates a user_profile

### DIFF
--- a/src/lib/tools/profile-tools.ts
+++ b/src/lib/tools/profile-tools.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@/lib/supabase/server";
 
 export const updateUserProfile = tool({
@@ -67,10 +68,12 @@ export const updateUserProfile = tool({
       return { profile, action: "updated", updated: Object.keys(fields) };
     }
 
-    // Create new profile
+    const { userId } = await auth();
+    if (!userId) throw new Error("Not authenticated");
+
     const { data: profile, error } = await supabase
       .from("user_profile")
-      .insert(fields)
+      .insert({ ...fields, user_id: userId })
       .select("*")
       .single();
 


### PR DESCRIPTION
The Clerk migration dropped the auth.users trigger that auto-populated user_id on user_profile. The profile page was updated to set user_id explicitly on insert; the AI chat tool's create branch was missed, so every chat-driven profile creation hit RLS 42501 (`new row violates row-level security policy`) because requesting_user_id() = NULL fails.

## Summary

<!-- 1-3 sentences. What does this change and why? -->

## Linked issue

<!-- Closes #123 / Relates to #456 -->

## How I tested

<!-- Commands run, manual steps, screenshots of the result. Delete what doesn't apply. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manually exercised the changed code path in dev

## Screenshots / recordings

<!-- If this touches the UI, paste a before/after screenshot or screen recording. -->

## Notes for the reviewer

<!-- Anything tricky, intentional trade-offs, follow-ups you plan to open separately. -->
