### PR TITLE
Restyle

### DIFF
--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -20,6 +20,7 @@ import type {
   CampaignCompany,
   CampaignContact,
 } from "@/lib/types/campaign";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface ActivityCounts {
   added: number;
@@ -329,7 +330,7 @@ export default function CampaignDetailPage() {
       contact_count: contacts.length,
     });
     try {
-      await fetch("/api/refresh-scores", {
+      await apiFetch("/api/refresh-scores", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ campaignId }),

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -387,7 +387,7 @@ export default function CampaignDetailPage() {
 
         <div>
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-semibold">Pipeline</h2>
+            <h2 className="type-header">Pipeline</h2>
             {hasScoringCapable && (
               <Button
                 variant="ghost"

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -80,7 +80,7 @@ export default function CampaignsIndexPage() {
     <div className="flex-1 overflow-y-auto">
       <div className="space-y-6 p-4 md:p-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Campaigns</h1>
+          <h1 className="type-title">Campaigns</h1>
           <p className="text-muted-foreground text-sm">
             All campaigns in your workspace. Click a name to open it; delete
             ones you no longer need.

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import type { UIMessage } from "ai";
 import { useChat } from "@ai-sdk/react";
@@ -8,13 +8,16 @@ import { SquarePen } from "lucide-react";
 
 import { useAuth } from "@clerk/nextjs";
 
+import { ChatErrorBanner } from "@/components/chat/chat-error-banner";
 import { ChatInput } from "@/components/chat/chat-input";
 import { ChatMessages } from "@/components/chat/chat-messages";
+import { createChatTransport } from "@/lib/chat-transport";
 import { Button } from "@/components/ui/button";
 import { useCampaign } from "@/lib/campaign-context";
 import { useStreaming } from "@/lib/streaming-context";
 import { loadChat, saveChat } from "@/lib/services/chat-history";
 import { createClient } from "@/lib/supabase/client";
+import { apiFetch } from "@/lib/api-fetch";
 
 // ---------------------------------------------------------------------------
 // Inner component -- only rendered after initial messages are loaded so that
@@ -30,7 +33,7 @@ function summarizeChat(chatId: string) {
       new Blob([body], { type: "application/json" }),
     );
   } else {
-    fetch("/api/chat/summarize", { method: "POST", body, keepalive: true });
+    apiFetch("/api/chat/summarize", { method: "POST", body, keepalive: true });
   }
 }
 
@@ -54,9 +57,12 @@ function ChatView({
 
   const turnCount = useRef(0);
 
-  const { messages, sendMessage, status, stop } = useChat({
+  const transport = useMemo(() => createChatTransport(), []);
+
+  const { messages, sendMessage, status, stop, error, regenerate } = useChat({
     id: chatId,
     messages: initialMessages,
+    transport,
     onFinish({ messages: allMessages }) {
       if (userId) {
         saveChat(
@@ -153,6 +159,7 @@ function ChatView({
         isLoading={isLoading}
         onSuggestionClick={handleSuggestionClick}
       />
+      {error && <ChatErrorBanner error={error} onRetry={() => regenerate()} />}
       <ChatInput
         input={input}
         isLoading={isLoading}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -64,7 +64,7 @@ export default function ChatPage() {
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-2xl px-4 py-12">
           <div className="mb-8 text-center">
-            <h2 className="text-lg font-semibold">How can I help?</h2>
+            <h2 className="type-header">How can I help?</h2>
             <p className="text-muted-foreground mt-1 text-sm">
               Start typing to begin a new conversation, or pick up where you
               left off.

--- a/src/app/companies/[id]/page.tsx
+++ b/src/app/companies/[id]/page.tsx
@@ -249,7 +249,7 @@ export default function CompanyPage() {
     <div className="mx-auto max-w-7xl space-y-4 p-6">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">{org.name}</h1>
+          <h1 className="type-title">{org.name}</h1>
           <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-2 text-sm">
             {org.domain && (
               <a

--- a/src/app/companies/[id]/page.tsx
+++ b/src/app/companies/[id]/page.tsx
@@ -17,6 +17,7 @@ import type {
   EnrichmentData,
   Seniority,
 } from "@/lib/types/campaign";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface OrgRow {
   id: string;
@@ -174,7 +175,7 @@ export default function CompanyPage() {
   const enrichContact = useCallback(
     async (personId: string) => {
       try {
-        await fetch("/api/enrich", {
+        await apiFetch("/api/enrich", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ contactId: personId }),
@@ -294,7 +295,7 @@ export default function CompanyPage() {
         onPersonClick={(id) => setSelectedPersonId(id)}
         onPersonReclassify={async (personId, next) => {
           try {
-            const res = await fetch(`/api/people/${personId}`, {
+            const res = await apiFetch(`/api/people/${personId}`, {
               method: "PATCH",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -314,7 +315,7 @@ export default function CompanyPage() {
         }}
         onPersonRemove={async (personId) => {
           try {
-            const res = await fetch(`/api/people/${personId}/from-company`, {
+            const res = await apiFetch(`/api/people/${personId}/from-company`, {
               method: "DELETE",
             });
             if (!res.ok) {
@@ -335,7 +336,7 @@ export default function CompanyPage() {
         onEnrich={enrichContact}
         onRemove={async (personId) => {
           try {
-            const res = await fetch(`/api/people/${personId}/from-company`, {
+            const res = await apiFetch(`/api/people/${personId}/from-company`, {
               method: "DELETE",
             });
             if (!res.ok) {

--- a/src/app/email-skills/page.tsx
+++ b/src/app/email-skills/page.tsx
@@ -197,7 +197,7 @@ export default function EmailSkillsPage() {
       <div className="flex-1 overflow-y-auto">
         <div className="space-y-6 p-4 md:p-6">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Email Skills</h1>
+            <h1 className="type-title">Email Skills</h1>
             <p className="text-muted-foreground flex items-center gap-1.5 text-sm">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Loading...
@@ -215,7 +215,7 @@ export default function EmailSkillsPage() {
       <div className="space-y-6 p-4 md:p-6">
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Email Skills</h1>
+            <h1 className="type-title">Email Skills</h1>
             <p className="text-muted-foreground text-sm">
               Reusable rule packs that shape how the agent writes emails. Attach
               at the global, profile, or campaign scope.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,10 +7,52 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ── Typography scale (ported from PLG dashboard) ─────────────────────── */
+@utility type-jumbo {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+}
+@utility type-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  line-height: 2rem;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+}
+@utility type-header {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  line-height: 2rem;
+  letter-spacing: -0.01em;
+  font-weight: 500;
+}
+@utility type-large {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  letter-spacing: -0.005em;
+}
+@utility type-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+@utility type-body {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+@utility type-caption {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  letter-spacing: 0.01em;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-inter);
+  --font-sans: var(--font-geist-sans);
+  --font-display: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -25,6 +67,10 @@
   --color-chart-3: var(--chart-3);
   --color-chart-2: var(--chart-2);
   --color-chart-1: var(--chart-1);
+  --color-success: var(--success);
+  --color-info: var(--info);
+  --color-warn: var(--warn);
+  --color-category: var(--category);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -54,77 +100,94 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(0.99 0.002 260);
-  --foreground: oklch(0.2 0.02 260);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.2 0.02 260);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.2 0.02 260);
+  /* PLG dashboard palette — warm neutrals, tight corners, violet accent */
+  --radius: 0.375rem;
+  --background: #f6f5f5;
+  --foreground: #260f17;
+  --card: #ffffff;
+  --card-foreground: #260f17;
+  --popover: #ffffff;
+  --popover-foreground: #260f17;
   --primary: oklch(0.56 0.23 265);
-  --primary-foreground: oklch(0.99 0.002 260);
-  --secondary: oklch(0.96 0.004 260);
-  --secondary-foreground: oklch(0.2 0.02 260);
-  --muted: oklch(0.96 0.004 260);
-  --muted-foreground: oklch(0.5 0.015 260);
-  --accent: oklch(0.96 0.004 260);
-  --accent-foreground: oklch(0.2 0.02 260);
-  --highlight: oklch(0.7 0.21 355);
-  --highlight-foreground: oklch(0.99 0.002 260);
-  --destructive: oklch(0.6 0.22 28);
-  --destructive-foreground: oklch(0.99 0.002 260);
-  --border: oklch(0.92 0.006 260);
-  --input: oklch(0.92 0.006 260);
+  --primary-foreground: #ffffff;
+  --secondary: #f1f0f0;
+  --secondary-foreground: #260f17;
+  --muted: #f1f0f0;
+  --muted-foreground: #6e6c6a;
+  --accent: #f1f0f0;
+  --accent-foreground: #260f17;
+  --highlight: oklch(0.56 0.23 265);
+  --highlight-foreground: #ffffff;
+  --destructive: #ce1f02;
+  --destructive-foreground: #ffffff;
+  /* Categorical status colors. Each doubles as pill text on its own /10 tint,
+     so these are the AA-safe dark shades (>=4.9:1), not the PLG display hues —
+     the brighter versions measured 3.2-3.7:1 and failed at pill text sizes. */
+  --success: #3d6b1a;
+  --info: #1a6ba8;
+  --warn: #8a5f0a;
+  --category: #b02d63;
+  --border: #edebeb;
+  --input: #edebeb;
   --ring: oklch(0.56 0.23 265);
   --chart-1: oklch(0.56 0.23 265);
-  --chart-2: oklch(0.7 0.21 355);
-  --chart-3: oklch(0.72 0.14 255);
-  --chart-4: oklch(0.55 0.2 350);
-  --chart-5: oklch(0.82 0.08 245);
-  --sidebar: oklch(0.985 0.003 260);
-  --sidebar-foreground: oklch(0.2 0.02 260);
+  --chart-2: #4da9e4;
+  --chart-3: #90c94d;
+  --chart-4: #f4ba41;
+  --chart-5: #ec679b;
+  --sidebar: #f6f5f5;
+  --sidebar-foreground: #260f17;
   --sidebar-primary: oklch(0.56 0.23 265);
-  --sidebar-primary-foreground: oklch(0.99 0.002 260);
-  --sidebar-accent: oklch(0.96 0.004 260);
-  --sidebar-accent-foreground: oklch(0.2 0.02 260);
-  --sidebar-border: oklch(0.92 0.006 260);
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f1f0f0;
+  --sidebar-accent-foreground: #260f17;
+  --sidebar-border: #edebeb;
   --sidebar-ring: oklch(0.56 0.23 265);
 }
 
 .dark {
-  --background: oklch(0.16 0.008 260);
-  --foreground: oklch(0.96 0.004 260);
-  --card: oklch(0.21 0.01 260);
-  --card-foreground: oklch(0.96 0.004 260);
-  --popover: oklch(0.21 0.01 260);
-  --popover-foreground: oklch(0.96 0.004 260);
+  /* PLG dashboard dark palette — warm near-black, warm-white text, violet accent */
+  --background: #0c0a0a;
+  --foreground: #f4f1ef;
+  --card: #161213;
+  --card-foreground: #f4f1ef;
+  --popover: #161213;
+  --popover-foreground: #f4f1ef;
   --primary: oklch(0.66 0.22 265);
-  --primary-foreground: oklch(0.16 0.008 260);
-  --secondary: oklch(0.28 0.01 260);
-  --secondary-foreground: oklch(0.96 0.004 260);
-  --muted: oklch(0.28 0.01 260);
-  --muted-foreground: oklch(0.64 0.012 260);
-  --accent: oklch(0.28 0.01 260);
-  --accent-foreground: oklch(0.96 0.004 260);
-  --highlight: oklch(0.75 0.21 355);
-  --highlight-foreground: oklch(0.16 0.008 260);
-  --destructive: oklch(0.66 0.21 28);
-  --destructive-foreground: oklch(0.96 0.004 260);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --primary-foreground: #0c0a0a;
+  /* One step above --card (#161213), never equal to it: --muted is what marks
+     the highlighted Select option on a --popover surface, so collapsing the two
+     leaves keyboard focus with nothing to show. */
+  --secondary: #221d1e;
+  --secondary-foreground: #f4f1ef;
+  --muted: #221d1e;
+  --muted-foreground: #a8a29e;
+  --accent: #221d1e;
+  --accent-foreground: #f4f1ef;
+  --highlight: oklch(0.66 0.22 265);
+  --highlight-foreground: #0c0a0a;
+  --destructive: oklch(0.62 0.2 28);
+  --destructive-foreground: #f4f1ef;
+  /* Categorical status colors (PLG palette, lifted for contrast on dark bg) */
+  --success: #9fd45f;
+  --info: #6fbef0;
+  --warn: #f0c24a;
+  --category: #f481ad;
+  --border: #2e2929;
+  --input: #2e2929;
   --ring: oklch(0.66 0.22 265);
   --chart-1: oklch(0.66 0.22 265);
-  --chart-2: oklch(0.75 0.21 355);
-  --chart-3: oklch(0.78 0.14 250);
-  --chart-4: oklch(0.6 0.2 350);
-  --chart-5: oklch(0.85 0.08 245);
-  --sidebar: oklch(0.19 0.008 260);
-  --sidebar-foreground: oklch(0.96 0.004 260);
+  --chart-2: #4da9e4;
+  --chart-3: #90c94d;
+  --chart-4: #f4ba41;
+  --chart-5: #ec679b;
+  --sidebar: #0c0a0a;
+  --sidebar-foreground: #f4f1ef;
   --sidebar-primary: oklch(0.66 0.22 265);
-  --sidebar-primary-foreground: oklch(0.16 0.008 260);
-  --sidebar-accent: oklch(0.28 0.01 260);
-  --sidebar-accent-foreground: oklch(0.96 0.004 260);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-primary-foreground: #0c0a0a;
+  --sidebar-accent: #221d1e;
+  --sidebar-accent-foreground: #f4f1ef;
+  --sidebar-border: #2e2929;
   --sidebar-ring: oklch(0.66 0.22 265);
 }
 
@@ -134,6 +197,8 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-weight: 300;
+    -webkit-font-smoothing: antialiased;
     font-synthesis-weight: none;
     text-rendering: optimizeLegibility;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -204,6 +204,39 @@
   }
 }
 
+/* ── Motion ───────────────────────────────────────────────────────────── */
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Entrance for cards/sections. Stagger with `--rise-delay` on the element. */
+@utility animate-rise {
+  animation: rise 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--rise-delay, 0ms);
+}
+
+/* Hover affordance for interactive surfaces (stat cards, list rows). */
+@utility lift {
+  transition:
+    transform 150ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 150ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 150ms ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px -8px
+      color-mix(in oklab, var(--foreground) 22%, transparent);
+    border-color: color-mix(in oklab, var(--foreground) 14%, transparent);
+  }
+}
+
 html,
 body {
   overflow: hidden;
@@ -241,6 +274,10 @@ body {
   *::before,
   *::after {
     animation-duration: 0.01ms !important;
+    /* Negative, not zero: `animate-rise` pairs a delay with fill-mode `both`,
+       so a surviving delay would hold the element at opacity 0 for its whole
+       stagger and then pop it in — the exact flash the preference forbids. */
+    animation-delay: -0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { ClerkProvider } from "@clerk/nextjs";
 import { shadcn } from "@clerk/ui/themes";
@@ -11,11 +11,6 @@ import { MissingKeyBannerStack } from "@/components/missing-key-banner-stack";
 import { PostHogIdentify } from "@/components/posthog-identify";
 import { StreamingProvider } from "@/lib/streaming-context";
 import "./globals.css";
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-});
 
 export const metadata: Metadata = {
   title: "Signal",
@@ -30,14 +25,14 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.variable} ${GeistMono.variable} font-sans antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} font-sans antialiased`}
       >
         <ClerkProvider appearance={{ theme: shadcn }}>
           <PostHogIdentify />
           <ThemeProvider
             attribute="class"
-            defaultTheme="system"
-            enableSystem
+            defaultTheme="light"
+            storageKey="signal-theme"
             disableTransitionOnChange
           >
             <StreamingProvider>

--- a/src/app/outreach/page.tsx
+++ b/src/app/outreach/page.tsx
@@ -257,7 +257,7 @@ export default function OutreachPage() {
       <div className="space-y-8 p-4 md:p-6">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Outreach</h1>
+            <h1 className="type-title">Outreach</h1>
             <p className="text-muted-foreground text-sm">
               Signal-driven email sequences across all campaigns.
             </p>

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { EditableEmail } from "@/components/ui/editable-email";
 import { createClient } from "@/lib/supabase/client";
 import type { CampaignContact, EnrichmentData } from "@/lib/types/campaign";
+import { apiFetch } from "@/lib/api-fetch";
 
 function htmlToPlain(html: string): string {
   if (!html) return "";
@@ -430,7 +431,7 @@ function ReviewPageInner() {
       );
 
       try {
-        const res = await fetch("/api/enrich", {
+        const res = await apiFetch("/api/enrich", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ contactId: personId }),
@@ -531,7 +532,7 @@ function ReviewPageInner() {
           return;
         }
 
-        const res = await fetch("/api/outreach/send-now", {
+        const res = await apiFetch("/api/outreach/send-now", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ draftId }),
@@ -596,7 +597,7 @@ function ReviewPageInner() {
       setRegeneratingDraftIds((prev) => new Set(prev).add(draftId));
 
       try {
-        const res = await fetch("/api/outreach/regenerate", {
+        const res = await apiFetch("/api/outreach/regenerate", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ draftId }),
@@ -682,7 +683,7 @@ function ReviewPageInner() {
       // Promote to user_entered source + recompute the org pattern. Fire-and-
       // forget so a slow recompute doesn't block the UI; the prior person
       // update already persisted the email.
-      void fetch("/api/email/record-verified", {
+      void apiFetch("/api/email/record-verified", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ personId, email: next }),

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -755,7 +755,7 @@ function ReviewPageInner() {
 
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-4">
-        <h2 className="text-xl font-bold">Review complete</h2>
+        <h2 className="type-header">Review complete</h2>
         <p className="text-muted-foreground text-sm">
           {approvedCount} approved, {rejectedCount} rejected across{" "}
           {totalContacts} contacts.
@@ -838,9 +838,7 @@ function ReviewPageInner() {
         <div className="flex-1 overflow-y-auto p-6">
           <div className="mx-auto flex max-w-3xl flex-col gap-4">
             <div className="space-y-1">
-              <h2 className="text-lg font-semibold">
-                {currentContact.person_name}
-              </h2>
+              <h2 className="type-header">{currentContact.person_name}</h2>
               <div className="text-muted-foreground flex items-center gap-1 text-xs">
                 <span className="shrink-0">Email:</span>
                 <EditableEmail
@@ -854,10 +852,10 @@ function ReviewPageInner() {
                   if (!chip) return null;
                   const toneClass =
                     chip.tone === "verified"
-                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                      ? "bg-success/10 text-success"
                       : chip.tone === "ok"
                         ? "bg-muted text-muted-foreground"
-                        : "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400";
+                        : "bg-warn/10 text-warn";
                   return (
                     <span
                       className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${toneClass}`}
@@ -1040,7 +1038,7 @@ function EmailCard({
         </div>
         <div className="flex items-center gap-2">
           {isSent ? (
-            <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+            <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
               Sent
             </span>
           ) : alreadyReviewed ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   PageHeaderSkeleton,
   StatsRowSkeleton,
 } from "@/components/ui/skeleton-presets";
+import { apiFetch } from "@/lib/api-fetch";
 
 const OutreachChart = dynamic(
   () =>
@@ -62,7 +63,7 @@ export default function DashboardPage() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/dashboard?range=${r}`);
+      const res = await apiFetch(`/api/dashboard?range=${r}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       setData(json);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,7 +122,7 @@ export default function DashboardPage() {
     <div className="flex-1 overflow-y-auto">
       <div className="space-y-6 p-4 md:p-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Overview</h1>
+          <h1 className="type-title">Overview</h1>
           <p className="text-muted-foreground text-sm">
             Cross-campaign performance at a glance.
           </p>
@@ -137,7 +137,7 @@ export default function DashboardPage() {
         />
 
         <div>
-          <h2 className="mb-3 text-lg font-semibold">Campaigns</h2>
+          <h2 className="mb-3 type-header">Campaigns</h2>
           <CampaignTable campaigns={data.campaigns} />
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,7 +136,7 @@ export default function DashboardPage() {
           onRangeChange={handleRangeChange}
         />
 
-        <div>
+        <div className="animate-rise [--rise-delay:300ms]">
           <h2 className="mb-3 type-header">Campaigns</h2>
           <CampaignTable campaigns={data.campaigns} />
         </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -187,7 +187,7 @@ export default function ProfilePage() {
     <div className="flex-1 overflow-y-auto">
       <div className="space-y-8 p-4 md:p-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Profiles</h1>
+          <h1 className="type-title">Profiles</h1>
           <p className="text-muted-foreground text-sm">
             Create different profiles for different campaigns. Each profile is a
             seller identity with its own company, offering, and links.
@@ -247,7 +247,7 @@ export default function ProfilePage() {
 
         {/* Personal Info */}
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold">Personal Info</h2>
+          <h2 className="type-header">Personal Info</h2>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <label
@@ -303,7 +303,7 @@ export default function ProfilePage() {
 
         {/* Company & Links */}
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold">Company & Links</h2>
+          <h2 className="type-header">Company & Links</h2>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <label
@@ -388,7 +388,7 @@ export default function ProfilePage() {
 
         {/* About Your Offering */}
         <section className="space-y-4">
-          <h2 className="text-lg font-semibold">About Your Offering</h2>
+          <h2 className="type-header">About Your Offering</h2>
           <div className="space-y-2">
             <label
               htmlFor="offering_summary"

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -45,7 +45,7 @@ export default function SettingsPage() {
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
+          <h1 className="type-title">Settings</h1>
           <p className="text-muted-foreground text-sm">
             Manage your account and preferences.
           </p>

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -182,7 +182,7 @@ function SignalsPageContent() {
       <div className="flex-1 overflow-y-auto">
         <div className="space-y-6 p-4 md:p-6">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Signals</h1>
+            <h1 className="type-title">Signals</h1>
             <p className="text-muted-foreground flex items-center gap-1.5 text-sm">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Loading...
@@ -199,7 +199,7 @@ function SignalsPageContent() {
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Signals</h1>
+            <h1 className="type-title">Signals</h1>
             <p className="text-muted-foreground text-sm">
               Browse and manage buying signals. Signals guide the agent on what
               to research for each prospect.

--- a/src/app/tracking/page.tsx
+++ b/src/app/tracking/page.tsx
@@ -199,7 +199,7 @@ function TrackingPageContent() {
       <div className="flex-1 overflow-y-auto">
         <div className="space-y-6 p-4 md:p-6">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Tracking</h1>
+            <h1 className="type-title">Tracking</h1>
             <p className="text-muted-foreground flex items-center gap-1.5 text-sm">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Loading...
@@ -215,7 +215,7 @@ function TrackingPageContent() {
       <div className="space-y-6 p-4 md:p-6">
         {/* Header */}
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Tracking</h1>
+          <h1 className="type-title">Tracking</h1>
           <p className="text-muted-foreground text-sm">
             Monitor companies over time. Signals run on schedule and flag
             entities when thresholds are met.

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import type { UIMessage } from "ai";
 import { useChat } from "@ai-sdk/react";
 
 import { useAuth } from "@clerk/nextjs";
 
+import { ChatErrorBanner } from "@/components/chat/chat-error-banner";
 import { ChatInput } from "@/components/chat/chat-input";
 import { ChatMessages } from "@/components/chat/chat-messages";
+import { createChatTransport } from "@/lib/chat-transport";
 import { useCampaign } from "@/lib/campaign-context";
 import { useStreaming } from "@/lib/streaming-context";
 import { saveChat } from "@/lib/services/chat-history";
@@ -147,9 +149,12 @@ function AgentPanelInner({
   const { userId } = useAuth();
   const didAutoSend = useRef(false);
 
-  const { messages, sendMessage, status, stop } = useChat({
+  const transport = useMemo(() => createChatTransport(), []);
+
+  const { messages, sendMessage, status, stop, error, regenerate } = useChat({
     id: campaignId ? `campaign-${campaignId}` : `global-${chatId}`,
     messages: initialMessages,
+    transport,
     onFinish({ messages: allMessages }) {
       if (userId) {
         saveChat(
@@ -254,6 +259,8 @@ function AgentPanelInner({
         onSuggestionClick={handleSuggestionClick}
         suggestions={getSuggestions(pathname ?? "", campaignId)}
       />
+
+      {error && <ChatErrorBanner error={error} onRetry={() => regenerate()} />}
 
       <ChatInput
         input={input}

--- a/src/components/campaign/campaign-header.tsx
+++ b/src/components/campaign/campaign-header.tsx
@@ -101,9 +101,7 @@ export function CampaignHeader({
     <div className="space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <h1 className="truncate text-2xl font-bold tracking-tight">
-            {campaign.name}
-          </h1>
+          <h1 className="truncate type-title">{campaign.name}</h1>
           <div className="text-muted-foreground mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
             <span>
               {contactCount} {contactCount === 1 ? "contact" : "contacts"}

--- a/src/components/campaign/campaign-stats.tsx
+++ b/src/components/campaign/campaign-stats.tsx
@@ -31,7 +31,7 @@ export function CampaignStats({ companies, contacts }: CampaignStatsProps) {
 
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-6">
-      <div className="border-border col-span-2 rounded-lg border bg-gradient-to-br from-emerald-500/5 to-transparent px-4 py-3 md:col-span-2">
+      <div className="border-border col-span-2 rounded-lg border bg-gradient-to-br from-success/5 to-transparent px-4 py-3 md:col-span-2">
         <div className="flex items-baseline gap-2">
           <span className="text-4xl font-semibold tabular-nums">
             {replyRate}

--- a/src/components/campaign/companies-list.tsx
+++ b/src/components/campaign/companies-list.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/status-styles";
 import { cn } from "@/lib/utils";
 import type { CampaignCompany, CampaignContact } from "@/lib/types/campaign";
+import { apiFetch } from "@/lib/api-fetch";
 
 const ROW_FOCUS =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
@@ -143,7 +144,7 @@ export function CompaniesList({
   const enrichContact = async (contactId: string) => {
     setEnrichingIds((prev) => new Set(prev).add(contactId));
     try {
-      await fetch("/api/enrich", {
+      await apiFetch("/api/enrich", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ contactId }),
@@ -164,7 +165,7 @@ export function CompaniesList({
   const enrichCompanyHandler = async (companyId: string) => {
     setEnrichingCompanyIds((prev) => new Set(prev).add(companyId));
     try {
-      const res = await fetch("/api/enrich-company", {
+      const res = await apiFetch("/api/enrich-company", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ companyId, campaignId }),
@@ -189,7 +190,7 @@ export function CompaniesList({
   const findContactsHandler = async (companyId: string) => {
     setFindingContactsIds((prev) => new Set(prev).add(companyId));
     try {
-      await fetch("/api/find-contacts", {
+      await apiFetch("/api/find-contacts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ companyId, campaignId }),
@@ -209,7 +210,7 @@ export function CompaniesList({
   const findEmailForContact = async (contact: CampaignContact) => {
     setFindingEmailIds((prev) => new Set(prev).add(contact.id));
     try {
-      await fetch("/api/find-email", {
+      await apiFetch("/api/find-email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ personId: contact.person_id }),
@@ -230,7 +231,7 @@ export function CompaniesList({
     if (!organizationId) return;
     setFindingEmailsCompanyIds((prev) => new Set(prev).add(organizationId));
     try {
-      await fetch("/api/find-email/bulk", {
+      await apiFetch("/api/find-email/bulk", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ campaignId, organizationId }),

--- a/src/components/campaign/company-detail.tsx
+++ b/src/components/campaign/company-detail.tsx
@@ -259,10 +259,10 @@ export function CompanyDetail({
 
       {data.errors && data.errors.length > 0 && (
         <section className="space-y-1">
-          <h4 className="text-xs font-medium uppercase tracking-wide text-red-600 dark:text-red-400">
+          <h4 className="text-xs font-medium uppercase tracking-wide text-destructive">
             Enrichment errors
           </h4>
-          <ul className="space-y-0.5 text-xs text-red-600 dark:text-red-400">
+          <ul className="space-y-0.5 text-xs text-destructive">
             {data.errors.map((e, i) => (
               <li key={i} className="flex items-start gap-1.5">
                 <span className="mt-0.5">•</span>

--- a/src/components/campaign/contact-detail.tsx
+++ b/src/components/campaign/contact-detail.tsx
@@ -202,7 +202,7 @@ export function ContactDetail({
   if (contact.enrichment_status === "failed") {
     return (
       <div className="flex flex-col items-center gap-2 px-4 py-4 text-center">
-        <p className="text-sm text-red-600 dark:text-red-400">
+        <p className="text-sm text-destructive">
           Enrichment failed for this contact.
         </p>
         {onRetry && (

--- a/src/components/campaign/contacts-table.tsx
+++ b/src/components/campaign/contacts-table.tsx
@@ -15,6 +15,7 @@ import {
   type EnrichmentStatus,
 } from "@/lib/status-styles";
 import type { CampaignContact } from "@/lib/types/campaign";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface ContactsTableProps {
   contacts: CampaignContact[];
@@ -34,7 +35,7 @@ export function ContactsTable({
   const findEmail = async (contact: CampaignContact) => {
     setFindingEmailIds((prev) => new Set(prev).add(contact.id));
     try {
-      const res = await fetch("/api/find-email", {
+      const res = await apiFetch("/api/find-email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ personId: contact.person_id }),
@@ -67,7 +68,7 @@ export function ContactsTable({
   const enrichContact = async (contactId: string) => {
     setEnrichingIds((prev) => new Set(prev).add(contactId));
     try {
-      const res = await fetch("/api/enrich", {
+      const res = await apiFetch("/api/enrich", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ contactId }),

--- a/src/components/campaign/csv-upload.tsx
+++ b/src/components/campaign/csv-upload.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface ParsedCompany {
   name: string;
@@ -226,7 +227,7 @@ export function CsvUpload({ campaignId, onImported }: CsvUploadProps) {
     setImporting(true);
     setError(null);
     try {
-      const res = await fetch("/api/import-csv", {
+      const res = await apiFetch("/api/import-csv", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ campaignId, companies }),

--- a/src/components/chat/chat-error-banner.tsx
+++ b/src/components/chat/chat-error-banner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, RotateCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/** Clerk rejects the request before the route runs, so the body is its own. */
+function isAuthError(error: Error): boolean {
+  const text = `${error.message}`.toLowerCase();
+  return (
+    text.includes("unauthorized") ||
+    text.includes("401") ||
+    text.includes("signed out")
+  );
+}
+
+interface ChatErrorBannerProps {
+  error: Error;
+  onRetry: () => void;
+}
+
+export function ChatErrorBanner({ error, onRetry }: ChatErrorBannerProps) {
+  const auth = isAuthError(error);
+
+  return (
+    <div
+      role="alert"
+      className="border-destructive/30 bg-destructive/5 mx-4 mb-2 flex items-start gap-2.5 rounded-lg border px-3 py-2.5"
+    >
+      <AlertCircle className="text-destructive mt-0.5 size-4 shrink-0" />
+
+      <div className="min-w-0 flex-1">
+        <p className="text-destructive text-sm font-medium">
+          {auth ? "Your session expired" : "The agent stopped unexpectedly"}
+        </p>
+        <p className="text-muted-foreground mt-0.5 text-xs">
+          {auth
+            ? "Sign in again to pick up where you left off. Your messages are saved."
+            : error.message}
+        </p>
+      </div>
+
+      {auth ? (
+        <Button size="sm" variant="outline" render={<Link href="/login" />}>
+          Sign in
+        </Button>
+      ) : (
+        <Button size="sm" variant="outline" onClick={onRetry}>
+          <RotateCw />
+          Retry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -52,7 +52,7 @@ export function ChatMessages({
             <MessageSquare className="text-muted-foreground h-6 w-6" />
           </div>
           <div>
-            <h3 className="text-lg font-semibold">How can I help?</h3>
+            <h3 className="type-header">How can I help?</h3>
             <p className="text-muted-foreground mt-1 text-sm">
               I&apos;m Signal, your AI assistant. Ask me anything or pick a
               suggestion below.

--- a/src/components/chat/tool-call-card.tsx
+++ b/src/components/chat/tool-call-card.tsx
@@ -71,7 +71,7 @@ export function ToolCallCard({
     return (
       <div className="my-1">
         <div className="bg-muted/40 border-border flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
-          <CheckCircle2 className="h-4 w-4 text-green-500" />
+          <CheckCircle2 className="h-4 w-4 text-success" />
           <Icon className="text-muted-foreground h-4 w-4" />
           <span className="text-muted-foreground flex-1 truncate">
             {config.label}
@@ -94,9 +94,9 @@ export function ToolCallCard({
           {isLoading ? (
             <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
           ) : hasError ? (
-            <AlertCircle className="h-4 w-4 text-red-500" />
+            <AlertCircle className="h-4 w-4 text-destructive" />
           ) : (
-            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <CheckCircle2 className="h-4 w-4 text-success" />
           )}
           <Icon className="text-muted-foreground h-4 w-4" />
           <span className="text-muted-foreground flex-1 truncate">
@@ -124,7 +124,7 @@ export function ToolCallCard({
 
       {expanded && hasError && errorText && (
         <div className="border-border border-t px-3 py-2">
-          <p className="text-xs text-red-500">{errorText}</p>
+          <p className="text-xs text-destructive">{errorText}</p>
         </div>
       )}
 
@@ -226,7 +226,7 @@ function CollapsibleToolResult({
     const campaign = data.campaign as { name: string; status: string };
     return (
       <div className="flex items-center gap-2">
-        <CheckCircle2 className="h-3 w-3 text-green-500" />
+        <CheckCircle2 className="h-3 w-3 text-success" />
         <span className="text-xs">
           Campaign &quot;{campaign.name}&quot; {data.action as string} (
           {campaign.status})
@@ -262,7 +262,7 @@ function CollapsibleToolResult({
         <span className="text-muted-foreground">Enriched from:</span>{" "}
         {sources.join(", ") || "no sources"}
         {data.errors ? (
-          <p className="mt-1 text-red-500">
+          <p className="mt-1 text-destructive">
             Errors: {(data.errors as string[]).join(", ")}
           </p>
         ) : null}

--- a/src/components/company/add-person-dialog.tsx
+++ b/src/components/company/add-person-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface OrphanRow {
   id: string;
@@ -76,7 +77,7 @@ export function AddPersonDialog({
   async function add(personId: string) {
     setAddingId(personId);
     try {
-      const res = await fetch(`/api/people/${personId}/to-company`, {
+      const res = await apiFetch(`/api/people/${personId}/to-company`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/components/company/embedded-org-chart.tsx
+++ b/src/components/company/embedded-org-chart.tsx
@@ -9,6 +9,7 @@ import { AddPersonDialog } from "./add-person-dialog";
 import { OrgChart, type OrgChartPerson } from "./org-chart";
 import { PersonDrawer } from "./person-drawer";
 import type { CampaignContact, Seniority } from "@/lib/types/campaign";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface EmbeddedOrgChartProps {
   organizationId: string;
@@ -121,7 +122,7 @@ export function EmbeddedOrgChart({
           onPersonClick={(id) => setSelectedPersonId(id)}
           onPersonReclassify={async (personId, next) => {
             try {
-              const res = await fetch(`/api/people/${personId}`, {
+              const res = await apiFetch(`/api/people/${personId}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({

--- a/src/components/company/find-more-button.tsx
+++ b/src/components/company/find-more-button.tsx
@@ -5,6 +5,7 @@ import { Loader2, Search } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface FindMoreButtonProps {
   companyId: string;
@@ -17,9 +18,12 @@ export function FindMoreButton({ companyId, onComplete }: FindMoreButtonProps) {
   async function run() {
     setBusy(true);
     try {
-      const res = await fetch(`/api/companies/${companyId}/find-more-people`, {
-        method: "POST",
-      });
+      const res = await apiFetch(
+        `/api/companies/${companyId}/find-more-people`,
+        {
+          method: "POST",
+        },
+      );
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err.error ?? `HTTP ${res.status}`);

--- a/src/components/company/person-node.tsx
+++ b/src/components/company/person-node.tsx
@@ -4,58 +4,39 @@ import { useState } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
 import { Linkedin, Loader2, Mail, Trash2 } from "lucide-react";
 
+import { outreachStatusStyles, type OutreachStatus } from "@/lib/status-styles";
 import { cn } from "@/lib/utils";
 
-const STATUS_STYLES: Record<
-  string,
-  { bg: string; ring: string; label: string }
-> = {
-  not_contacted: {
-    bg: "bg-muted text-muted-foreground",
-    ring: "ring-border",
-    label: "Not contacted",
-  },
-  queued: {
-    bg: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
-    ring: "ring-blue-500/30",
-    label: "Queued",
-  },
-  sent: {
-    bg: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
-    ring: "ring-blue-500/30",
-    label: "Sent",
-  },
-  delivered: {
-    bg: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
-    ring: "ring-blue-500/30",
-    label: "Delivered",
-  },
-  opened: {
-    bg: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
-    ring: "ring-amber-500/30",
-    label: "Opened",
-  },
-  clicked: {
-    bg: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
-    ring: "ring-amber-500/30",
-    label: "Clicked",
-  },
-  replied: {
-    bg: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-    ring: "ring-emerald-500/40",
-    label: "Replied",
-  },
-  bounced: {
-    bg: "bg-red-500/10 text-red-700 dark:text-red-400",
-    ring: "ring-red-500/30",
-    label: "Bounced",
-  },
-  complained: {
-    bg: "bg-red-500/10 text-red-700 dark:text-red-400",
-    ring: "ring-red-500/30",
-    label: "Complained",
-  },
+// Pill colors and labels come from the shared map, so a contact can't show one
+// status colour in the outreach table and a different one in the org chart.
+// Only the ring — which the table has no equivalent of — lives here.
+const STATUS_RINGS: Record<OutreachStatus, string> = {
+  queued: "ring-border",
+  sent: "ring-info/30",
+  delivered: "ring-info/30",
+  opened: "ring-warn/30",
+  clicked: "ring-category/30",
+  replied: "ring-success/40",
+  bounced: "ring-destructive/30",
+  complained: "ring-destructive/30",
 };
+
+const NOT_CONTACTED = {
+  bg: "bg-muted text-muted-foreground",
+  ring: "ring-border",
+  label: "Not contacted",
+};
+
+function statusStyle(status: string) {
+  const shared = outreachStatusStyles[status as OutreachStatus];
+  if (!shared) return NOT_CONTACTED;
+
+  return {
+    bg: shared.className,
+    ring: STATUS_RINGS[status as OutreachStatus],
+    label: shared.label,
+  };
+}
 
 export interface PersonNodeData {
   personId: string;
@@ -74,21 +55,17 @@ export interface PersonNodeData {
 function EnrichmentLabel({ status }: { status: string | null }) {
   if (status === "enriched") {
     return (
-      <span className="text-[10px] font-medium text-emerald-700 dark:text-emerald-400">
-        Enriched
-      </span>
+      <span className="text-[10px] font-medium text-success">Enriched</span>
     );
   }
   if (status === "in_progress") {
     return (
-      <span className="text-[10px] font-medium text-amber-700 dark:text-amber-400">
-        Enriching…
-      </span>
+      <span className="text-[10px] font-medium text-warn">Enriching…</span>
     );
   }
   if (status === "failed") {
     return (
-      <span className="text-[10px] font-medium text-red-700 dark:text-red-400">
+      <span className="text-[10px] font-medium text-destructive">
         Enrichment failed
       </span>
     );
@@ -100,7 +77,7 @@ function EnrichmentLabel({ status }: { status: string | null }) {
 
 export function PersonNode({ data, selected }: NodeProps<PersonNodeData>) {
   const status = data.outreach_status ?? "not_contacted";
-  const style = STATUS_STYLES[status] ?? STATUS_STYLES.not_contacted;
+  const style = statusStyle(status);
 
   const [confirming, setConfirming] = useState(false);
   const [removing, setRemoving] = useState(false);

--- a/src/components/dashboard/campaign-table.tsx
+++ b/src/components/dashboard/campaign-table.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Sparkles, Target } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { campaignStatusStyles, type CampaignStatus } from "@/lib/status-styles";
 
 interface CampaignRow {
@@ -30,8 +31,18 @@ export function CampaignTable({ campaigns }: CampaignTableProps) {
 
   if (campaigns.length === 0) {
     return (
-      <div className="border-border rounded-lg border p-6 text-center">
-        <p className="text-muted-foreground text-sm">No campaigns yet</p>
+      <div className="border-border rounded-lg border">
+        <EmptyState
+          icon={Target}
+          title="No campaigns yet"
+          description="Start a campaign and Signal will find companies, enrich contacts, and draft outreach for you."
+          action={
+            <Button size="sm" render={<Link href="/chat" />}>
+              <Sparkles />
+              Start a campaign
+            </Button>
+          }
+        />
       </div>
     );
   }

--- a/src/components/dashboard/outreach-chart.tsx
+++ b/src/components/dashboard/outreach-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Activity } from "lucide-react";
 import {
   AreaChart,
   Area,
@@ -9,6 +10,16 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
+
+import { EmptyState } from "@/components/ui/empty-state";
+
+// Colors come from the theme tokens so the chart tracks light/dark, and match
+// the accent on the matching stat card above it.
+const series = [
+  { key: "sent", name: "Sent", color: "var(--color-info)" },
+  { key: "opened", name: "Opened", color: "var(--color-warn)" },
+  { key: "replied", name: "Replied", color: "var(--color-success)" },
+] as const;
 
 interface TimeSeriesPoint {
   date: string;
@@ -32,7 +43,7 @@ export function OutreachChart({
   onRangeChange,
 }: OutreachChartProps) {
   return (
-    <div className="border-border rounded-lg border p-4">
+    <div className="border-border animate-rise rounded-lg border p-4 [--rise-delay:240ms]">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-sm font-semibold">Outreach Activity</h2>
         <div className="flex gap-1">
@@ -53,14 +64,31 @@ export function OutreachChart({
       </div>
 
       {timeSeries.length === 0 ? (
-        <div className="flex h-[200px] items-center justify-center">
-          <p className="text-muted-foreground text-sm">
-            No outreach activity yet
-          </p>
-        </div>
+        <EmptyState
+          icon={Activity}
+          accent="info"
+          title="No outreach activity yet"
+          description="Sends, opens, and replies will chart here once your first sequence goes out."
+          className="h-[200px] py-0"
+        />
       ) : (
         <ResponsiveContainer width="100%" height={240}>
           <AreaChart data={timeSeries}>
+            <defs>
+              {series.map(({ key, color }) => (
+                <linearGradient
+                  key={key}
+                  id={`fill-${key}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="0%" stopColor={color} stopOpacity={0.28} />
+                  <stop offset="100%" stopColor={color} stopOpacity={0.02} />
+                </linearGradient>
+              ))}
+            </defs>
             <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
             <XAxis
               dataKey="date"
@@ -87,33 +115,18 @@ export function OutreachChart({
                 backgroundColor: "var(--color-background)",
               }}
             />
-            <Area
-              type="monotone"
-              dataKey="sent"
-              name="Sent"
-              stroke="oklch(0.623 0.214 259.815)"
-              fill="oklch(0.623 0.214 259.815)"
-              fillOpacity={0.1}
-              strokeWidth={2}
-            />
-            <Area
-              type="monotone"
-              dataKey="opened"
-              name="Opened"
-              stroke="oklch(0.769 0.188 70.08)"
-              fill="oklch(0.769 0.188 70.08)"
-              fillOpacity={0.1}
-              strokeWidth={2}
-            />
-            <Area
-              type="monotone"
-              dataKey="replied"
-              name="Replied"
-              stroke="oklch(0.723 0.219 149.579)"
-              fill="oklch(0.723 0.219 149.579)"
-              fillOpacity={0.1}
-              strokeWidth={2}
-            />
+            {series.map(({ key, name, color }) => (
+              <Area
+                key={key}
+                type="monotone"
+                dataKey={key}
+                name={name}
+                stroke={color}
+                fill={`url(#fill-${key})`}
+                strokeWidth={2}
+                activeDot={{ r: 4, strokeWidth: 2 }}
+              />
+            ))}
           </AreaChart>
         </ResponsiveContainer>
       )}

--- a/src/components/dashboard/stat-cards.tsx
+++ b/src/components/dashboard/stat-cards.tsx
@@ -1,3 +1,5 @@
+import { MailOpen, MessageSquareReply, Send, Users } from "lucide-react";
+
 import { StatCard } from "@/components/ui/stat-card";
 
 interface DashboardTotals {
@@ -20,17 +22,35 @@ export function StatCards({ totals }: StatCardsProps) {
 
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-      <StatCard label="Total Leads" value={totals.leads} />
-      <StatCard label="Sent" value={totals.sent} />
+      <StatCard
+        label="Total Leads"
+        value={totals.leads}
+        accent="primary"
+        icon={Users}
+        className="animate-rise"
+      />
+      <StatCard
+        label="Sent"
+        value={totals.sent}
+        accent="info"
+        icon={Send}
+        className="animate-rise [--rise-delay:60ms]"
+      />
       <StatCard
         label="Opened"
         value={totals.opened}
         sublabel={totals.sent > 0 ? `${openRate}% open rate` : undefined}
+        accent="warn"
+        icon={MailOpen}
+        className="animate-rise [--rise-delay:120ms]"
       />
       <StatCard
         label="Replied"
         value={totals.replied}
         sublabel={totals.sent > 0 ? `${replyRate}% reply rate` : undefined}
+        accent="success"
+        icon={MessageSquareReply}
+        className="animate-rise [--rise-delay:180ms]"
       />
     </div>
   );

--- a/src/components/email-skills/email-skill-card.tsx
+++ b/src/components/email-skills/email-skill-card.tsx
@@ -21,8 +21,8 @@ export function EmailSkillCard({
 }: EmailSkillCardProps) {
   const badgeLabel = skill.is_builtin ? "Built-in" : "Custom";
   const badgeClass = skill.is_builtin
-    ? "bg-blue-500/10 text-blue-500"
-    : "bg-emerald-500/10 text-emerald-500";
+    ? "bg-info/10 text-info"
+    : "bg-success/10 text-success";
 
   return (
     <button

--- a/src/components/email-skills/email-skill-detail-dialog.tsx
+++ b/src/components/email-skills/email-skill-detail-dialog.tsx
@@ -50,8 +50,8 @@ export function EmailSkillDetailDialog({
 
   const canEdit = !skill.is_builtin;
   const badgeClass = skill.is_builtin
-    ? "bg-blue-500/10 text-blue-600 dark:text-blue-400"
-    : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+    ? "bg-info/10 text-info"
+    : "bg-success/10 text-success";
   const badgeLabel = skill.is_builtin ? "Built-in" : "Custom";
 
   const handleSave = async () => {

--- a/src/components/email-skills/email-skills-attacher.tsx
+++ b/src/components/email-skills/email-skills-attacher.tsx
@@ -196,8 +196,8 @@ export function EmailSkillsAttacher({
                       <span
                         className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
                           skill.is_builtin
-                            ? "bg-blue-500/10 text-blue-500"
-                            : "bg-emerald-500/10 text-emerald-500"
+                            ? "bg-info/10 text-info"
+                            : "bg-success/10 text-success"
                         }`}
                       >
                         {skill.is_builtin ? "Built-in" : "Custom"}

--- a/src/components/missing-key-banner.tsx
+++ b/src/components/missing-key-banner.tsx
@@ -17,7 +17,7 @@ export function MissingKeyBanner({
   return (
     <div
       role="alert"
-      className="border-b border-amber-500/30 bg-amber-500/15 px-4 py-2 text-sm"
+      className="border-b border-warn/30 bg-warn/15 px-4 py-2 text-sm"
     >
       <strong>{integration.name} not configured.</strong>{" "}
       {integration.consequence}{" "}
@@ -26,7 +26,7 @@ export function MissingKeyBanner({
         {missingEnvVars.map((v, i) => (
           <span key={v}>
             {i > 0 && ", "}
-            <code className="rounded bg-amber-500/20 px-1">{v}</code>
+            <code className="rounded bg-warn/20 px-1">{v}</code>
           </span>
         ))}
         . {integration.fixHint && <>{integration.fixHint}. </>}

--- a/src/components/outreach/outreach-drafts-panel.tsx
+++ b/src/components/outreach/outreach-drafts-panel.tsx
@@ -13,6 +13,7 @@ import { ReviewButton } from "@/components/outreach/review-button";
 import { OUTREACH_STATUS, type OutreachStatus } from "@/lib/outreach/status";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
+import { apiFetch } from "@/lib/api-fetch";
 
 export interface DraftRow {
   id: string;
@@ -126,7 +127,7 @@ export function OutreachDraftsPanel({
   const handleSendNow = async (draftId: string) => {
     setSendingIds((prev) => new Set(prev).add(draftId));
     try {
-      const res = await fetch("/api/outreach/send-now", {
+      const res = await apiFetch("/api/outreach/send-now", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ draftId }),

--- a/src/components/outreach/outreach-drafts-panel.tsx
+++ b/src/components/outreach/outreach-drafts-panel.tsx
@@ -161,7 +161,7 @@ export function OutreachDraftsPanel({
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Needs attention</h2>
+        <h2 className="type-header">Needs attention</h2>
         <span className="text-muted-foreground text-xs tabular-nums">
           {drafts.length} draft{drafts.length === 1 ? "" : "s"} in flight
         </span>

--- a/src/components/outreach/ready-to-send-hero.tsx
+++ b/src/components/outreach/ready-to-send-hero.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import type { DraftRow } from "@/components/outreach/outreach-drafts-panel";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface ReadyToSendHeroProps {
   drafts: DraftRow[];
@@ -31,7 +32,7 @@ export function ReadyToSendHero({ drafts, onRefresh }: ReadyToSendHeroProps) {
     try {
       const results = await Promise.allSettled(
         drafts.map((d) =>
-          fetch("/api/outreach/send-now", {
+          apiFetch("/api/outreach/send-now", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ draftId: d.id }),

--- a/src/components/outreach/ready-to-send-hero.tsx
+++ b/src/components/outreach/ready-to-send-hero.tsx
@@ -57,7 +57,7 @@ export function ReadyToSendHero({ drafts, onRefresh }: ReadyToSendHeroProps) {
     <section className="border-primary/20 bg-primary/5 rounded-lg border p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-lg font-semibold">
+          <h2 className="type-header">
             {drafts.length} email{drafts.length === 1 ? "" : "s"} ready to send
           </h2>
           <p className="text-muted-foreground mt-0.5 text-sm">

--- a/src/components/outreach/sequence-list.tsx
+++ b/src/components/outreach/sequence-list.tsx
@@ -35,7 +35,7 @@ export function SequenceList({
   if (sequences.length === 0) {
     return (
       <section className="space-y-4">
-        <h2 className="text-lg font-semibold">Sequences</h2>
+        <h2 className="type-header">Sequences</h2>
         <p className="text-muted-foreground text-sm">
           No sequences yet. Ask the AI to set up outreach for a campaign.
         </p>
@@ -45,7 +45,7 @@ export function SequenceList({
 
   return (
     <section className="space-y-4">
-      <h2 className="text-lg font-semibold">Sequences</h2>
+      <h2 className="type-header">Sequences</h2>
       <div className="border-border overflow-hidden rounded-lg border">
         <table className="w-full text-sm">
           <thead>

--- a/src/components/outreach/sequence-progress-bar.tsx
+++ b/src/components/outreach/sequence-progress-bar.tsx
@@ -20,9 +20,9 @@ export function SequenceProgressBar({
   return (
     <div className={cn("flex flex-col gap-1.5 min-w-[180px]", className)}>
       <div className="bg-muted flex h-1.5 overflow-hidden rounded-full">
-        <span className="bg-emerald-500" style={{ width: pct(replied) }} />
-        <span className="bg-orange-500" style={{ width: pct(sent) }} />
-        <span className="bg-amber-400" style={{ width: pct(waiting) }} />
+        <span className="bg-success" style={{ width: pct(replied) }} />
+        <span className="bg-info" style={{ width: pct(sent) }} />
+        <span className="bg-warn" style={{ width: pct(waiting) }} />
       </div>
       <div className="text-muted-foreground flex gap-3 text-xs tabular-nums">
         <span>{replied} replied</span>

--- a/src/components/outreach/signal-kanban.tsx
+++ b/src/components/outreach/signal-kanban.tsx
@@ -56,7 +56,7 @@ export function SignalKanban({ enrollments }: SignalKanbanProps) {
   if (enrollments.length === 0) {
     return (
       <section className="space-y-4">
-        <h2 className="text-lg font-semibold">Pipeline</h2>
+        <h2 className="type-header">Pipeline</h2>
         <p className="text-muted-foreground text-sm">
           No active enrollments. Create a sequence and approve emails to get
           started.
@@ -67,7 +67,7 @@ export function SignalKanban({ enrollments }: SignalKanbanProps) {
 
   return (
     <section className="space-y-4">
-      <h2 className="text-lg font-semibold">Pipeline</h2>
+      <h2 className="type-header">Pipeline</h2>
       <div className="grid grid-cols-4 gap-4">
         {COLUMNS.map((col) => {
           const cards = enrollments.filter(

--- a/src/components/settings/cost-center.tsx
+++ b/src/components/settings/cost-center.tsx
@@ -250,7 +250,7 @@ export function CostCenter() {
                     total spend ({PERIOD_LABELS[period]})
                   </span>
                   {anyEstimate && (
-                    <span className="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                    <span className="rounded border border-warn/40 bg-warn/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-warn">
                       partly est
                     </span>
                   )}
@@ -315,7 +315,7 @@ export function CostCenter() {
                                     ? REAL_SPEND_FALLBACK_HINT[realKey]
                                     : "Estimated from local tracking -- no billing API integration for this provider."
                                 }
-                                className="rounded border border-amber-500/40 bg-amber-500/10 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide text-amber-600 dark:text-amber-400"
+                                className="rounded border border-warn/40 bg-warn/10 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide text-warn"
                               >
                                 est
                               </span>

--- a/src/components/settings/email-settings.tsx
+++ b/src/components/settings/email-settings.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { SettingsSection } from "@/components/settings/settings-section";
+import { apiFetch } from "@/lib/api-fetch";
 
 interface Inbox {
   inbox_id: string;
@@ -33,7 +34,7 @@ export function EmailSettings() {
 
     const load = async () => {
       try {
-        const res = await fetch("/api/settings/email");
+        const res = await apiFetch("/api/settings/email");
         if (!res.ok) return;
         const data = await res.json();
         if (!mountedRef.current) return;
@@ -59,7 +60,7 @@ export function EmailSettings() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/settings/email", {
+      const res = await apiFetch("/api/settings/email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -86,7 +87,7 @@ export function EmailSettings() {
     if (!newInboxName.trim()) return;
     setCreating(true);
     try {
-      const res = await fetch("/api/settings/email", {
+      const res = await apiFetch("/api/settings/email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/components/settings/email-settings.tsx
+++ b/src/components/settings/email-settings.tsx
@@ -130,7 +130,7 @@ export function EmailSettings() {
   }
 
   const statusBadge = isConfigured ? (
-    <span className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 rounded-full px-2.5 py-0.5 text-xs font-medium">
+    <span className="bg-success/10 text-success rounded-full px-2.5 py-0.5 text-xs font-medium">
       Connected
     </span>
   ) : (

--- a/src/components/settings/integrations-panel.tsx
+++ b/src/components/settings/integrations-panel.tsx
@@ -110,7 +110,7 @@ function IntegrationRow({
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium">{integration.name}</span>
             {isRequired && (
-              <span className="text-muted-foreground rounded-sm bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+              <span className="text-muted-foreground rounded-sm bg-warn/15 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-warn">
                 required
               </span>
             )}
@@ -152,9 +152,9 @@ function StatusIcon({
       className={cn(
         "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full",
         configured
-          ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+          ? "bg-success/15 text-success"
           : required
-            ? "bg-amber-500/20 text-amber-700 dark:text-amber-400"
+            ? "bg-warn/20 text-warn"
             : "bg-muted text-muted-foreground",
       )}
       aria-label={configured ? "Configured" : "Not configured"}

--- a/src/components/settings/settings-section.tsx
+++ b/src/components/settings/settings-section.tsx
@@ -36,12 +36,7 @@ export function SettingsSection({
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <h2
-            className={cn(
-              "text-lg font-semibold",
-              isDanger && "text-destructive",
-            )}
-          >
+          <h2 className={cn("type-header", isDanger && "text-destructive")}>
             {title}
           </h2>
           {description && (

--- a/src/components/sidebar-campaigns.tsx
+++ b/src/components/sidebar-campaigns.tsx
@@ -104,7 +104,7 @@ export function SidebarCampaigns({
                 <div className="relative">
                   <Target className="h-4 w-4" />
                   <span
-                    className={`absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full ${campaignStatusDotStyles[campaign.status as CampaignStatus] || "bg-gray-400"}`}
+                    className={`absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full ${campaignStatusDotStyles[campaign.status as CampaignStatus] || "bg-muted-foreground/40"}`}
                   />
                 </div>
                 <span className="truncate">{campaign.name}</span>

--- a/src/components/signals/signal-card.tsx
+++ b/src/components/signals/signal-card.tsx
@@ -38,10 +38,10 @@ export function SignalCard({
       : "Custom";
 
   const badgeClass = signal.is_builtin
-    ? "bg-blue-500/10 text-blue-500"
+    ? "bg-info/10 text-info"
     : signal.is_public
-      ? "bg-purple-500/10 text-purple-500"
-      : "bg-emerald-500/10 text-emerald-500";
+      ? "bg-category/10 text-category"
+      : "bg-success/10 text-success";
 
   const serviceLabel =
     signal.execution_type === "tool_call" && signal.tool_key

--- a/src/components/signals/signal-detail-dialog.tsx
+++ b/src/components/signals/signal-detail-dialog.tsx
@@ -55,10 +55,10 @@ export function SignalDetailDialog({
   const canEdit = !signal.is_builtin && onEdit;
 
   const badgeClass = signal.is_builtin
-    ? "bg-blue-500/10 text-blue-600 dark:text-blue-400"
+    ? "bg-info/10 text-info"
     : signal.is_public
-      ? "bg-purple-500/10 text-purple-600 dark:text-purple-400"
-      : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+      ? "bg-category/10 text-category"
+      : "bg-success/10 text-success";
 
   const badgeLabel = signal.is_builtin
     ? "Built-in"

--- a/src/components/tracking/tracking-timeline.tsx
+++ b/src/components/tracking/tracking-timeline.tsx
@@ -27,11 +27,11 @@ export function TrackingTimeline({ changes }: { changes: TrackingChange[] }) {
             <span
               className={
                 change.change_type === "threshold_crossed"
-                  ? "font-medium text-emerald-600 dark:text-emerald-400"
+                  ? "font-medium text-success"
                   : change.change_type === "added"
-                    ? "text-emerald-600 dark:text-emerald-400"
+                    ? "text-success"
                     : change.change_type === "removed"
-                      ? "text-red-500 dark:text-red-400"
+                      ? "text-destructive"
                       : "text-foreground"
               }
             >

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,61 @@
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type EmptyAccent = "primary" | "info" | "warn" | "success" | "category";
+
+const accentStyles: Record<EmptyAccent, string> = {
+  primary: "bg-primary/10 text-primary",
+  info: "bg-info/10 text-info",
+  warn: "bg-warn/10 text-warn",
+  success: "bg-success/10 text-success",
+  category: "bg-category/10 text-category",
+};
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  accent?: EmptyAccent;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  accent = "primary",
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 px-6 py-10 text-center",
+        className,
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "flex size-10 items-center justify-center rounded-full",
+          accentStyles[accent],
+        )}
+      >
+        <Icon className="size-5" />
+      </span>
+
+      <div className="space-y-1">
+        <p className="text-foreground text-sm font-medium">{title}</p>
+        {description && (
+          <p className="text-muted-foreground max-w-xs text-xs">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {action}
+    </div>
+  );
+}

--- a/src/components/ui/score-badge.tsx
+++ b/src/components/ui/score-badge.tsx
@@ -3,8 +3,8 @@ import { cn } from "@/lib/utils";
 type Variant = "pill" | "inline";
 
 const TIER_STYLES = {
-  high: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-  mid: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+  high: "bg-success/10 text-success",
+  mid: "bg-info/10 text-info",
   low: "bg-muted text-muted-foreground",
 } as const;
 

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -1,10 +1,33 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+
+import { useCountUp } from "@/hooks/use-count-up";
 import { cn } from "@/lib/utils";
+
+export type StatAccent = "primary" | "info" | "warn" | "success" | "category";
+
+// Tailwind can't build class names from a variable, so each accent spells its
+// utilities out in full.
+const accentStyles: Record<
+  StatAccent | "neutral",
+  { chip: string; rule: string }
+> = {
+  primary: { chip: "bg-primary/10 text-primary", rule: "bg-primary" },
+  info: { chip: "bg-info/10 text-info", rule: "bg-info" },
+  warn: { chip: "bg-warn/10 text-warn", rule: "bg-warn" },
+  success: { chip: "bg-success/10 text-success", rule: "bg-success" },
+  category: { chip: "bg-category/10 text-category", rule: "bg-category" },
+  neutral: { chip: "bg-muted text-muted-foreground", rule: "bg-border" },
+};
 
 interface StatCardProps {
   label: string;
   value: string | number;
   sublabel?: string;
   size?: "default" | "sm";
+  accent?: StatAccent;
+  icon?: LucideIcon;
   className?: string;
 }
 
@@ -13,28 +36,65 @@ export function StatCard({
   value,
   sublabel,
   size = "default",
+  accent,
+  icon: Icon,
   className,
 }: StatCardProps) {
+  const isNumeric = typeof value === "number";
+  const counted = useCountUp(isNumeric ? value : 0);
+  const display = isNumeric ? counted.toLocaleString() : value;
+
+  // An icon with no accent still renders, in neutral — dropping it silently
+  // because a sibling prop is missing is the more surprising behaviour.
+  const styles = accentStyles[accent ?? "neutral"];
+  const showRule = accent !== undefined;
+
   return (
     <div
-      className={cn("border-border rounded-lg border px-3 py-2.5", className)}
+      className={cn(
+        "border-border lift relative overflow-hidden rounded-lg border px-3 py-2.5",
+        className,
+      )}
     >
-      <div className="flex items-baseline gap-1.5">
+      {showRule && (
         <span
-          className={cn(
-            "font-semibold tabular-nums",
-            size === "sm" ? "text-xl" : "text-2xl",
-          )}
-        >
-          {value}
-        </span>
-        {sublabel && (
-          <span className="text-muted-foreground text-xs tabular-nums">
-            {sublabel}
+          aria-hidden
+          className={cn("absolute inset-x-0 top-0 h-0.5", styles.rule)}
+        />
+      )}
+
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-1.5">
+            <span
+              className={cn(
+                "font-semibold tabular-nums",
+                size === "sm" ? "text-xl" : "text-2xl",
+              )}
+            >
+              {display}
+            </span>
+            {sublabel && (
+              <span className="text-muted-foreground text-xs tabular-nums">
+                {sublabel}
+              </span>
+            )}
+          </div>
+          <span className="text-muted-foreground text-xs">{label}</span>
+        </div>
+
+        {Icon && (
+          <span
+            aria-hidden
+            className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-md",
+              styles.chip,
+            )}
+          >
+            <Icon className="size-3.5" />
           </span>
         )}
       </div>
-      <span className="text-muted-foreground text-xs">{label}</span>
     </div>
   );
 }

--- a/src/components/ui/status-pill.tsx
+++ b/src/components/ui/status-pill.tsx
@@ -7,9 +7,9 @@ import {
 
 const TONE_STYLES: Record<OutreachTone, string> = {
   primary: "bg-primary/10 text-primary",
-  warn: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  warn: "bg-warn/15 text-warn",
   muted: "bg-muted text-muted-foreground",
-  success: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  success: "bg-success/10 text-success",
   neutral: "bg-muted text-muted-foreground",
 };
 

--- a/src/hooks/use-count-up.ts
+++ b/src/hooks/use-count-up.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+
+const DURATION_MS = 650;
+
+// Ease-out cubic: fast off the mark, settles gently on the final value.
+const ease = (t: number) => 1 - Math.pow(1 - t, 3);
+
+const reducedMotionQuery = "(prefers-reduced-motion: reduce)";
+
+const subscribe = (onChange: () => void) => {
+  const query = window.matchMedia(reducedMotionQuery);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+};
+
+const getSnapshot = () => window.matchMedia(reducedMotionQuery).matches;
+
+// On the server, assume reduced motion so the markup ships the final value.
+const getServerSnapshot = () => true;
+
+/**
+ * Animates from 0 up to `target` on mount, and from the previous value on any
+ * subsequent change.
+ *
+ * Returns `target` unanimated when the user prefers reduced motion — the CSS
+ * `prefers-reduced-motion` guard in globals.css can't reach a JS-driven
+ * counter, so it's re-checked here.
+ */
+export function useCountUp(target: number): number {
+  const reduced = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+  // Seeded at 0, not `target`: seeding with the final value paints the finished
+  // number for one frame before the first rAF tick knocks it back to the start.
+  const [value, setValue] = useState(0);
+
+  // Where the next run counts from. Tracks the displayed value throughout the
+  // animation, so a target that changes mid-flight resumes from what's on
+  // screen rather than snapping back to the previous run's origin.
+  const fromRef = useRef(0);
+
+  // Counting up to zero has nothing to show, and a non-finite target can't be
+  // interpolated — both render as-is.
+  const animate = !reduced && Number.isFinite(target) && target !== 0;
+
+  useEffect(() => {
+    if (!animate) {
+      fromRef.current = Number.isFinite(target) ? target : 0;
+      return;
+    }
+
+    const from = fromRef.current;
+    const start = performance.now();
+    let frame = requestAnimationFrame(function tick(now) {
+      const t = Math.min((now - start) / DURATION_MS, 1);
+      const next = Math.round(from + (target - from) * ease(t));
+      fromRef.current = next;
+      setValue(next);
+
+      if (t < 1) {
+        frame = requestAnimationFrame(tick);
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [animate, target]);
+
+  return animate ? value : target;
+}

--- a/src/hooks/use-integrations-status.ts
+++ b/src/hooks/use-integrations-status.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 
 export interface IntegrationStatus {
   id: string;
@@ -29,7 +30,7 @@ export function useIntegrationsStatus(): State {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/api/integrations/status")
+    apiFetch("/api/integrations/status")
       .then((res) => {
         if (!res.ok) throw new Error(`status ${res.status}`);
         return res.json();

--- a/src/lib/api-fetch.ts
+++ b/src/lib/api-fetch.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { toast } from "sonner";
+
+interface ClerkWindow {
+  Clerk?: { session?: { getToken: () => Promise<string | null> } };
+}
+
+/**
+ * A freshly-minted Clerk session token, or null when signed out.
+ *
+ * `getToken()` returns the cached token and transparently refreshes it when it
+ * is close to expiring, so calling this per request is the point — not waste.
+ */
+export async function getSessionToken(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+
+  const token = await (
+    window as unknown as ClerkWindow
+  ).Clerk?.session?.getToken();
+
+  return token ?? null;
+}
+
+// Several calls can fail together (e.g. Send All fires one request per draft).
+// One toast for the burst, not one per request.
+const TOAST_COOLDOWN_MS = 10_000;
+let lastExpiryToast = 0;
+
+function reportExpiredSession() {
+  const now = Date.now();
+  if (now - lastExpiryToast < TOAST_COOLDOWN_MS) return;
+  lastExpiryToast = now;
+
+  toast.error("Your session expired", {
+    description: "Sign in again to continue — nothing was lost.",
+    action: {
+      label: "Sign in",
+      onClick: () => {
+        window.location.href = "/login";
+      },
+    },
+  });
+}
+
+/**
+ * Drop-in `fetch` for this app's own /api routes.
+ *
+ * Clerk's `__session` cookie is short-lived and stops refreshing while a tab is
+ * backgrounded, so a cookie-only request from a long-open tab gets rejected by
+ * `auth.protect()` before the route ever runs. Clerk accepts a Bearer token as
+ * readily as the cookie, so attaching a fresh one keeps a stale tab working.
+ *
+ * A 401 that survives that is a genuinely dead session: surface it once, rather
+ * than letting callers render it as "3 failed to send".
+ *
+ * Returns the `Response` unchanged, so `res.ok` / `res.json()` callers are
+ * unaffected.
+ */
+export async function apiFetch(
+  input: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const token = await getSessionToken();
+  const headers = new Headers(init.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  const res = await fetch(input, { ...init, headers });
+  if (res.status === 401) reportExpiredSession();
+
+  return res;
+}

--- a/src/lib/chat-transport.ts
+++ b/src/lib/chat-transport.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { DefaultChatTransport } from "ai";
+import type { UIMessage } from "ai";
+
+import { getSessionToken } from "@/lib/api-fetch";
+
+/**
+ * Chat transport that mints a fresh Clerk session token for every request, for
+ * the same reason `apiFetch` does — see the note there. The chat is the most
+ * visible victim of a stale tab because a dead POST kills the whole stream.
+ */
+export function createChatTransport() {
+  return new DefaultChatTransport<UIMessage>({
+    api: "/api/chat",
+    headers: async (): Promise<Record<string, string>> => {
+      const token = await getSessionToken();
+      return token ? { Authorization: `Bearer ${token}` } : {};
+    },
+  });
+}

--- a/src/lib/status-styles.ts
+++ b/src/lib/status-styles.ts
@@ -29,33 +29,33 @@ export type CampaignStatus =
 export const campaignStatusStyles: Record<CampaignStatus, StatusStyle> = {
   discovery: {
     label: "discovery",
-    className: "bg-blue-500/15 text-blue-700 dark:text-blue-400",
+    className: "bg-info/15 text-info",
   },
   researching: {
     label: "researching",
-    className: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-400",
+    className: "bg-warn/15 text-warn",
   },
   active: {
     label: "active",
-    className: "bg-green-500/15 text-green-700 dark:text-green-400",
+    className: "bg-success/15 text-success",
   },
   paused: {
     label: "paused",
-    className: "bg-gray-500/15 text-gray-600 dark:text-gray-400",
+    className: "bg-muted text-muted-foreground",
   },
   completed: {
     label: "completed",
-    className: "bg-gray-500/15 text-gray-600 dark:text-gray-400",
+    className: "bg-muted text-muted-foreground",
   },
 };
 
 // Solid bg color used for the small dot indicator in the sidebar nav (no text).
 export const campaignStatusDotStyles: Record<CampaignStatus, string> = {
-  discovery: "bg-blue-500",
-  researching: "bg-yellow-500",
-  active: "bg-green-500",
-  paused: "bg-gray-400",
-  completed: "bg-gray-300",
+  discovery: "bg-info",
+  researching: "bg-warn",
+  active: "bg-success",
+  paused: "bg-muted-foreground/60",
+  completed: "bg-muted-foreground/40",
 };
 
 /**
@@ -73,38 +73,41 @@ export type OutreachStatus =
   | "bounced"
   | "complained";
 
+// Colors track the funnel, not the individual state: pending (muted), in
+// flight (info), engaged (warn -> category), won (success), failed
+// (destructive). Adjacent states share a hue; the label disambiguates.
 export const outreachStatusStyles: Record<OutreachStatus, StatusStyle> = {
   queued: {
     label: "Queued",
-    className: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+    className: "bg-muted text-muted-foreground",
   },
   sent: {
     label: "Sent",
-    className: "bg-yellow-500/10 text-yellow-700 dark:text-yellow-400",
+    className: "bg-info/10 text-info",
   },
   opened: {
     label: "Opened",
-    className: "bg-orange-500/10 text-orange-700 dark:text-orange-400",
+    className: "bg-warn/10 text-warn",
   },
   replied: {
     label: "Replied",
-    className: "bg-green-500/10 text-green-700 dark:text-green-400",
+    className: "bg-success/10 text-success",
   },
   delivered: {
     label: "Delivered",
-    className: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+    className: "bg-info/20 text-info",
   },
   clicked: {
     label: "Clicked",
-    className: "bg-purple-500/10 text-purple-700 dark:text-purple-400",
+    className: "bg-category/10 text-category",
   },
   bounced: {
     label: "Bounced",
-    className: "bg-red-500/10 text-red-700 dark:text-red-400",
+    className: "bg-destructive/10 text-destructive",
   },
   complained: {
     label: "Spam",
-    className: "bg-red-500/10 text-red-700 dark:text-red-400",
+    className: "bg-destructive/10 text-destructive",
   },
 };
 
@@ -121,10 +124,10 @@ export type EnrichmentStatus =
   | "failed";
 
 export const enrichmentStatusStyles: Record<EnrichmentStatus, StatusStyle> = {
-  pending: { label: "Pending", className: "bg-gray-400" },
-  in_progress: { label: "In Progress", className: "bg-yellow-500" },
-  enriched: { label: "Enriched", className: "bg-green-500" },
-  failed: { label: "Failed", className: "bg-red-500" },
+  pending: { label: "Pending", className: "bg-muted-foreground/40" },
+  in_progress: { label: "In Progress", className: "bg-warn" },
+  enriched: { label: "Enriched", className: "bg-success" },
+  failed: { label: "Failed", className: "bg-destructive" },
 };
 
 /**
@@ -134,11 +137,11 @@ export const enrichmentStatusStyles: Record<EnrichmentStatus, StatusStyle> = {
 export const trackingReadinessStyles: Record<ReadinessTag, StatusStyle> = {
   ready_to_contact: {
     label: "Ready",
-    className: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    className: "bg-success/10 text-success",
   },
   monitoring: {
     label: "Monitoring",
-    className: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    className: "bg-warn/10 text-warn",
   },
   not_ready: {
     label: "Not Ready",


### PR DESCRIPTION
Three commits, readable in order. The first two are cosmetic; the third is a production bug fix and can be reviewed on its own.

## 1. `restyle:` PLG theme port

Geist + Geist Mono replace Inter/GeistMono (the original design used licensed Grilli Type faces, which are not in this repo). Warm neutral palette, violet primary, tighter radius, and the `type-*` scale applied to headings. Hardcoded Tailwind colors across the UI are replaced with semantic tokens (`success` / `info` / `warn` / `category`).

Two accessibility fixes came out of this, both measured:

- Light-mode status text was **3.2–3.7:1** on its own tinted pill — below the 4.5 WCAG AA floor at 12px. The tokens are now the AA-safe dark shades and measure **≥4.9:1**.
- Dark `--muted` was byte-identical to `--card`/`--popover` (`#161213`), so the highlighted Select option and every muted pill were invisible on a card. `--muted` is now lifted one step off the card surface.

## 2. `feat(dashboard):` accents, empty states, motion

Stat cards carry a semantic accent; the chart's three areas use the same tokens so a card and its series read as one thing. The chart previously hardcoded raw `oklch()` strokes that ignored the theme entirely and would not have tracked dark mode. Empty states get an icon and a real next step. Count-up on stat values, staggered entrance, hover lift — all behind `prefers-reduced-motion`, which the JS counter re-checks itself since the CSS guard can't reach a rAF loop.

## 3. `fix(auth):` keep long-lived tabs authenticated ⚠️ the one that matters

Clerk's `__session` cookie is short-lived and stops refreshing while a tab is backgrounded, so a request from a long-open tab was rejected by `auth.protect()` before the route ran. The chat was the visible victim — a dead POST kills the whole stream and the user has to reload and sign in — but **all 28 browser fetches to `/api` were exposed**, including `send-now`, `enrich`, and `import-csv`.

`apiFetch()` mints a fresh Clerk token per request and sends it as a Bearer header. It's a drop-in for `fetch` and returns the `Response` unchanged, so existing `res.ok` checks are untouched. The browser Supabase client already did exactly this inside its own fetch wrapper — this brings the API calls in line with it.

A 401 that still gets through now surfaces once as "Your session expired" instead of silently, or as **"3 failed to send"** — which is what the outreach UI reported when the real problem was auth, not mail delivery. `useChat` had no `onError` and nothing rendered its error status, so a failed chat just stopped; it now shows a banner with sign-in or retry.

## Verification

`tsc` clean · ESLint 0 errors · Prettier clean · 171 tests passing.

**Not verified end-to-end.** Local Supabase was down for this work (Docker not running), so I could not drive the real flows. The load-bearing assumption in commit 3 is that Clerk accepts a Bearer session token as readily as the cookie — if that's wrong, the header is ignored and we're no worse off than today, but the fix won't work either. Worth confirming against a real stale tab before merging.

**Known gap:** `summarizeChat` uses `navigator.sendBeacon`, which cannot carry headers, so it still fails silently in a stale tab. Cost is a chat keeping its raw first message as its title.

## Separately

While investigating, I found `/api/dashboard` never inspects `.error` on any of its eight queries — it coalesces straight to `?? 0` / `?? []`. An unreachable database returns **HTTP 200 with a plausible empty dashboard**. That's how the dead local Supabase stayed invisible, and it's the same shape as the auth problem: a failure that renders as "no data". Not fixed here — worth its own PR.
