### PR TITLE
fix(auth): refresh Clerk token for Supabase calls in long-running req…

### DIFF
--- a/src/__tests__/outreach-sender.test.ts
+++ b/src/__tests__/outreach-sender.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sendApprovedDraft } from "@/lib/services/outreach-sender";
+import { sendMessage } from "@/lib/services/agentmail-service";
+
+vi.mock("@/lib/services/agentmail-service", () => ({
+  sendMessage: vi.fn(),
+}));
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: vi.fn(),
+}));
+
+const sendMessageMock = vi.mocked(sendMessage);
+
+interface RecordedCall {
+  table: string;
+  ops: Array<{ name: string; args: unknown[] }>;
+}
+
+/**
+ * Minimal thenable query-builder fake: every chained method records itself
+ * and awaiting the chain pops the next queued response. Lets us assert the
+ * exact sequence of reads/claims/updates the sender performs.
+ */
+function fakeSupabase(responses: Array<{ data?: unknown; error?: unknown }>) {
+  let i = 0;
+  const calls: RecordedCall[] = [];
+
+  const from = (table: string) => {
+    const call: RecordedCall = { table, ops: [] };
+    calls.push(call);
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "in",
+      "update",
+      "insert",
+      "single",
+      "maybeSingle",
+    ]) {
+      builder[name] = (...args: unknown[]) => {
+        call.ops.push({ name, args });
+        return builder;
+      };
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+        resolve,
+        reject,
+      );
+    return builder;
+  };
+
+  return { client: { from } as never, calls };
+}
+
+const enrollment = {
+  id: "enr_1",
+  sequence_id: "seq_1",
+  person_id: "per_1",
+  campaign_people_id: "cp_1",
+  current_step: 1,
+};
+
+const draft = {
+  id: "draft_1",
+  user_id: "user_1",
+  campaign_id: "camp_1",
+  to_email: "prospect@example.com",
+  subject: "Hi",
+  body_html: "<p>Hi</p>",
+  body_text: "Hi",
+};
+
+// Await order inside sendApprovedDraft:
+// 0 step select · 1 draft select · 2 settings select · 3 claim update
+// then send, then bookkeeping (insert, updates, next-step select, enrollment)
+const preSendResponses = [
+  { data: { id: "step_1" } },
+  { data: draft },
+  { data: { agentmail_inbox_id: "inbox_1" } },
+];
+
+describe("sendApprovedDraft claim semantics", () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+  });
+
+  it("sends after winning the claim", async () => {
+    const { client, calls } = fakeSupabase([
+      ...preSendResponses,
+      { data: { id: draft.id } }, // claim won
+      {}, // sent_emails insert
+      {}, // draft → sent
+      {}, // campaign_people → sent
+      { data: null }, // no next step
+      {}, // enrollment → completed
+    ]);
+    sendMessageMock.mockResolvedValue({ messageId: "m1", threadId: "t1" });
+
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result).toMatchObject({ ok: true, messageId: "m1" });
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    const claim = calls[3];
+    expect(claim.table).toBe("email_drafts");
+    expect(claim.ops).toContainEqual({
+      name: "update",
+      args: [expect.objectContaining({ status: "queued" })],
+    });
+    // The claim must be conditional on the current status, not just the id.
+    expect(claim.ops).toContainEqual({
+      name: "eq",
+      args: ["status", "draft"],
+    });
+  });
+
+  it("does not send when another caller already claimed the draft", async () => {
+    const { client } = fakeSupabase([
+      ...preSendResponses,
+      { data: null }, // claim lost — someone else got there first
+    ]);
+
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result).toMatchObject({ ok: false });
+    expect((result as { reason: string }).reason).toMatch(/already claimed/i);
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("releases the claim when the send itself fails", async () => {
+    const { client, calls } = fakeSupabase([
+      ...preSendResponses,
+      { data: { id: draft.id } }, // claim won
+      {}, // release update
+    ]);
+    sendMessageMock.mockRejectedValue(new Error("AgentMail 503"));
+
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result).toMatchObject({ ok: false, reason: "AgentMail 503" });
+    const release = calls[4];
+    expect(release.table).toBe("email_drafts");
+    expect(release.ops).toContainEqual({
+      name: "update",
+      args: [expect.objectContaining({ status: "draft" })],
+    });
+    // Release is also conditional, so it can't clobber a concurrent "sent".
+    expect(release.ops).toContainEqual({
+      name: "eq",
+      args: ["status", "queued"],
+    });
+  });
+
+  it("keeps the claim when bookkeeping fails after the email left", async () => {
+    sendMessageMock.mockResolvedValue({ messageId: "m1", threadId: null });
+
+    const base = fakeSupabase([
+      ...preSendResponses,
+      { data: { id: draft.id } },
+    ]);
+    const origFrom = (base.client as { from: (t: string) => unknown }).from;
+    // The sent_emails insert (first call after the send) blows up.
+    const client = {
+      from: (table: string) =>
+        table === "sent_emails"
+          ? { insert: () => Promise.reject(new Error("insert failed")) }
+          : origFrom(table),
+    } as never;
+
+    await expect(sendApprovedDraft(client, enrollment)).rejects.toThrow(
+      "insert failed",
+    );
+    // No release back to "draft" — the email already went out, and a retry
+    // would send it twice.
+    const draftReleases = base.calls
+      .filter((c) => c.table === "email_drafts")
+      .flatMap((c) => c.ops)
+      .filter(
+        (op) =>
+          op.name === "update" &&
+          (op.args[0] as { status?: string })?.status === "draft",
+      );
+    expect(draftReleases).toHaveLength(0);
+  });
+});

--- a/src/__tests__/outreach-sender.test.ts
+++ b/src/__tests__/outreach-sender.test.ts
@@ -158,7 +158,7 @@ describe("sendApprovedDraft claim semantics", () => {
   });
 
   it("keeps the claim when bookkeeping fails after the email left", async () => {
-    sendMessageMock.mockResolvedValue({ messageId: "m1", threadId: null });
+    sendMessageMock.mockResolvedValue({ messageId: "m1", threadId: "t1" });
 
     const base = fakeSupabase([
       ...preSendResponses,

--- a/src/__tests__/supabase-server-token.test.ts
+++ b/src/__tests__/supabase-server-token.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type FetchImpl = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const h = vi.hoisted(() => ({
+  auth: vi.fn(),
+  // One entry per createServerClient call, in order.
+  fetches: [] as FetchImpl[],
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: h.auth }));
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: (
+    _url: string,
+    _key: string,
+    options: { global: { fetch: FetchImpl } },
+  ) => {
+    h.fetches.push(options.global.fetch);
+    return {};
+  },
+}));
+
+/** A JWT whose payload carries a readable `exp` and an identifying marker. */
+function jwt(marker: string, expiresInMs: number) {
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: "user_1",
+      role: "authenticated",
+      marker,
+      exp: Math.floor((Date.now() + expiresInMs) / 1000),
+    }),
+  ).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+/**
+ * Stands in for Clerk's server-side getToken: bare calls return the token that
+ * arrived with the request, calls passing expiresInSeconds mint a new one.
+ */
+function stubGetToken(
+  incoming: string | null,
+  minted = jwt("minted", 600_000),
+) {
+  return vi.fn(async (options?: { expiresInSeconds?: number }) =>
+    options?.expiresInSeconds === undefined ? incoming : minted,
+  );
+}
+
+function mintCalls(getToken: ReturnType<typeof stubGetToken>) {
+  return getToken.mock.calls.filter(
+    ([options]) => options?.expiresInSeconds !== undefined,
+  );
+}
+
+function sentToken(call: readonly unknown[]) {
+  const init = call[1] as RequestInit | undefined;
+  const auth = new Headers(init?.headers).get("authorization") ?? "";
+  const payload = auth.replace("Bearer ", "").split(".")[1] ?? "";
+  return (
+    JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      marker: string;
+    }
+  ).marker;
+}
+
+describe("createClient token freshness", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Fresh module = fresh token cache.
+    vi.resetModules();
+    h.auth.mockReset();
+    h.fetches.length = 0;
+    process.env.CLERK_FRONTEND_API_DOMAIN = "test.clerk.accounts.dev";
+    fetchSpy = vi.fn(async () => new Response("[]", { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  // Exact body observed from PostgREST (supabase local) for an expired token.
+  const expiredJwtResponse = () =>
+    new Response(
+      JSON.stringify({
+        code: "PGRST303",
+        details: null,
+        hint: null,
+        message: "JWT expired",
+      }),
+      { status: 401 },
+    );
+
+  it("reuses the request's own token while it still has life left", async () => {
+    const getToken = stubGetToken(jwt("incoming", 55_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    await h.fetches[0]("http://db/rest/v1/companies", {});
+
+    expect(sentToken(fetchSpy.mock.calls[0])).toBe("incoming");
+    expect(mintCalls(getToken)).toHaveLength(0);
+  });
+
+  it("mints a longer-lived token once the request's token is spent", async () => {
+    const getToken = stubGetToken(jwt("incoming", -1_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    await h.fetches[0]("http://db/rest/v1/companies", {});
+
+    expect(mintCalls(getToken)).toEqual([[{ expiresInSeconds: 600 }]]);
+    expect(sentToken(fetchSpy.mock.calls[0])).toBe("minted");
+  });
+
+  it("shares one mint across every client in the same session", async () => {
+    const getToken = stubGetToken(jwt("incoming", -1_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await Promise.all([createClient(), createClient()]);
+    await Promise.all([
+      h.fetches[0]("http://db/rest/v1/companies", {}),
+      h.fetches[1]("http://db/rest/v1/people", {}),
+    ]);
+
+    expect(mintCalls(getToken)).toHaveLength(1);
+    expect(sentToken(fetchSpy.mock.calls[0])).toBe("minted");
+    expect(sentToken(fetchSpy.mock.calls[1])).toBe("minted");
+  });
+
+  it("re-mints and replays once when the token is rejected anyway", async () => {
+    const getToken = stubGetToken(jwt("incoming", 55_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+    fetchSpy
+      .mockImplementationOnce(async () => expiredJwtResponse())
+      .mockImplementationOnce(async () => new Response("[]", { status: 200 }));
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    const res = await h.fetches[0]("http://db/rest/v1/companies", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Acme" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(sentToken(fetchSpy.mock.calls[0])).toBe("incoming");
+    expect(sentToken(fetchSpy.mock.calls[1])).toBe("minted");
+    expect(mintCalls(getToken)).toHaveLength(1);
+  });
+
+  it("does not replay a 401 that is not about an expired token", async () => {
+    const getToken = stubGetToken(jwt("incoming", 55_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ message: "permission denied" }), {
+          status: 401,
+        }),
+    );
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    const res = await h.fetches[0]("http://db/rest/v1/companies", {});
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the caller's response body readable after inspecting a 401", async () => {
+    const getToken = stubGetToken(jwt("incoming", 55_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+    fetchSpy.mockImplementation(async () => expiredJwtResponse());
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    const res = await h.fetches[0]("http://db/rest/v1/companies", {});
+
+    // Both attempts failed, so the caller gets the 401 — and must still be
+    // able to read it, since supabase-js parses the error body.
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({ code: "PGRST303" });
+  });
+
+  it("skips the replay when the body cannot be sent twice", async () => {
+    const getToken = stubGetToken(jwt("incoming", 55_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+    fetchSpy.mockImplementation(async () => expiredJwtResponse());
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    const res = await h.fetches[0]("http://db/rest/v1/companies", {
+      method: "POST",
+      body: new ReadableStream(),
+      // @ts-expect-error duplex is required for stream bodies at runtime
+      duplex: "half",
+    });
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the plain token when there is no session to mint against", async () => {
+    const getToken = stubGetToken(jwt("incoming", -1_000));
+    h.auth.mockResolvedValue({ getToken, sessionId: null });
+
+    const { createClient } = await import("@/lib/supabase/server");
+    await createClient();
+    await h.fetches[0]("http://db/rest/v1/companies", {});
+
+    expect(mintCalls(getToken)).toHaveLength(0);
+    expect(sentToken(fetchSpy.mock.calls[0])).toBe("incoming");
+  });
+});

--- a/src/__tests__/supabase-server-token.test.ts
+++ b/src/__tests__/supabase-server-token.test.ts
@@ -203,6 +203,32 @@ describe("createClient token freshness", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("fails fast instead of hanging when the mint call stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const incoming = jwt("incoming", -1_000);
+      // Mint never settles — simulates a stalled connection to api.clerk.com.
+      const getToken = vi.fn((options?: { expiresInSeconds?: number }) =>
+        options?.expiresInSeconds === undefined
+          ? Promise.resolve(incoming)
+          : new Promise<string>(() => {}),
+      );
+      h.auth.mockResolvedValue({ getToken, sessionId: "sess_1" });
+
+      const { createClient } = await import("@/lib/supabase/server");
+      await createClient();
+      const pending = h.fetches[0]("http://db/rest/v1/companies", {});
+      pending.catch(() => {}); // avoid unhandled rejection between timers
+      await vi.advanceTimersByTimeAsync(16_000);
+
+      await expect(pending).rejects.toThrow(/timed out/);
+      // The wrapper never reached the network — it failed on the mint.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to the plain token when there is no session to mint against", async () => {
     const getToken = stubGetToken(jwt("incoming", -1_000));
     h.auth.mockResolvedValue({ getToken, sessionId: null });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -19,9 +19,16 @@ import {
 import { getPostHogClient } from "@/lib/posthog-server";
 import { buildSystemPrompt } from "@/lib/system-prompt";
 import { allTools } from "@/lib/tools";
+import { saveChat } from "@/lib/services/chat-history";
 import { getSupabaseAndUser } from "@/lib/supabase/server";
 
-export const maxDuration = 120;
+// Full-pipeline agent runs (enrich → score → find contacts) regularly exceed
+// two minutes; at 120 the platform killed the function mid-stream and the UI
+// looked stuck. Vercel fluid compute allows up to 300s on all current plans.
+export const maxDuration = 300;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // ── Token budget ───────────────────────────────────────────────────────────
 // Chat context is capped aggressively: once cache_control is applied to the
@@ -81,11 +88,15 @@ export async function POST(request: Request) {
     messages: uiMessages,
     campaignId,
     pageContext,
+    chatId,
   } = body as {
     messages: UIMessage[];
     campaignId?: string;
     pageContext?: string;
+    chatId?: string;
   };
+  const persistChatId =
+    typeof chatId === "string" && UUID_RE.test(chatId) ? chatId : null;
   const modelMessages = trimMessages(await convertToModelMessages(uiMessages));
 
   // Mark the last message with ephemeral cache_control so everything before
@@ -117,6 +128,21 @@ export async function POST(request: Request) {
   });
 
   const stream = createUIMessageStream({
+    // originalMessages + onFinish give us the full final message list so the
+    // conversation is persisted server-side — the client-side save in
+    // agent-panel never runs when the tab dies or navigates mid-stream.
+    originalMessages: uiMessages,
+    onFinish: persistChatId
+      ? async ({ messages }) => {
+          await saveChat(
+            ctx.supabase,
+            user.id,
+            persistChatId,
+            messages,
+            campaignId,
+          );
+        }
+      : undefined,
     execute: ({ writer }) => {
       const result = streamText({
         model: anthropic(MODELS.CHAT),

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -124,7 +124,13 @@ export async function POST(request: Request) {
         messages: modelMessages,
         tools: allTools,
         maxOutputTokens: 8192,
-        stopWhen: stepCountIs(15),
+        // Full-pipeline agent runs (enrich → score → find contacts → draft)
+        // routinely take 20+ steps; at 15 the loop halted silently mid-batch
+        // and the UI just looked stuck. 40 covers the longest observed runs.
+        stopWhen: stepCountIs(40),
+        // Without this, Stop / closing the tab leaves the server running the
+        // whole remaining pipeline (and paying for it) invisibly.
+        abortSignal: request.signal,
         // Cache the system prompt + tool definitions (~30k stable tokens) across
         // turns in a conversation. Follow-up turns read them at ~10% of input cost.
         providerOptions: {
@@ -167,6 +173,10 @@ export async function POST(request: Request) {
       });
       writer.merge(result.toUIMessageStream());
     },
+    // Default masks every failure as "An error occurred" — surface the real
+    // message (rate limit, overloaded, tool crash) so the banner is actionable.
+    onError: (error) =>
+      error instanceof Error ? error.message : "Stream failed",
   });
 
   return createUIMessageStreamResponse({ stream });

--- a/src/app/api/email/cleanup/route.ts
+++ b/src/app/api/email/cleanup/route.ts
@@ -1,12 +1,21 @@
 import { NextResponse } from "next/server";
 import { getAdminClient } from "@/lib/supabase/admin";
+import { verifyQStashSignature } from "@/lib/services/qstash";
 
 /**
- * Draft cleanup endpoint. Call via cron or QStash schedule.
+ * Draft cleanup endpoint. Call via a QStash schedule (the route is public,
+ * so the signature check is the only auth).
  * - Deletes discarded drafts older than 7 days
  * - Deletes stale drafts (never sent) older than 30 days
  */
-export async function POST() {
+export async function POST(request: Request) {
+  try {
+    await verifyQStashSignature(request);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Invalid signature";
+    return NextResponse.json({ error: msg }, { status: 401 });
+  }
+
   const supabase = getAdminClient();
 
   const sevenDaysAgo = new Date(

--- a/src/app/api/email/cleanup/route.ts
+++ b/src/app/api/email/cleanup/route.ts
@@ -5,6 +5,7 @@ import { verifyQStashSignature } from "@/lib/services/qstash";
 /**
  * Draft cleanup endpoint. Call via a QStash schedule (the route is public,
  * so the signature check is the only auth).
+ * - Recovers drafts stranded in "queued" by a send process that died
  * - Deletes discarded drafts older than 7 days
  * - Deletes stale drafts (never sent) older than 30 days
  */
@@ -25,6 +26,54 @@ export async function POST(request: Request) {
     Date.now() - 30 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
+  // Recover drafts stranded in "queued": the send claim was taken but the
+  // process died before finishing. If a sent_emails row exists the message
+  // left the building — finish the bookkeeping as "sent". If none exists the
+  // send (almost certainly) never happened — release back to "draft" so it's
+  // retryable. The residual risk (crash in the instant between AgentMail
+  // accepting the send and the sent_emails insert) is taken deliberately:
+  // after 24h, a stuck invisible draft is worse than the sliver of a chance
+  // of a duplicate.
+  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  let recoveredSent = 0;
+  let recoveredDraft = 0;
+
+  const { data: stuck } = await supabase
+    .from("email_drafts")
+    .select("id")
+    .eq("status", "queued")
+    .lt("updated_at", dayAgo);
+
+  if (stuck && stuck.length > 0) {
+    const ids = stuck.map((d) => d.id);
+    const { data: sentRows } = await supabase
+      .from("sent_emails")
+      .select("draft_id")
+      .in("draft_id", ids);
+    const sentIds = new Set((sentRows ?? []).map((r) => r.draft_id));
+
+    const wasSent = ids.filter((id) => sentIds.has(id));
+    const neverSent = ids.filter((id) => !sentIds.has(id));
+    const now = new Date().toISOString();
+
+    if (wasSent.length > 0) {
+      await supabase
+        .from("email_drafts")
+        .update({ status: "sent", updated_at: now })
+        .in("id", wasSent)
+        .eq("status", "queued");
+      recoveredSent = wasSent.length;
+    }
+    if (neverSent.length > 0) {
+      await supabase
+        .from("email_drafts")
+        .update({ status: "draft", updated_at: now })
+        .in("id", neverSent)
+        .eq("status", "queued");
+      recoveredDraft = neverSent.length;
+    }
+  }
+
   // Delete old discarded drafts
   const { count: discardedCount } = await supabase
     .from("email_drafts")
@@ -43,6 +92,10 @@ export async function POST(request: Request) {
     cleaned: {
       discarded: discardedCount ?? 0,
       stale: staleCount ?? 0,
+    },
+    recovered: {
+      markedSent: recoveredSent,
+      returnedToDraft: recoveredDraft,
     },
   });
 }

--- a/src/app/api/email/track/route.ts
+++ b/src/app/api/email/track/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getAdminClient } from "@/lib/supabase/admin";
 import { getMessage } from "@/lib/services/agentmail-service";
 import { getPostHogClient } from "@/lib/posthog-server";
+import { verifyQStashSignature } from "@/lib/services/qstash";
 
 const STATUS_EVENT: Record<string, string> = {
   delivered: "email_delivered",
@@ -13,7 +14,10 @@ const STATUS_EVENT: Record<string, string> = {
 };
 
 /**
- * Delivery tracking endpoint. Call via cron or QStash schedule.
+ * Delivery tracking endpoint. Call via a QStash schedule (the route is
+ * public, so the signature check is the only auth — each run makes one
+ * AgentMail API call per pending email, which an open endpoint would let
+ * anyone burn through).
  * Polls AgentMail for delivery status of recently sent emails
  * and updates outreach_status accordingly.
  */
@@ -31,7 +35,14 @@ const STATUS_PRIORITY: Record<string, number> = {
   complained: 6,
 };
 
-export async function POST() {
+export async function POST(request: Request) {
+  try {
+    await verifyQStashSignature(request);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Invalid signature";
+    return NextResponse.json({ error: msg }, { status: 401 });
+  }
+
   const supabase = getAdminClient();
 
   // Load recent sent emails that haven't reached a terminal state

--- a/src/app/api/outreach/process/route.ts
+++ b/src/app/api/outreach/process/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getAdminClient } from "@/lib/supabase/admin";
+import { verifyQStashSignature } from "@/lib/services/qstash";
 import { getPostHogClient } from "@/lib/posthog-server";
 import { sendApprovedDraft } from "@/lib/services/outreach-sender";
 import {
@@ -49,11 +50,17 @@ interface FollowupPayload {
 type Payload = SignalPayload | FollowupPayload;
 
 export async function POST(request: Request) {
+  // This route is public (QStash can't send Clerk cookies) and sends real
+  // email through the admin client, so the signature check is the only thing
+  // standing between the internet and the user's outbox. All callers must go
+  // through QStash: the signal path publishes from /api/tracking/run, and the
+  // followups schedule must be a QStash schedule, not a bare cron.
   let payload: Payload;
   try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    payload = await verifyQStashSignature<Payload>(request);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Invalid signature";
+    return NextResponse.json({ error: msg }, { status: 401 });
   }
 
   const supabase = getAdminClient();

--- a/src/app/api/tracking/run/route.ts
+++ b/src/app/api/tracking/run/route.ts
@@ -1,5 +1,9 @@
 import { getAdminClient } from "@/lib/supabase/admin";
-import { verifyQStashSignature, getBaseUrl } from "@/lib/services/qstash";
+import {
+  verifyQStashSignature,
+  getQStashClient,
+  getBaseUrl,
+} from "@/lib/services/qstash";
 import { withAction } from "@/lib/services/cost-tracker";
 import { executeSignal } from "@/lib/signals/executor";
 import type { Signal } from "@/lib/types/signal";
@@ -262,21 +266,25 @@ export async function POST(request: Request) {
         .eq("campaign_id", config.campaign_id)
         .eq(entityField, entityId);
 
-      const outreachBaseUrl = getBaseUrl();
-      void fetch(`${outreachBaseUrl}/api/outreach/process`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: "signal",
-          signalId: config.signal_id,
-          campaignId: config.campaign_id,
-          organizationId: config.organization_id ?? undefined,
-          reason: verdict.reason,
-          confidence: verdict.confidence,
-        }),
-      }).catch(() => {
-        // Fire-and-forget -- don't block tracking response
-      });
+      // Publish via QStash (not a bare fetch) so the request arrives signed —
+      // /api/outreach/process rejects anything without a valid signature.
+      // Fire-and-forget: don't block the tracking response on the dispatch.
+      void getQStashClient()
+        .publishJSON({
+          url: `${getBaseUrl()}/api/outreach/process`,
+          body: {
+            type: "signal",
+            signalId: config.signal_id,
+            campaignId: config.campaign_id,
+            organizationId: config.organization_id ?? undefined,
+            reason: verdict.reason,
+            confidence: verdict.confidence,
+          },
+          retries: 2,
+        })
+        .catch((err) => {
+          console.error("[tracking] Failed to dispatch outreach:", err);
+        });
     }
 
     return Response.json({

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -108,10 +108,13 @@ function ChatView({
     };
   }, [chatId]);
 
-  // Auto-send the initial query passed via ?q= search param
-  const requestOptions = activeCampaignId
-    ? { body: { campaignId: activeCampaignId } }
-    : undefined;
+  // chatId lets the server persist the conversation even when the tab dies
+  // mid-stream and the client-side onFinish save never runs.
+  const requestOptions = {
+    body: activeCampaignId
+      ? { chatId, campaignId: activeCampaignId }
+      : { chatId },
+  };
 
   useEffect(() => {
     if (autoSendText && !didAutoSend.current) {

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -177,10 +177,12 @@ function AgentPanelInner({
 
   const buildRequestOptions = useCallback(() => {
     const pageContext = pageContextFromPath(pathname ?? "", campaignId);
-    const body: Record<string, unknown> = { pageContext };
+    // chatId lets the server persist the conversation even when the tab dies
+    // mid-stream and the client-side onFinish save never runs.
+    const body: Record<string, unknown> = { pageContext, chatId };
     if (campaignId) body.campaignId = campaignId;
     return { body };
-  }, [campaignId, pathname]);
+  }, [campaignId, chatId, pathname]);
 
   // Auto-send any prompt that was queued via openAgentWith()
   useEffect(() => {

--- a/src/lib/email-composition/compose.ts
+++ b/src/lib/email-composition/compose.ts
@@ -1,4 +1,5 @@
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { anthropic } from "@ai-sdk/anthropic";
 import {
   ComposedEmailSchema,
@@ -37,6 +38,7 @@ export async function composeEmail(
   try {
     const { skills, ...userPromptInput } = input;
     const { object } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODELS.EMAIL),
       schema: ComposedEmailSchema,
       system: buildEmailSystemPrompt(skills ?? []),

--- a/src/lib/services/contact-filter.ts
+++ b/src/lib/services/contact-filter.ts
@@ -1,5 +1,6 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
 import { WebExtractionService } from "@/lib/services/web-extraction-service";
@@ -160,6 +161,7 @@ export async function findPeopleOnDomain(
 
   try {
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODELS.LIGHT),
       schema: z.object({
         people: z.array(
@@ -290,6 +292,7 @@ export async function filterContactsByCompany(
 
   try {
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODELS.LIGHT),
       schema: z.object({
         verified: z.array(

--- a/src/lib/services/contact-selector.ts
+++ b/src/lib/services/contact-selector.ts
@@ -1,4 +1,5 @@
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
@@ -88,6 +89,7 @@ export async function selectContactsForSignal(
     .join("\n\n");
 
   const { object, usage } = await generateObject({
+    abortSignal: llmTimeout(),
     model: anthropic(MODELS.LIGHT),
     schema: verdictSchema,
     prompt: `You are picking the best contact(s) to email at a company after a buying-signal fired. You have the reason the signal fired (in the buyer's own words, via an upstream LLM) and a list of known contacts at the company.

--- a/src/lib/services/department-classifier.ts
+++ b/src/lib/services/department-classifier.ts
@@ -1,5 +1,6 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
 import {
@@ -80,6 +81,7 @@ export async function classifyPeople(
     );
 
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODELS.STRUCTURED),
       schema: ResponseSchema,
       prompt: `You are categorising employees of ${stringify(companyName)} into departments and seniority levels for an org chart.

--- a/src/lib/services/enrichment-summarizer.ts
+++ b/src/lib/services/enrichment-summarizer.ts
@@ -1,5 +1,6 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { z } from "zod";
 
 import { MODELS } from "@/lib/ai/models";
@@ -42,6 +43,7 @@ export async function summarizeWebsite(input: {
 
   try {
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODEL_ID),
       schema: z.object({
         summary: z
@@ -140,6 +142,7 @@ export async function summarizePerson(
 
   try {
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODEL_ID),
       schema: z.object({
         summary: z
@@ -194,6 +197,7 @@ export async function summarizeSearchResults<T extends SearchResultLike>(
 
   try {
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODEL_ID),
       schema: z.object({
         summaries: z.array(

--- a/src/lib/services/intent-evaluator.ts
+++ b/src/lib/services/intent-evaluator.ts
@@ -1,4 +1,5 @@
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
@@ -52,6 +53,7 @@ export async function evaluateIntent(
   }
 
   const { object, usage } = await generateObject({
+    abortSignal: llmTimeout(),
     model: anthropic(MODELS.LIGHT),
     schema: verdictSchema,
     prompt: `You decide whether the observed change on a company warrants flagging them as "ready to contact" for outreach. You have the buyer's tracking intent (their own words) and a summary of what changed since the last snapshot.

--- a/src/lib/services/outreach-sender.ts
+++ b/src/lib/services/outreach-sender.ts
@@ -63,89 +63,118 @@ export async function sendApprovedDraft(
     return { ok: false, reason: "No AgentMail inbox configured" };
   }
 
+  // Atomically claim the draft before sending. Overlapping callers — the
+  // followups cron racing a send-now click, or two process invocations — all
+  // pass the read above; only the one whose conditional update lands gets to
+  // send, so the prospect can't receive the same email twice.
+  const { data: claimed } = await supabase
+    .from("email_drafts")
+    .update({ status: "queued", updated_at: now })
+    .eq("id", draft.id)
+    .eq("status", "draft")
+    .select("id")
+    .maybeSingle();
+
+  if (!claimed) {
+    return { ok: false, reason: "Draft already claimed by another send" };
+  }
+
+  // Only a failure of the send itself releases the claim. Once the email has
+  // left, bookkeeping errors below must NOT flip the draft back to "draft" —
+  // a retry would email the prospect twice. Worst case there is a draft
+  // stuck in "queued" with the message already delivered.
+  let result: Awaited<ReturnType<typeof sendMessage>>;
   try {
-    const result = await sendMessage(settings.agentmail_inbox_id, {
+    result = await sendMessage(settings.agentmail_inbox_id, {
       to: draft.to_email,
       subject: draft.subject,
       html: draft.body_html,
       text: draft.body_text ?? undefined,
     });
-
-    const messageId = result.messageId ?? crypto.randomUUID();
-    const threadId = result.threadId ?? null;
-
-    await supabase.from("sent_emails").insert({
-      agentmail_message_id: messageId,
-      agentmail_thread_id: threadId,
-      draft_id: draft.id,
-      campaign_people_id: enrollment.campaign_people_id,
-      campaign_id: draft.campaign_id,
-      person_id: enrollment.person_id,
-      user_id: draft.user_id,
-      to_email: draft.to_email,
-      from_email: settings.agentmail_inbox_id,
-      subject: draft.subject,
-      status: "sent",
-      sent_at: now,
-    });
-
+  } catch (err) {
+    // Release the claim so the draft is retryable instead of stuck in
+    // "queued" forever.
     await supabase
       .from("email_drafts")
-      .update({ status: "sent", sent_at: now, updated_at: now })
-      .eq("id", draft.id);
+      .update({ status: "draft", updated_at: new Date().toISOString() })
+      .eq("id", draft.id)
+      .eq("status", "queued");
 
-    await supabase
-      .from("campaign_people")
-      .update({ outreach_status: "sent" })
-      .eq("id", enrollment.campaign_people_id);
-
-    const nextStep = enrollment.current_step + 1;
-    const { data: nextStepRow } = await supabase
-      .from("sequence_steps")
-      .select("delay_days, delay_hours")
-      .eq("sequence_id", enrollment.sequence_id)
-      .eq("step_number", nextStep)
-      .single();
-
-    if (nextStepRow) {
-      const delayMs =
-        ((nextStepRow.delay_days ?? 0) * 86400 +
-          (nextStepRow.delay_hours ?? 0) * 3600) *
-        1000;
-      const nextSendAt = new Date(Date.now() + delayMs).toISOString();
-
-      await supabase
-        .from("sequence_enrollments")
-        .update({
-          current_step: nextStep,
-          status: "active",
-          next_send_at: nextSendAt,
-          updated_at: now,
-        })
-        .eq("id", enrollment.id);
-    } else {
-      await supabase
-        .from("sequence_enrollments")
-        .update({ status: "completed", updated_at: now })
-        .eq("id", enrollment.id);
-    }
-
-    trackUsage({
-      service: "agentmail",
-      operation: "send-email",
-      estimated_cost_usd: 0.0004,
-      campaign_id: draft.campaign_id,
-      user_id: draft.user_id,
-      metadata: {
-        draftId: draft.id,
-        to: draft.to_email,
-        sequenceId: enrollment.sequence_id,
-      },
-    });
-
-    return { ok: true, messageId, draftId: draft.id };
-  } catch (err) {
     const reason = err instanceof Error ? err.message : "Send failed";
     return { ok: false, reason };
   }
+
+  const messageId = result.messageId ?? crypto.randomUUID();
+  const threadId = result.threadId ?? null;
+
+  await supabase.from("sent_emails").insert({
+    agentmail_message_id: messageId,
+    agentmail_thread_id: threadId,
+    draft_id: draft.id,
+    campaign_people_id: enrollment.campaign_people_id,
+    campaign_id: draft.campaign_id,
+    person_id: enrollment.person_id,
+    user_id: draft.user_id,
+    to_email: draft.to_email,
+    from_email: settings.agentmail_inbox_id,
+    subject: draft.subject,
+    status: "sent",
+    sent_at: now,
+  });
+
+  await supabase
+    .from("email_drafts")
+    .update({ status: "sent", sent_at: now, updated_at: now })
+    .eq("id", draft.id);
+
+  await supabase
+    .from("campaign_people")
+    .update({ outreach_status: "sent" })
+    .eq("id", enrollment.campaign_people_id);
+
+  const nextStep = enrollment.current_step + 1;
+  const { data: nextStepRow } = await supabase
+    .from("sequence_steps")
+    .select("delay_days, delay_hours")
+    .eq("sequence_id", enrollment.sequence_id)
+    .eq("step_number", nextStep)
+    .single();
+
+  if (nextStepRow) {
+    const delayMs =
+      ((nextStepRow.delay_days ?? 0) * 86400 +
+        (nextStepRow.delay_hours ?? 0) * 3600) *
+      1000;
+    const nextSendAt = new Date(Date.now() + delayMs).toISOString();
+
+    await supabase
+      .from("sequence_enrollments")
+      .update({
+        current_step: nextStep,
+        status: "active",
+        next_send_at: nextSendAt,
+        updated_at: now,
+      })
+      .eq("id", enrollment.id);
+  } else {
+    await supabase
+      .from("sequence_enrollments")
+      .update({ status: "completed", updated_at: now })
+      .eq("id", enrollment.id);
+  }
+
+  trackUsage({
+    service: "agentmail",
+    operation: "send-email",
+    estimated_cost_usd: 0.0004,
+    campaign_id: draft.campaign_id,
+    user_id: draft.user_id,
+    metadata: {
+      draftId: draft.id,
+      to: draft.to_email,
+      sequenceId: enrollment.sequence_id,
+    },
+  });
+
+  return { ok: true, messageId, draftId: draft.id };
 }

--- a/src/lib/services/relevance-filter.ts
+++ b/src/lib/services/relevance-filter.ts
@@ -1,5 +1,6 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
 import {
@@ -52,6 +53,7 @@ export async function filterRelevantResults(
 
   try {
     const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
       model: anthropic(MODELS.LIGHT),
       schema: z.object({
         relevant: z

--- a/src/lib/services/tracking-differ.ts
+++ b/src/lib/services/tracking-differ.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
@@ -128,6 +129,7 @@ export async function classifyNewRoles(
   if (jobs.length === 0) return [];
 
   const { object, usage } = await generateObject({
+    abortSignal: llmTimeout(),
     model: anthropic(MODELS.LIGHT),
     schema: z.object({
       classifications: z.array(

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,8 @@
 import { auth } from "@clerk/nextjs/server";
 import { createServerClient } from "@supabase/ssr";
 
+import { withTimeout } from "@/lib/utils/timeout";
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 
@@ -45,6 +47,14 @@ function warnIfKeyless() {
 
 /** Comfortably longer than the longest route maxDuration (300s). */
 const MINTED_TOKEN_TTL_SECONDS = 600;
+/**
+ * Minting goes over the network to api.clerk.com, and every concurrent query
+ * in the session awaits the same in-flight mint. Without a bound, one stalled
+ * connection (undici waits ~5min for headers) freezes every DB call behind a
+ * single promise. Fail fast instead — the error surfaces as a normal query
+ * failure and the next call starts a fresh mint.
+ */
+const MINT_TIMEOUT_MS = 15_000;
 /** Treat a token expiring within this window as already spent. */
 const REFRESH_SKEW_MS = 30_000;
 
@@ -143,9 +153,11 @@ function createTokenProvider(getToken: GetToken, sessionId: string | null) {
     const pending = inFlightMints.get(sessionId);
     if (pending) return pending;
 
-    const mintPromise = getToken({
-      expiresInSeconds: MINTED_TOKEN_TTL_SECONDS,
-    })
+    const mintPromise = withTimeout(
+      getToken({ expiresInSeconds: MINTED_TOKEN_TTL_SECONDS }),
+      MINT_TIMEOUT_MS,
+      "Clerk session token mint",
+    )
       .then((token) => {
         if (token) cacheToken(sessionId, token);
         return token;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -30,9 +30,186 @@ function warnIfKeyless() {
   );
 }
 
+// ── Token freshness ────────────────────────────────────────────────────────
+// Clerk's server-side getToken() with no options does NOT mint anything: it
+// returns the JWT that arrived on the request, verbatim, forever (see
+// createGetToken in @clerk/backend). Those tokens live ~60s, but our routes
+// run much longer — maxDuration is 120s on /api/chat and 300s on
+// /api/find-email/bulk, and one chat turn can take 15 tool steps. So any
+// Supabase call made past the ~60s mark used to fail with "JWT expired", and
+// stayed broken for the rest of the request, retries included.
+//
+// Passing expiresInSeconds takes Clerk's other branch, which mints a fresh
+// token through the Backend API. We only do that once the request's own token
+// is spent, so short requests behave exactly as before, with no extra calls.
+
+/** Comfortably longer than the longest route maxDuration (300s). */
+const MINTED_TOKEN_TTL_SECONDS = 600;
+/** Treat a token expiring within this window as already spent. */
+const REFRESH_SKEW_MS = 30_000;
+
+type CachedToken = { token: string; expMs: number };
+
+// Keyed by Clerk session id, so concurrent tool calls in one request — and
+// back-to-back requests from the same session — share a single mint.
+const tokenCache = new Map<string, CachedToken>();
+const inFlightMints = new Map<string, Promise<string | null>>();
+
+/**
+ * `exp` in ms from a JWT, or null when it can't be read. No signature check —
+ * Supabase verifies the token; we only need to know when to replace it.
+ */
+function jwtExpMs(token: string): number | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const json = Buffer.from(
+      payload.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    ).toString("utf8");
+    const { exp } = JSON.parse(json) as { exp?: number };
+    return typeof exp === "number" ? exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasLifeLeft(token: string | null | undefined): token is string {
+  if (!token) return false;
+  const expMs = jwtExpMs(token);
+  // Unreadable exp: replace it with one we can reason about.
+  if (expMs === null) return false;
+  return expMs - Date.now() > REFRESH_SKEW_MS;
+}
+
+let warnedMissingRole = false;
+/**
+ * A minted token inherits the instance's session token claims, so it should
+ * carry the custom `role: authenticated` claim the Supabase integration needs.
+ * If it ever doesn't, Supabase maps the request to `anon` and RLS returns zero
+ * rows instead of erroring — so say so loudly rather than silently read empty.
+ */
+function warnIfRoleClaimMissing(token: string) {
+  if (warnedMissingRole) return;
+  const payload = token.split(".")[1];
+  if (!payload) return;
+  try {
+    const { role } = JSON.parse(
+      Buffer.from(
+        payload.replace(/-/g, "+").replace(/_/g, "/"),
+        "base64",
+      ).toString("utf8"),
+    ) as { role?: string };
+    if (role === "authenticated") return;
+    warnedMissingRole = true;
+    console.error(
+      "FATAL: Clerk-minted session token has no `role: authenticated` claim " +
+        `(got ${JSON.stringify(role)}). Supabase will treat these requests as ` +
+        "anon and every RLS-protected query will return zero rows. Add the " +
+        "claim to the session token in Clerk → Sessions → Customize token.",
+    );
+  } catch {
+    // Unparseable payload is already handled by the exp fallback.
+  }
+}
+
+function cacheToken(sessionId: string, token: string) {
+  warnIfRoleClaimMissing(token);
+  const now = Date.now();
+  for (const [key, entry] of tokenCache) {
+    if (entry.expMs <= now) tokenCache.delete(key);
+  }
+  tokenCache.set(sessionId, {
+    token,
+    expMs: jwtExpMs(token) ?? now + MINTED_TOKEN_TTL_SECONDS * 1000,
+  });
+}
+
+type GetToken = (options?: {
+  expiresInSeconds?: number;
+}) => Promise<string | null>;
+
+/**
+ * Returns a getter for a token that is still valid right now, minting a
+ * longer-lived one via Clerk's Backend API when the request's own token has
+ * run out. `force` discards what we have and mints unconditionally.
+ */
+function createTokenProvider(getToken: GetToken, sessionId: string | null) {
+  const mint = (): Promise<string | null> => {
+    // No session id means no session to mint against (signed out, or a
+    // machine token) — hand back whatever getToken gives us.
+    if (!sessionId) return getToken();
+
+    const pending = inFlightMints.get(sessionId);
+    if (pending) return pending;
+
+    const mintPromise = getToken({
+      expiresInSeconds: MINTED_TOKEN_TTL_SECONDS,
+    })
+      .then((token) => {
+        if (token) cacheToken(sessionId, token);
+        return token;
+      })
+      .finally(() => inFlightMints.delete(sessionId));
+
+    inFlightMints.set(sessionId, mintPromise);
+    return mintPromise;
+  };
+
+  return async ({ force = false } = {}): Promise<string | null> => {
+    if (force) {
+      if (sessionId) tokenCache.delete(sessionId);
+      return mint();
+    }
+    const cached = sessionId ? tokenCache.get(sessionId) : undefined;
+    if (cached && cached.expMs - Date.now() > REFRESH_SKEW_MS) {
+      return cached.token;
+    }
+    const incoming = await getToken();
+    if (hasLifeLeft(incoming)) return incoming;
+    return mint();
+  };
+}
+
+// Verified against local PostgREST: an expired JWT gets 401
+// {"code":"PGRST303","message":"JWT expired"}. Older PostgREST used PGRST301;
+// match both codes plus the message so a version bump can't unhook the retry.
+const JWT_REJECTED = /jwt expired|PGRST30[13]/i;
+
+/** True when a 401 is specifically "your token is past its exp". */
+async function isExpiredTokenResponse(res: Response): Promise<boolean> {
+  if (res.status !== 401) return false;
+  try {
+    // Clone so the caller still receives an unread body.
+    return JWT_REJECTED.test(await res.clone().text());
+  } catch {
+    return false;
+  }
+}
+
+/** A request can only be replayed if its body can be sent a second time. */
+function isReplayable(
+  input: RequestInfo | URL,
+  body: BodyInit | null,
+): boolean {
+  if (
+    typeof Request !== "undefined" &&
+    input instanceof Request &&
+    input.body
+  ) {
+    return false;
+  }
+  if (body == null) return true;
+  if (typeof body === "string") return true;
+  if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) return true;
+  if (body instanceof URLSearchParams) return true;
+  return false; // streams, FormData — a half-consumed replay is worse than the 401
+}
+
 export const createClient = async () => {
   warnIfKeyless();
-  const { getToken } = await auth();
+  const { getToken, sessionId } = await auth();
+  const freshToken = createTokenProvider(getToken, sessionId);
 
   return createServerClient(supabaseUrl!, supabaseKey!, {
     // @supabase/ssr requires a cookies adapter even though Clerk-issued JWTs
@@ -40,10 +217,22 @@ export const createClient = async () => {
     cookies: { getAll: () => [], setAll: () => {} },
     global: {
       fetch: async (input, init = {}) => {
-        const token = await getToken();
-        const headers = new Headers(init.headers);
-        if (token) headers.set("Authorization", `Bearer ${token}`);
-        return fetch(input, { ...init, headers });
+        const send = async (token: string | null) => {
+          const headers = new Headers(init.headers);
+          if (token) headers.set("Authorization", `Bearer ${token}`);
+          return fetch(input, { ...init, headers });
+        };
+
+        const res = await send(await freshToken());
+        if (!isReplayable(input, init.body ?? null)) return res;
+        if (!(await isExpiredTokenResponse(res))) return res;
+
+        // The token was rejected anyway — clock skew, or an exp we misread.
+        // Mint and replay exactly once, so a genuinely unauthorized request
+        // still surfaces its 401 instead of looping.
+        const retryToken = await freshToken({ force: true });
+        if (!retryToken) return res;
+        return send(retryToken);
       },
     },
   });

--- a/src/lib/utils/timeout.ts
+++ b/src/lib/utils/timeout.ts
@@ -1,4 +1,15 @@
 /**
+ * Bound for a single LLM call (including the SDK's internal retries). Every
+ * external scraper already runs under withTimeout/fetchWithTimeout; without
+ * this, a stalled model call was the one unbounded await left inside tools —
+ * and one stalled tool freezes the whole agent stream.
+ */
+export const LLM_TIMEOUT_MS = 90_000;
+
+/** Fresh abort signal for one LLM call. Pass as `abortSignal` to the AI SDK. */
+export const llmTimeout = () => AbortSignal.timeout(LLM_TIMEOUT_MS);
+
+/**
  * Race a promise against a timer; rejects with a labeled error if `ms` elapses first.
  */
 export function withTimeout<T>(


### PR DESCRIPTION
…uests

Server-side getToken() with no options never mints: @clerk/backend's createGetToken returns the JWT that arrived on the request, verbatim, for the whole request lifetime. Those tokens live ~60s, but routes run up to 120s (/api/chat, 15 tool steps) and 300s (/api/find-email/bulk), so every Supabase call past the first minute failed with "JWT expired" and stayed broken for the rest of the request — retries included. Agent runs hit this constantly: enrichment reads landed inside the window, then updateCampaign / findContacts / getCompanyDetail died past it.

This is the server-side twin of 60c5a9d, which fixed the same class of staleness for browser fetches; nothing about that fix reached tool calls running inside a stream.

The Supabase fetch wrapper in src/lib/supabase/server.ts now:

- reuses the request's own token while it has >30s of life left, so short requests behave exactly as before with zero extra calls
- once it's spent, mints a 600s token via getToken({ expiresInSeconds }) — Clerk's Backend API path — cached and in-flight-deduped per session id so parallel tool calls mint once
- if a token is rejected anyway, force-mints and replays the request exactly once, reading the error off res.clone() so supabase-js still gets a readable body, and skipping bodies that can't be sent twice
- logs a FATAL if a minted token ever lacks the role: authenticated claim, since Supabase would silently map it to anon (zero rows, no error)

All ~60 createClient() call sites in lib/tools and lib/services are fixed transparently; no call-site changes.

Verified live against real Clerk + local PostgREST: a 600s mint keeps role/sub and full lifetime, and the previously-failing write path succeeds with an expired incoming token. That test also showed current PostgREST returns PGRST303 (not PGRST301) for expired JWTs — the retry matcher covers both codes plus the message.

Tradeoff: server-side revocation window grows from ~60s to ~10min (MINTED_TOKEN_TTL_SECONDS is a single constant if tighter is wanted). Known pre-existing gap left as-is: sendBeacon chat summarize cannot carry auth headers.

## Summary

<!-- 1-3 sentences. What does this change and why? -->

## Linked issue

<!-- Closes #123 / Relates to #456 -->

## How I tested

<!-- Commands run, manual steps, screenshots of the result. Delete what doesn't apply. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manually exercised the changed code path in dev

## Screenshots / recordings

<!-- If this touches the UI, paste a before/after screenshot or screen recording. -->

## Notes for the reviewer

<!-- Anything tricky, intentional trade-offs, follow-ups you plan to open separately. -->
