### PR TITLE
ci: push supabase migrations to production on merge to main

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -1,0 +1,78 @@
+name: Migrate database
+
+# Vercel deploys straight from a push to main, so the schema has to catch up on
+# the same trigger — otherwise new code goes live against a database that is
+# still a migration behind (see the gmail_transport incident, 2026-07-30).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/migrate.yaml"
+  # Escape hatch: re-run by hand after fixing a failed push, or to apply a
+  # migration that landed on main before this workflow existed.
+  workflow_dispatch:
+
+# Deliberately NOT cancel-in-progress: a migration killed halfway through leaves
+# the database in a state no later run can reason about. Queue instead.
+concurrency:
+  group: migrate-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    name: Push migrations to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          # Pinned so a CLI release can never change migration behaviour
+          # under us. Bump deliberately, alongside a local `db push` test.
+          version: 2.110.0
+
+      # Signal is self-hosted per team, so most forks will never set these
+      # secrets. Skip cleanly rather than failing their CI.
+      - name: Check for credentials
+        id: check
+        env:
+          ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+        run: |
+          if [ -z "$ACCESS_TOKEN" ] || [ -z "$DB_PASSWORD" ] || [ -z "$PROJECT_ID" ]; then
+            echo "::notice::Supabase secrets not configured — skipping migration push. This is expected on forks."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Link project
+        if: steps.check.outputs.configured == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_ID }}"
+
+      # Surfaces the pending list in the job log before anything is applied, so
+      # a failed push has a readable "what was it about to do" record.
+      - name: Show pending migrations
+        if: steps.check.outputs.configured == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: supabase migration list
+
+      - name: Push migrations
+        if: steps.check.outputs.configured == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: supabase db push


### PR DESCRIPTION
Vercel deploys straight from a push to main, so nothing was keeping the schema in step with the code. A migration written and tested locally stayed invisible to production until someone remembered to run `supabase db push` by hand — which is how 20260730000001_gmail_transport reached main unapplied and surfaced as a PGRST204 "could not find the 'gmail_address' column of 'user_settings' in the schema cache" when connecting a mailbox.

Runs on pushes touching supabase/migrations/**, plus workflow_dispatch as an escape hatch for re-running after a failure.

Two deliberate choices:

- No cancel-in-progress. The CI workflow cancels superseded runs, which is right for tests and wrong for migrations: a run killed partway through leaves the database in a state no later run can reason about. Queue instead.
- Skips itself when the Supabase secrets are absent. Signal is self-hosted one project per team, so most forks will never set them and should not inherit a permanently red workflow.

Requires SUPABASE_ACCESS_TOKEN, SUPABASE_DB_PASSWORD and SUPABASE_PROJECT_ID.

## Summary

<!-- 1-3 sentences. What does this change and why? -->

## Linked issue

<!-- Closes #123 / Relates to #456 -->

## How I tested

<!-- Commands run, manual steps, screenshots of the result. Delete what doesn't apply. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manually exercised the changed code path in dev

## Screenshots / recordings

<!-- If this touches the UI, paste a before/after screenshot or screen recording. -->

## Notes for the reviewer

<!-- Anything tricky, intentional trade-offs, follow-ups you plan to open separately. -->
