### PR TITLE
fix(email): widen IMAP search window to survive timezone skew

### DIFF
--- a/src/__tests__/gmail-imap.test.ts
+++ b/src/__tests__/gmail-imap.test.ts
@@ -9,7 +9,10 @@ import { Readable } from "node:stream";
  * bounce bodies only after the fetch loop has fully drained.
  */
 
-const state = vi.hoisted(() => ({ order: [] as string[] }));
+const state = vi.hoisted(() => ({
+  order: [] as string[],
+  searchQuery: null as { since?: Date } | null,
+}));
 
 vi.mock("imapflow", () => {
   class FakeImapFlow {
@@ -19,7 +22,8 @@ vi.mock("imapflow", () => {
     async getMailboxLock() {
       return { release: () => state.order.push("release") };
     }
-    async *fetch() {
+    async *fetch(query: { since?: Date }) {
+      state.searchQuery = query;
       state.order.push("fetch-start");
       yield {
         uid: 11,
@@ -103,5 +107,29 @@ describe("fetchInboundSince", () => {
 
     expect(inbound[1].subject).toBe("Re: Signal test");
     expect(inbound[1].date).toEqual(new Date("2026-07-30T14:32:00Z"));
+  });
+
+  /**
+   * Regression: IMAP SINCE is DATE-granular and the server compares it against
+   * each message's internal date in the ACCOUNT's timezone, not UTC. Passing
+   * the raw UTC timestamp means that for a US/Pacific account, every send
+   * between 17:00 local and midnight searches a calendar day AHEAD of the
+   * server's view and returns zero rows — replies sitting correctly threaded
+   * in the INBOX are silently invisible. Verified live: a reply to a 05:48Z
+   * send was unfindable until the window was widened.
+   */
+  it("widens the IMAP search window by a day to survive timezone skew", async () => {
+    const sentAt = new Date("2026-07-31T05:48:26.000Z");
+    await fetchInboundSince(
+      { address: "jay@sahnan.co", appPassword: "pw" },
+      sentAt,
+    );
+
+    const searched = state.searchQuery?.since;
+    expect(searched).toBeInstanceOf(Date);
+    expect(sentAt.getTime() - searched!.getTime()).toBe(86400_000);
+    // The UTC calendar date must land strictly before the caller's, or the
+    // date-granular SINCE can still exclude the very message we want.
+    expect(searched!.getUTCDate()).toBeLessThan(sentAt.getUTCDate());
   });
 });

--- a/src/lib/services/gmail-service.ts
+++ b/src/lib/services/gmail-service.ts
@@ -118,6 +118,19 @@ export async function fetchInboundSince(
   creds: GmailCreds,
   since: Date,
 ): Promise<InboundSummary[]> {
+  // IMAP SINCE is DATE-granular, and the server evaluates it against each
+  // message's internal date in the account's own timezone — not UTC. A UTC
+  // timestamp taken late in the local day is therefore a calendar day ahead
+  // of the server's view, and the search silently returns zero rows. For a
+  // US/Pacific account that is every send between 17:00 and midnight local:
+  // sent 05:48Z (22:48 local, 30 Jul), searching SINCE 31-Jul finds nothing
+  // even though the reply is sitting in the INBOX correctly threaded.
+  //
+  // Widen by a day so the date can never land ahead of the server's. Max real
+  // UTC offset is 14h, so one day always covers it. Over-fetching envelopes
+  // is cheap and costs no correctness: matching is exact on Message-ID.
+  const searchSince = new Date(since.getTime() - 86400_000);
+
   const imap = imapClient(creds);
   await imap.connect();
   const results: InboundSummary[] = [];
@@ -130,7 +143,7 @@ export async function fetchInboundSince(
       // doesn't complete until every row is consumed, and a nested command
       // (like download) queues behind it — mutual wait, guaranteed hang.
       for await (const msg of imap.fetch(
-        { since },
+        { since: searchSince },
         { envelope: true, headers: ["references"], uid: true },
       )) {
         const fromAddress = msg.envelope?.from?.[0]?.address ?? "";


### PR DESCRIPTION
Reply tracking silently found nothing for roughly seven hours a day.

IMAP SINCE is DATE-granular, and the server compares it against each message's internal date in the ACCOUNT's timezone rather than UTC. We passed the raw UTC timestamp. For a US/Pacific mailbox every send between 17:00 local and midnight has a UTC date one calendar day ahead of the server's view, so the search returns zero rows — replies sitting correctly threaded in the INBOX are invisible.

Confirmed against a live mailbox. A test sent at 05:48Z (22:48 local, 30 Jul) was replied to 28 seconds later, correctly threaded:

  SENT   Message-ID  <8e16bd0b-...@sahnan.co>
  REPLY  In-Reply-To <8e16bd0b-...@sahnan.co>

yet fetchInboundSince returned 0 messages. Bisecting the window showed the boundary sitting exactly on the UTC date rollover:

  since=2026-07-30T17:48Z -> 3 msgs, found
  since=2026-07-31T04:48Z -> 0 msgs, not found

After widening, the same call returns 3 messages and finds the reply.

This is not specific to the test-send button — /api/email/track calls the same function, so campaign reply tracking has been losing evening replies too. It is masked whenever an older pending send drags the window back, which is why it went unnoticed; a lone recent send hits it exactly.

One day always covers it: the largest real UTC offset is 14h. Over-fetching envelopes is cheap and costs no correctness, since matching is exact on Message-ID.

## Summary

<!-- 1-3 sentences. What does this change and why? -->

## Linked issue

<!-- Closes #123 / Relates to #456 -->

## How I tested

<!-- Commands run, manual steps, screenshots of the result. Delete what doesn't apply. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manually exercised the changed code path in dev

## Screenshots / recordings

<!-- If this touches the UI, paste a before/after screenshot or screen recording. -->

## Notes for the reviewer

<!-- Anything tricky, intentional trade-offs, follow-ups you plan to open separately. -->
