### PR TITLE
feat(email): show live polling state on the test card

### DIFF
--- a/src/components/settings/email-settings.tsx
+++ b/src/components/settings/email-settings.tsx
@@ -372,22 +372,40 @@ export function EmailSettings() {
 
               {testStatus === "waiting" && (
                 <div className="text-muted-foreground space-y-1.5 text-xs">
-                  <p>
-                    {polling
-                      ? "Sent — waiting for your reply. Reply to it and this updates within ~20s."
-                      : "No reply detected yet. Reply to the test, then check again."}
-                  </p>
+                  <div className="flex items-center gap-2">
+                    {polling && (
+                      // Without a live indicator the card looks frozen between
+                      // 20s ticks and the user cannot tell we are still
+                      // watching. motion-safe so it respects reduced-motion.
+                      <span
+                        className="relative flex h-2 w-2 shrink-0"
+                        aria-hidden="true"
+                      >
+                        <span className="bg-success absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full opacity-75" />
+                        <span className="bg-success relative inline-flex h-2 w-2 rounded-full" />
+                      </span>
+                    )}
+                    <p aria-live="polite">
+                      {polling
+                        ? testChecking
+                          ? "Checking your inbox..."
+                          : `Watching for your reply — checking every ${POLL_MS / 1000}s.`
+                        : "No reply detected yet. Reply to the test, then check again."}
+                    </p>
+                  </div>
                   {testWarning && <p>{testWarning}</p>}
-                  {!polling && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => void checkTest()}
-                      disabled={testChecking}
-                    >
-                      {testChecking ? "Checking..." : "Check now"}
-                    </Button>
-                  )}
+                  {/* Always offered, not just once polling gives up: the user
+                      knows they replied well before the next tick, and making
+                      them wait up to 20s for a round trip they already
+                      completed is the whole complaint. */}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void checkTest()}
+                    disabled={testChecking}
+                  >
+                    {testChecking ? "Checking..." : "I've replied — check now"}
+                  </Button>
                 </div>
               )}
 


### PR DESCRIPTION
The card sat static between 20s ticks with no sign it was still watching, so a successful round trip looked like a hang. Adds a pulsing indicator while polling (motion-safe, so reduced-motion users get a static dot) and swaps the copy to name the interval.

The check button is now always offered while waiting rather than only after polling gives up: the user knows they replied well before the next tick, and making them wait up to 20s for a round trip they already completed is the whole complaint.

## Summary

<!-- 1-3 sentences. What does this change and why? -->

## Linked issue

<!-- Closes #123 / Relates to #456 -->

## How I tested

<!-- Commands run, manual steps, screenshots of the result. Delete what doesn't apply. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manually exercised the changed code path in dev

## Screenshots / recordings

<!-- If this touches the UI, paste a before/after screenshot or screen recording. -->

## Notes for the reviewer

<!-- Anything tricky, intentional trade-offs, follow-ups you plan to open separately. -->
