### PR TITLE
feat(signals): v2 lane-specific signal catalogue

### DIFF
--- a/docs/plans/2026-07-20-signal-engine-v2.md
+++ b/docs/plans/2026-07-20-signal-engine-v2.md
@@ -1,0 +1,79 @@
+# Signal Engine v2 — 3-Lane Grounded Catalogue & Plan
+
+_Derived from ~35 sales/customer accounts mined from Granola (May 2025–Jul 2026) + the GTM playbook. Goal: highest-precision signals that find buyers about to move, grounded in real call evidence. Confirmed 2026-07-20._
+
+## The three lanes (product motions)
+
+| Lane                        | What it is                                                                                                                          | Pitch                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **1 — AI QA**               | QA over **AI bots + human agents**; cost-reduction of AI CX platforms (Sierra-class)                                                | "You run Sierra/Decagon/Fin + humans → we grade the AI _and_ the humans and cut the cost" |
+| **2 — Long-horizon tasks**  | Multi-step, time-spanning **customer + growth** ops (activation, reactivation, retention, onboarding-over-weeks, dispute lifecycle) | "Agents that pursue an outcome over days/weeks, not one ticket"                           |
+| **3 — AI for customer ops** | Front-line **ops agents that handle interactions end-to-end** (Gradient Labs approach)                                              | "Agents that run the ops, not just watch them"                                            |
+
+**Market cut (spans all three lanes):** SMBs across **regulated industries, FS-led.** FS is the beachhead (proof + reference base); expand to other regulated verticals where conversations carry compliance risk: health/telehealth, insurance/insurtech, legal, iGaming/betting, debt-collection/ARM, telecom/utilities, edtech, pharma/cannabis.
+
+## Data-source architecture
+
+Signal-engine recipes call only the in-process toolbox (`exa_search`, `stagehand`/`extractWebContent`, `scrapeJobListings`, `enrichCompany`, `getGoogleReviews`, GitHub, `getSignalResults`). **Crustdata and Apollo are new primitive tools** (registry addition + PR).
+
+- **Exa** (have it) → narrative/event signals: AI-platform deployments, funding, launches, exec moves, consent orders, "migrating off X".
+- **`scrapeJobListings`** (have it) → all hiring signals.
+- **`getGoogleReviews`** / stagehand (have it) → review/complaint-surge + on-site Zendesk/Intercom widget detection (per-account verification).
+- **Crustdata** (new tool; auth pending via `/mcp`) → technographics (CX platform, AI-CX platform, QA tool), department headcount trends, exec/decision-maker changes.
+- **Apollo** (new tool; already paid) → firmographic + industry filtering (SMB + regulated), verified contacts, technographics fallback.
+- BuiltWith considered and **dropped** for now.
+
+## What the calls showed (empirical basis, ~35 accounts)
+
+- **"Manual QA at scale" is the market, not a signal** — pair it with a forcing function.
+- 🥇 **Incumbent QA-tool displacement converts best** (Kuda, Rho, Qonto, Nala, Spendesk all displaced PlayVox/EvaluAgent/MaestroQA/Ripit/Level AI/PerformLine/Klaus). Fastest near renewal → **Lane 1**.
+- **Onboarding/activation revenue leak after growth** = strongest recent win cluster (Wayflyer, Coast, RWA, Paystack, Vestwell) → **Lanes 2/3**.
+- **New CX/Quality/Risk leader <90d** = urgency (FairMoney, Relay, Emburse, Novo, Pleo), medium conversion.
+- 🚫 **Negative signal** (biggest losses — Relay, Ramp, Stash, Zolve, Capital One, Bill.com): engineering-first / Claude-LLM-native "build it ourselves" cultures. Encode as a suppressor. Also: single-champion/no-budget; <5k tickets/mo; enterprise bank in procurement; needs deep back-office integration to start.
+
+## Golden profile (FS beachhead → lookalikes)
+
+Regulated, revenue-generating company; SMB up through scale-up; real compliance obligation. **Zendesk/Intercom/Freshdesk** + **no or legacy QA tool**; SOPs in Notion/Drive/Confluence. Support org of 10–600+ agents, heavy BPO/multi-region; small QA function (3–35% manual coverage) + adjacent compliance team. Named **Head of CX / Head of Quality** champion (ideally recently hired). Strongest in Africa & Europe; US skews to onboarding/business-banking.
+
+## Signal catalogue by lane
+
+### Lane 1 — AI QA
+
+| Signal                        | Detects                                                                                            | Source                                   | Now?                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------- | ----------------------------- |
+| AI-CX platform deployed       | Running Sierra/Decagon/Ada/Intercom Fin/Zendesk AI (AI to grade)                                   | Exa + Crustdata technographics           | Exa now; tech needs Crustdata |
+| Zendesk/Intercom + human org  | Real contact center to QA                                                                          | Crustdata/Apollo technographics          | needs tool                    |
+| QA-tool displacement          | MaestroQA/EvaluAgent/PlayVox/Klaus/Level AI/PerformLine/Ripit in stack, or "migrating off X" posts | technographics + `scrapeJobListings`/Exa | partly now                    |
+| Support headcount (cost base) | Large/growing human support = cost to cut                                                          | Crustdata headcount                      | needs Crustdata               |
+| QA/Quality hiring             | Building QA manually                                                                               | `scrapeJobListings`                      | ✅ now                        |
+
+### Lane 2 — Long-horizon tasks
+
+| Signal                                          | Detects                              | Source                    | Now?    |
+| ----------------------------------------------- | ------------------------------------ | ------------------------- | ------- |
+| Onboarding/activation/underwriting hiring       | Manual multi-step onboarding scaling | `scrapeJobListings`       | ✅ now  |
+| Funding / growth event                          | Volume/backlog about to spike        | Exa + Crustdata headcount | Exa now |
+| Reactivation / churn / dormant-account language | Revenue leak over time               | Exa + `scrapeJobListings` | ✅ now  |
+| New market / license launch                     | New onboarding flow per market       | Exa + `scrapeJobListings` | ✅ now  |
+
+### Lane 3 — AI for customer ops
+
+| Signal                               | Detects                                                 | Source                                   | Now?       |
+| ------------------------------------ | ------------------------------------------------------- | ---------------------------------------- | ---------- |
+| High front-line volume + manual ops  | Ops ripe for autonomous agents                          | Crustdata headcount + `getGoogleReviews` | partly now |
+| Evaluating autonomous support agents | In-market for ops agents (Gradient Labs/Sierra/Decagon) | Exa                                      | ✅ now     |
+| Support/BPO hiring at scale          | Linear-scaling ops cost                                 | `scrapeJobListings` + Crustdata          | ✅ now     |
+| Regulated front-line workflows       | Compliance-sensitive interactions                       | industry classifier (Apollo) + Exa       | partly     |
+
+### Cross-lane
+
+- **Runs Zendesk/Intercom/Freshdesk** (installed-base screen) — technographics.
+- **SMB + regulated-industry firmographics** (FS-led) — Apollo.
+- 🚫 **Internal-build / Claude-native suppressor** — Exa + `scrapeJobListings` (AI/ML eng for internal QA; "built our own"). ✅ now.
+
+## Phasing
+
+- **Phase 1 (now, no new deps):** author `SignalRecipe`s for the ✅-now signals — Lane 2 (onboarding hiring, funding, reactivation, new-market), Lane 3 (evaluating-agents, support hiring), Lane 1 (QA hiring), + review-surge + internal-build suppressor. PR into `signal-engine`.
+- **Phase 2 (after Crustdata auth):** add Crustdata primitive tool → technographics (CX/AI-CX platform, QA tool), headcount trends, exec-change. Unlocks the Lane-1 flagship + the installed-base screen.
+- **Phase 3:** add Apollo primitive tool for SMB + regulated-industry firmographic filtering + contacts; lookalike TAM from the golden profile.
+- **Phase 4:** per-lane scoring/tiering + routing; enriched Smartlead CSV output (no Slack). Call-mining refresh loop.

--- a/supabase/migrations/20260720000000_lane_signals_v2.sql
+++ b/supabase/migrations/20260720000000_lane_signals_v2.sql
@@ -1,0 +1,107 @@
+-- Signal Engine v2 — lane-specific signals
+-- See docs/plans/2026-07-20-signal-engine-v2.md. Three lanes:
+--   Lane 1 AI QA · Lane 2 Long-horizon tasks · Lane 3 AI for customer ops
+-- Market cut (all lanes): SMBs across regulated industries, FS-led.
+--
+-- All are exa_search recipes (news/web queries, {company} templated), grounded
+-- in ~35 mined sales/customer calls. Existing signals already cover the generic
+-- triggers (executive-changes = new leader, funding-news, product-launches,
+-- hiring-activity, website-tech-stack, google-reviews) so this adds only the
+-- lane-specific ones. config carries tier/scoreBoost/lane for downstream scoring.
+-- scoreBoost is negative for the suppressor. Idempotent.
+
+INSERT INTO signals (name, slug, description, long_description, category, icon, execution_type, tool_key, config, is_builtin)
+VALUES
+-- ── Lane 1: AI QA (QA the AI + humans; cost-reduce AI CX platforms) ──────────
+(
+  'AI CX Platform Deployed',
+  'ai-cx-platform-deployed',
+  'Company has deployed an AI customer-service agent platform (Sierra, Decagon, Ada, Intercom Fin, Zendesk AI) — the AI now needs QA.',
+  'When a company rolls out an AI CX agent, nobody is grading what the AI says. Rulebase QAs the AI and the humans together and cuts the cost of running the platform. Strongest Lane 1 entry point.',
+  'product', 'Bot', 'exa_search', NULL,
+  '{"query": "\"{company}\" (Sierra OR Decagon OR Ada OR \"Intercom Fin\" OR \"Fin AI\" OR \"Zendesk AI\" OR \"AI agent\" OR \"AI customer service\" OR \"resolution bot\") (launched OR deployed OR \"rolled out\" OR \"goes live\" OR partners) 2025 OR 2026", "category": "news", "tier": 2, "scoreBoost": 4, "lane": 1}'::jsonb,
+  true
+),
+(
+  'QA Tool In Use (Displacement)',
+  'qa-tool-in-use',
+  'Company runs a legacy/point QA tool (MaestroQA, EvaluAgent, Klaus, PlayVox, Level AI, PerformLine, Ripit) — displacement target, converts fastest near renewal.',
+  'Every core won logo displaced a manual or legacy QA tool. Public mention of an incumbent QA tool marks a displacement opportunity; a clean technographic version arrives with the Crustdata tool.',
+  'custom', 'ArrowRightLeft', 'exa_search', NULL,
+  '{"query": "\"{company}\" (MaestroQA OR EvaluAgent OR Klaus OR PlayVox OR \"Level AI\" OR PerformLine OR Ripit OR Loris OR \"quality assurance platform\") (support OR CX OR \"customer service\" OR \"contact center\") 2025 OR 2026", "category": "news", "tier": 2, "scoreBoost": 4, "lane": 1}'::jsonb,
+  true
+),
+(
+  'CX QA / Quality Hiring',
+  'qa-quality-hiring',
+  'Open reqs for CX Quality / QA roles — building a QA function manually, ready for automation.',
+  'Hiring humans to grade tickets means QA is manual and scaling linearly. Route to Lane 1.',
+  'hiring', 'Briefcase', 'exa_search', NULL,
+  '{"query": "\"{company}\" (hiring OR careers OR \"job posting\") (\"Quality Analyst\" OR \"QA Analyst\" OR \"Quality Assurance\" OR \"CX Quality\" OR \"Head of Quality\" OR \"QA Manager\") (support OR customer OR CX) 2025 OR 2026", "category": "news", "tier": 3, "scoreBoost": 2, "lane": 1}'::jsonb,
+  true
+),
+-- ── Lane 2: Long-horizon tasks (customer + growth ops over time) ─────────────
+(
+  'Onboarding / Activation Hiring',
+  'onboarding-activation-hiring',
+  'Open reqs for onboarding / implementation / activation / underwriting roles — manual multi-step onboarding scaling with headcount.',
+  'A burst of onboarding/activation hiring (especially after funding) is the strongest Lane 2 trigger — the multi-step task is manual and revenue is gated behind it.',
+  'hiring', 'Briefcase', 'exa_search', NULL,
+  '{"query": "\"{company}\" (hiring OR careers) (\"Onboarding Specialist\" OR \"Implementation Manager\" OR \"Activation\" OR \"Merchant Onboarding\" OR \"Customer Onboarding\" OR \"Underwriting\" OR \"KYB Analyst\") 2025 OR 2026", "category": "news", "tier": 3, "scoreBoost": 2, "lane": 2}'::jsonb,
+  true
+),
+(
+  'Reactivation / Churn Motion',
+  'reactivation-churn-language',
+  'Company is running (or hiring for) reactivation, win-back, retention, or dormant-account recovery — a long-horizon revenue task.',
+  'Evidence the money exists and nobody owns collecting it over time. Anchor Lane 2 value against the recovered revenue.',
+  'custom', 'TrendingUp', 'exa_search', NULL,
+  '{"query": "\"{company}\" (reactivation OR \"dormant accounts\" OR \"win-back\" OR churn OR retention OR \"re-engagement\" OR \"stalled onboarding\" OR \"recovered revenue\") 2025 OR 2026", "category": "news", "tier": 2, "scoreBoost": 3, "lane": 2}'::jsonb,
+  true
+),
+(
+  'New Market / License Launch',
+  'new-market-license-launch',
+  'Payments/banking/lending/insurance license approval or new-market entry — a new onboarding flow and compliance regime built from scratch.',
+  'A new licence or market means onboarding logic forks and stalls multiply over time. Lane 2 / Lane 3 depending on the workflow.',
+  'product', 'Globe', 'exa_search', NULL,
+  '{"query": "\"{company}\" (license OR licence OR \"new market\" OR \"expands to\" OR \"goes live in\" OR \"launches in\" OR \"granted approval\") (payments OR banking OR lending OR insurance OR remittance OR EMI) 2025 OR 2026", "category": "news", "tier": 2, "scoreBoost": 3, "lane": 2}'::jsonb,
+  true
+),
+-- ── Lane 3: AI for customer ops (front-line ops agents, Gradient Labs style) ─
+(
+  'Evaluating Autonomous Support Agents',
+  'evaluating-ai-support-agents',
+  'Company is in-market for autonomous customer-ops agents (Gradient Labs, Sierra, Decagon) — direct Lane 3 intent.',
+  'A company evaluating agentic support is deciding whether agents run the ops. Reach them during the evaluation.',
+  'custom', 'Bot', 'exa_search', NULL,
+  '{"query": "\"{company}\" (\"Gradient Labs\" OR Sierra OR Decagon OR Ada OR \"AI agent\" OR \"autonomous agent\" OR \"AI resolution\" OR agentic) (evaluating OR piloting OR \"in talks\" OR RFP OR selecting OR trialing) (\"customer support\" OR \"customer service\" OR operations) 2025 OR 2026", "category": "news", "tier": 2, "scoreBoost": 3, "lane": 3}'::jsonb,
+  true
+),
+(
+  'Support / Ops Scale Hiring',
+  'support-scale-hiring',
+  'Company scaling front-line support/ops headcount (incl. BPO) — linear-scaling ops cost ripe for agents.',
+  'Heavy front-line hiring signals ops volume growing faster than tooling — the Lane 3 automation opening.',
+  'hiring', 'Briefcase', 'exa_search', NULL,
+  '{"query": "\"{company}\" (hiring OR careers) (\"Customer Support\" OR \"Support Specialist\" OR \"Contact Center\" OR \"Customer Service\" OR \"Operations Associate\" OR BPO) (team OR \"multiple roles\" OR scaling OR expanding) 2025 OR 2026", "category": "news", "tier": 3, "scoreBoost": 1, "lane": 3}'::jsonb,
+  true
+),
+-- ── Cross-lane: negative suppressor ─────────────────────────────────────────
+(
+  'Internal-Build / LLM-Native (Suppressor)',
+  'internal-build-suppressor',
+  'Company is building its own QA/CX/compliance tooling on Claude/LLMs in-house — the biggest historical loss pattern. Negative signal.',
+  'Relay, Ramp, Stash, Zolve, Capital One and Bill.com all built their own. Hiring AI/ML engineers for internal compliance/QA tooling, or public "we built our own" content, predicts a loss. scoreBoost is negative to suppress these.',
+  'custom', 'Ban', 'exa_search', NULL,
+  '{"query": "\"{company}\" (\"built our own\" OR \"in-house\" OR \"internal tool\" OR \"AI engineer\" OR \"ML engineer\" OR \"applied AI\") (QA OR quality OR compliance OR \"customer support\" OR agents) 2025 OR 2026", "category": "news", "tier": 0, "scoreBoost": -4, "lane": 0}'::jsonb,
+  true
+)
+ON CONFLICT (slug) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  long_description = EXCLUDED.long_description,
+  category = EXCLUDED.category,
+  icon = EXCLUDED.icon,
+  execution_type = EXCLUDED.execution_type,
+  config = EXCLUDED.config;


### PR DESCRIPTION
## What
Adds the **v2 signal catalogue** — 9 grounded, lane-specific signals + the plan doc (`docs/plans/2026-07-20-signal-engine-v2.md`). Derived from ~35 mined sales/customer calls.

Three confirmed lanes (market cut = SMBs across regulated industries, FS-led):
- **Lane 1 — AI QA:** `ai-cx-platform-deployed`, `qa-tool-in-use` (displacement), `qa-quality-hiring`
- **Lane 2 — Long-horizon tasks:** `onboarding-activation-hiring`, `reactivation-churn-language`, `new-market-license-launch`
- **Lane 3 — AI for customer ops:** `evaluating-ai-support-agents`, `support-scale-hiring`
- **Cross-lane:** `internal-build-suppressor` (negative scoreBoost — the biggest historical loss pattern)

## How
All `exa_search` recipes with `{company}`-templated queries + `{tier, scoreBoost, lane}` config (the proven RA-migration pattern). Existing signals already cover the generic triggers (`executive-changes`, `funding-news`, `product-launches`, `hiring-activity`), so this adds only the lane-specific ones. Idempotent (`ON CONFLICT (slug)`).

## Verification
Applied to the local dev DB — `INSERT 0 9`, all rows land with correct lane + scoreBoost. Pre-commit lint clean (0 errors).

## Not included (next phases)
- Crustdata primitive tool → technographics (Zendesk/Intercom, AI-CX platform, QA tool), headcount trends, exec-change — unlocks the Lane-1 flagship + installed-base screen. (pending `/mcp` auth)
- Apollo primitive tool → SMB + regulated-industry firmographic filtering + contacts.
- Per-lane scoring/tiering + routing; lookalike TAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)