### PR TITLE
feat: target account lists — upload, interview, triage, background enrichment

### DIFF
--- a/docs/plans/2026-07-30-target-account-lists.md
+++ b/docs/plans/2026-07-30-target-account-lists.md
@@ -1,0 +1,428 @@
+# Target Account Lists Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> Design rationale: `docs/plans/2026-07-30-target-account-lists-design.md` (local, gitignored by repo convention).
+
+**Goal:** Users drop a target-account CSV into chat; the agent interviews them (who to reach, what's sold), triages the list against the ICP, enriches the top ~10% on approval, and flows into existing contact/outreach machinery — with lists stored as first-class owned data.
+
+**Architecture:** Two new owner-scoped tables (`target_account_lists`, `target_accounts`) resolve rows to the global `organizations` pool at import. Scoring reuses `campaign_organizations.relevance_score/score_reason/status` (no parallel tier system). Prioritization is a chunked sonnet scorer gated on campaign ICP. Enrichment tranches run as a self-draining QStash chain (1–2 accounts/hop) over an `enrichAndFindContacts` service extracted from the enrich-company route. Chat upload parses client-side and POSTs JSON rows — never CSV into model context.
+
+**Tech Stack:** Next.js 16 App Router, Supabase RLS (Clerk `requesting_user_id()`), QStash, Vercel AI SDK `generateObject` + zod, Vitest.
+
+**Branch:** `feat/target-account-lists` (created, off current main which includes the Gmail transport).
+
+**Conventions the executor must follow (from the 2026-07-30 audits):**
+
+- New tools: RLS `createClient()` from `@/lib/supabase/server`, explicit `campaignId`/`listId` zod inputs (tools do NOT read campaignId from context), register in `src/lib/tools/index.ts` barrel (telemetry wraps automatically).
+- Never name anything `companyId` — use `organizationId` (elsewhere `companyId` means the campaign-link id).
+- All CSV-derived text entering prompts goes through `wrapUntrusted`/`UNTRUSTED_NOTICE` (`src/lib/prompt-safety.ts`).
+- LLM cost: `withAction("Verb: subject", …)` around route bodies AFTER auth; `trackUsage({service:"claude", operation, tokens, estimated_cost_usd: estimateClaudeCostFromUsage("sonnet"|"haiku", usage), campaign_id, user_id})` per chunk.
+- Tests: vitest jsdom; `vi.hoisted` mocks; thenable `fakeSupabase(responses[])` pattern from `src/__tests__/outreach-sender.test.ts`.
+
+---
+
+### Task 1: Migration
+
+**Files:**
+
+- Create: `supabase/migrations/20260731000000_target_account_lists.sql`
+
+**Step 1: Write it** (shape copied from `20260729000000_email_voice_profiles.sql` — transaction, lock timeouts, named policies, updated_at trigger):
+
+```sql
+-- Target account lists: first-class, user-owned uploads of companies.
+-- A list is a lens over the global organizations pool: rows resolve to
+-- organizations at import (domain-deduped), so enrichment/contacts/outreach
+-- reuse existing machinery. Scores/qualification deliberately do NOT live
+-- here — they belong to campaign_organizations (see design doc D1/D4).
+
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '60s';
+
+create table if not exists target_account_lists (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,           -- Clerk sub; no FK by convention
+  name text not null,
+  original_filename text,
+  row_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger target_account_lists_updated_at
+  before update on target_account_lists
+  for each row execute function update_updated_at_column();
+
+create table if not exists target_accounts (
+  id uuid primary key default gen_random_uuid(),
+  list_id uuid not null references target_account_lists(id) on delete cascade,
+  organization_id uuid not null references organizations(id) on delete cascade,
+  raw jsonb not null default '{}'::jsonb,   -- original CSV row, verbatim
+  enrich_requested_at timestamptz,          -- set when a tranche is approved
+  created_at timestamptz not null default now(),
+  unique (list_id, organization_id)
+);
+
+create index if not exists idx_target_accounts_list on target_accounts(list_id);
+create index if not exists idx_target_accounts_org on target_accounts(organization_id);
+-- The QStash processor's work query:
+create index if not exists idx_target_accounts_enrich_queue
+  on target_accounts(list_id, enrich_requested_at)
+  where enrich_requested_at is not null;
+
+alter table target_account_lists enable row level security;
+create policy "target_account_lists_select" on target_account_lists
+  for select to authenticated using (user_id = requesting_user_id());
+create policy "target_account_lists_insert" on target_account_lists
+  for insert to authenticated with check (user_id = requesting_user_id());
+create policy "target_account_lists_update" on target_account_lists
+  for update to authenticated using (user_id = requesting_user_id())
+  with check (user_id = requesting_user_id());
+create policy "target_account_lists_delete" on target_account_lists
+  for delete to authenticated using (user_id = requesting_user_id());
+
+alter table target_accounts enable row level security;
+create policy "target_accounts_select" on target_accounts
+  for select to authenticated using (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+create policy "target_accounts_insert" on target_accounts
+  for insert to authenticated with check (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+create policy "target_accounts_update" on target_accounts
+  for update to authenticated using (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+create policy "target_accounts_delete" on target_accounts
+  for delete to authenticated using (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+
+commit;
+```
+
+**Step 2:** `supabase migration up` → applies. `psql "\d target_accounts"` shows the partial index. (Never `db reset` — wipes seeded signals.)
+
+**Step 3:** Commit: `feat(db): target account lists tables`
+
+---
+
+### Task 2: Types
+
+**Files:**
+
+- Create: `src/lib/types/target-list.ts`
+
+```ts
+export interface TargetAccountList {
+  id: string;
+  user_id: string;
+  name: string;
+  original_filename: string | null;
+  row_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TargetAccount {
+  id: string;
+  list_id: string;
+  organization_id: string;
+  raw: Record<string, string>;
+  enrich_requested_at: string | null;
+  created_at: string;
+}
+
+/** A parsed, column-mapped CSV row ready for import. */
+export interface TargetAccountRow {
+  name: string;
+  domain?: string | null;
+  url?: string | null;
+  industry?: string | null;
+  location?: string | null;
+  description?: string | null;
+  /** Everything else from the original row, preserved verbatim. */
+  extra?: Record<string, string>;
+}
+```
+
+Commit with Task 3 (no behavior yet).
+
+---
+
+### Task 3: Shared CSV parsing module (lift from csv-upload.tsx) + LLM header fallback (TDD)
+
+**Files:**
+
+- Create: `src/lib/csv/company-csv.ts` (move `parseCSV`, `COLUMN_MAP`, `mapColumns` out of `src/components/campaign/csv-upload.tsx:30-169`; the component imports from here afterward — behavior identical)
+- Create: `src/lib/csv/header-mapper.ts` (server-side Haiku fallback for unrecognized headers)
+- Test: `src/__tests__/company-csv.test.ts`, `src/__tests__/header-mapper.test.ts`
+
+**Step 1: Failing tests for the extraction** — exercise `parseCSV` (quoted fields, commas inside quotes, CRLF), `mapColumns` (aliases: `company_name→name`, `website→domain`, `hq→location`; first-column fallback to name; unmapped headers land in `extra`). Note: `mapColumns` today drops unmapped columns — extend it to collect them into `extra` (that's the only behavior change; `csv-upload.tsx` ignores `extra`).
+
+**Step 2:** Red. **Step 3:** Move code + add `extra` collection. **Step 4:** Green, plus `pnpm test src/__tests__/import-csv-batching.test.ts` still green (component unchanged behaviorally).
+
+**Step 5: header-mapper** — pure prompt-wrapper, clone the department-classifier shape but `MODELS.LIGHT`:
+
+```ts
+// src/lib/csv/header-mapper.ts
+// Given headers COLUMN_MAP didn't recognize plus 3 sample values each,
+// ask Haiku to map them to name|domain|url|industry|location|description|ignore.
+// Returns Record<header, CanonicalField>. Falls back to "ignore" on any error
+// (permissive-fallback convention from relevance-filter.ts:93-97).
+```
+
+Schema: `z.object({ mappings: z.array(z.object({ header: z.string(), field: z.enum([...CANONICAL, "ignore"]) })) })`; prompt wraps headers+samples with `wrapUntrusted`; `trackUsage({service:"claude", operation:"csv-header-mapper", …, estimateClaudeCostFromUsage("haiku", usage)})`. Test with a mocked `ai.generateObject` (`vi.mock("ai")`): known aliases pass through without an LLM call (COLUMN_MAP first), only unknowns hit the mock, hallucinated headers dropped.
+
+**Step 6:** Commit: `feat(csv): shared company CSV parser with LLM header fallback`
+
+---
+
+### Task 4: List API routes (TDD on the dedup/ownership core)
+
+**Files:**
+
+- Create: `src/app/api/target-lists/route.ts` (POST create + GET list-mine)
+- Create: `src/app/api/target-lists/[id]/accounts/route.ts` (POST append batch)
+- Create: `src/lib/services/target-lists.ts` (the logic, testable)
+- Test: `src/__tests__/target-lists-service.test.ts`
+
+**Service (the testable core):**
+
+```ts
+// src/lib/services/target-lists.ts
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { findOrCreateOrganization } from "@/lib/services/knowledge-base";
+import type { TargetAccountRow } from "@/lib/types/target-list";
+
+export const MAX_ROWS_PER_REQUEST = 500; // mirror import-limits.ts
+
+/**
+ * Resolve rows to organizations (domain-deduped globally) and insert
+ * target_accounts. Dedup within the list is by organization_id via the
+ * unique constraint — on-conflict-do-nothing, counted as skipped.
+ * Chunks of 10 like import-csv (route.ts:164-179).
+ */
+export async function appendAccountsToList(
+  supabase: SupabaseClient,
+  listId: string,
+  rows: TargetAccountRow[],
+): Promise<{ imported: number; skipped: number; failed: number }> { … }
+```
+
+Implementation notes for the executor: `findOrCreateOrganization` builds its own RLS client internally — call it as-is (the route is Clerk-authed); pass `source: "target_list"`. Insert `target_accounts` rows with `raw: {name, domain, …, ...extra}`; use `.upsert(..., { onConflict: "list_id,organization_id", ignoreDuplicates: true })` and count skips via returned rows vs input. After each batch, `update target_account_lists set row_count = row_count + imported` (read-modify-write is fine under one owner).
+
+**Routes:** copy `import-csv/route.ts`'s skeleton exactly: `getSupabaseAndUser()` → 401; zod-parse body; 413 over `MAX_ROWS_PER_REQUEST`; ownership re-check (`list.user_id !== user.id → 403`) on the accounts route; PostHog `target_list_created` / `target_list_accounts_imported` events mirroring `csv_import_completed` (import-csv:181-192). `POST /api/target-lists` body: `{ name, original_filename? }` → returns the list row. No `withAction` (no LLM spend here).
+
+**Tests (fakeSupabase):** append dedups within batch by resolved org; upsert carries `onConflict: "list_id,organization_id"`; row_count updated; 413 shape.
+
+Commit: `feat(target-lists): create/append API with org resolution`
+
+---
+
+### Task 5: Extract `company-enrichment` service from the enrich-company route
+
+**Files:**
+
+- Create: `src/lib/services/company-enrichment.ts`
+- Modify: `src/app/api/enrich-company/route.ts` (becomes a thin wrapper)
+
+Mechanical move, no behavior change. From `enrich-company/route.ts` move:
+
+- `enrichOrganization(...)` (route.ts:312) and `findContactsForCompany(...)` (route.ts:166), `getActiveSignalSlugs` (:34) and the four `SIGNAL_SLUG_*` constants (:28-31).
+- New exported entry point:
+
+```ts
+export async function enrichAndFindContacts(
+  supabase: SupabaseClient, // RLS client from the route, admin from QStash
+  organizationId: string,
+  campaignId: string | null,
+): Promise<{ enriched: boolean; contactsFound: number; errors: string[] }>;
+```
+
+Critical invariants to preserve (verify against the current file while moving): the 7-day `isRecentlyEnriched` skip still runs contact-finding; `withAction("Enrich company: …")` stays at the ROUTE level (and the QStash route adds its own) so cost attribution is unchanged; every internal `trackUsage` keeps its operation names. The route keeps its auth, link-id-vs-org-id resolution (:110-140), and response shape, then delegates.
+
+Gate: `pnpm test && pnpm typecheck` green (no unit tests target the route internals today; this is a compile-and-suite gate). Commit: `refactor(enrich): extract enrichAndFindContacts service`
+
+---
+
+### Task 6: List agent tools (TDD)
+
+**Files:**
+
+- Create: `src/lib/tools/target-list-tools.ts`
+- Modify: `src/lib/tools/index.ts` (register: `getTargetLists`, `getTargetList`, `linkTargetListToCampaign`, `prioritizeTargetAccounts` [Task 7], `enrichTargetAccounts` [Task 8])
+- Test: `src/__tests__/target-list-tools.test.ts`
+
+Three tools in this task (all `createClient()` RLS, zod inputs, description text that tells the model when to use them):
+
+- `getTargetLists()` — lists mine, newest first, with row_count.
+- `getTargetList({ listId })` — list meta + first 25 accounts (org name/domain + enrichment_status) + counts: total, enriched, enrich-queued. This is what the agent quotes progress from.
+- `linkTargetListToCampaign({ listId, campaignId })` — loads all `target_accounts.organization_id` for the list (ownership via RLS), bulk-upserts `campaign_organizations` rows `{campaign_id, organization_id}` with `onConflict: "campaign_id,organization_id", ignoreDuplicates: true` in chunks of 500. Returns `{ linked, alreadyLinked }`. Do NOT loop `linkOrganizationToCampaign` per-row (N round-trips; audited phantom-membership caveat is fine here — creating `discovered/0` memberships is exactly the intent, they get scored next).
+
+Tests: link upsert carries the right onConflict; idempotent second call reports alreadyLinked; getTargetList count shape.
+
+Commit: `feat(agent): target list tools — get, link to campaign`
+
+---
+
+### Task 7: `prioritizeTargetAccounts` — scorer service + tool (TDD)
+
+**Files:**
+
+- Create: `src/lib/services/target-account-scorer.ts`
+- Modify: `src/lib/tools/target-list-tools.ts`
+- Test: `src/__tests__/target-account-scorer.test.ts`
+
+**Service** — clone `department-classifier.ts` structurally (CHUNK_SIZE 25, id-keyed schema, drop hallucinated ids) and `refresh-scores/route.ts:139-176` for the rubric shape:
+
+```ts
+export async function scoreTargetAccounts(input: {
+  campaign: { id: string; name: string; icp: CampaignIcp; offering: unknown };
+  accounts: Array<{
+    organizationId: string;
+    name: string;
+    domain: string | null;
+    industry: string | null;
+    location: string | null;
+    raw: Record<string, string>;
+  }>;
+  userId: string;
+}): Promise<Array<{ organizationId: string; score: number; reason: string }>>;
+```
+
+- `MODELS.STRUCTURED` (sonnet), `providerOptions.anthropic.cacheControl: {type:"ephemeral"}` on the rubric block, `llmTimeout()` abort signal.
+- Prompt: ICP + offering (trusted) above; account rows via `wrapUntrusted` below; explicit bands mirroring the system-prompt rubric — 8-10 strong ICP fit, 6-7 plausible, ≤5 weak; "score from the base data given; do not invent facts; reason ≤ 140 chars".
+- `trackUsage({service:"claude", operation:"prioritize-target-accounts", …, campaign_id, user_id})` per chunk.
+
+**Tool** `prioritizeTargetAccounts({ listId, campaignId, topFraction = 0.1 })`:
+
+1. **Hard gate:** load campaign; if `!campaign.icp?.targetTitles?.length` → return `{ error: "This campaign has no ICP yet. Interview the user (who do they want to reach? what are they selling?) and call saveCampaign first." }` — mirror the `needsVoice` gate wording style.
+2. Require the list linked (count `campaign_organizations` for the list's orgs; if none, tell the model to call `linkTargetListToCampaign`).
+3. Score ONLY accounts not already scored (`relevance_score = 0 or null`) so re-runs are cheap; write per-org: `campaign_organizations.relevance_score, score_reason, status: score >= 6 ? "qualified" : "disqualified"` (existing rubric).
+4. Return `{ scored, topSlice: [{organizationId, name, score, reason}...ceil(total*topFraction)], estimatedEnrichCostUsd: slice.length * 0.08, note }` — the agent presents this and asks for approval; the tool description says so explicitly ("NEVER call enrichTargetAccounts without the user approving the quoted cost").
+
+Tests: no-ICP gate returns error without any LLM call; chunking (26 accounts → 2 calls with mocked `generateObject`); writes keyed by organizationId; hallucinated org ids from the model are dropped; already-scored rows excluded.
+
+Commit: `feat(agent): prioritize target accounts against campaign ICP`
+
+---
+
+### Task 8: Enrichment tranche — tool + QStash chain route (TDD on the pure picker)
+
+**Files:**
+
+- Create: `src/app/api/target-lists/process/route.ts`
+- Modify: `src/lib/tools/target-list-tools.ts` (add `enrichTargetAccounts`)
+- Modify: `src/proxy.ts` (add `"/api/target-lists/process(.*)"` to public routes — explicit path, not a wildcard prefix)
+- Test: `src/__tests__/target-list-process.test.ts`
+
+**Tool** `enrichTargetAccounts({ listId, campaignId, organizationIds })`:
+
+- RLS-verify the list is mine and orgs belong to it; stamp `enrich_requested_at = now()` on those `target_accounts`; publish ONE QStash message `{ listId, campaignId, userId }` to `getBaseUrl() + "/api/target-lists/process"`; return `{ queued: n, note: "Enrichment runs in the background (~1 min/company). Ask me for progress." }`.
+- If QStash env is missing (`getQStashClient` throws), return a clear error naming the integration — don't fall back to inline enrichment.
+
+**Route** (QStash-signed, admin client, `maxDuration = 120`, `runtime` default node):
+
+```ts
+const BATCH_PER_INVOCATION = 2;
+
+export async function POST(request: Request) {
+  let payload; // verifyQStashSignature<{listId; campaignId; userId}> — 401 on throw, 400 on null
+  const supabase = getAdminClient();
+  const work = await pickEnrichBatch(supabase, payload.listId, BATCH_PER_INVOCATION);
+  for (const account of work) {
+    try {
+      await withAction(`Enrich target account: ${account.orgName}`, () =>
+        enrichAndFindContacts(supabase, account.organizationId, payload.campaignId));
+    } catch (err) {
+      console.error(`[target-lists/process] enrich failed for org ${account.organizationId}:`, err);
+      // org enrichment_status stays 'pending'/'failed'; do not retry here —
+      // clear enrich_requested_at so the chain can't loop on a poison row
+      await supabase.from("target_accounts").update({ enrich_requested_at: null })
+        .eq("list_id", payload.listId).eq("organization_id", account.organizationId);
+    }
+  }
+  const remaining = await countRemaining(supabase, payload.listId);
+  if (remaining > 0) {
+    await getQStashClient().publishJSON({ url: …same route…, body: payload });
+  }
+  return NextResponse.json({ processed: work.length, remaining });
+}
+```
+
+`pickEnrichBatch` (exported, pure-ish, unit-tested with fakeSupabase): `target_accounts` where `list_id`, `enrich_requested_at not null`, joined org `enrichment_status = 'pending'`, oldest `enrich_requested_at` first, limit N. Note the join filter means already-enriched orgs (shared pool) drain instantly without spend — desired. `countRemaining` = same filters, count only.
+
+Tests: picker query shape (filters + limit); poison-row clears `enrich_requested_at`; re-publish only when remaining > 0 (mock QStash client); 401 pathway via mocked `verifyQStashSignature`.
+
+Commit: `feat(target-lists): background enrichment chain via QStash`
+
+---
+
+### Task 9: Chat upload intercept
+
+**Files:**
+
+- Modify: `src/app/chat/[id]/page.tsx:137-140` (replace `onCsvUpload`)
+- Modify: `src/components/chat/chat-input.tsx:66-82` (add a 5 MB size guard + toast; keep `readAsText`)
+
+New `onCsvUpload`: parse with `parseCSV` + `mapColumns` from `@/lib/csv/company-csv`; if unmapped headers exist, POST them to the header-mapper via the accounts payload (server maps; client stays dumb — put unmapped columns in `extra` and let the server run header-mapper once per import when `extra` keys look canonical-ish; simplest: server-side in `appendAccountsToList` when `rows[0].extra` present). Create list (`POST /api/target-lists` with filename), append in 500-row batches with a progress toast (`sonner`), then:
+
+```ts
+sendMessage(
+  {
+    text: `I've uploaded a target account list "${fileName}" — ${imported} companies imported (${skipped} duplicates skipped), list ID ${listId}. Please help me work this list.`,
+  },
+  requestOptions,
+);
+```
+
+Failure paths: partial batch failure → still send the message with accurate counts + "some rows failed"; total failure → toast, no message. No test file (client glue); covered by manual E2E.
+
+Commit: `feat(chat): CSV upload creates a target list instead of pasting into context`
+
+---
+
+### Task 10: System prompt — the target-list pipeline
+
+**Files:**
+
+- Modify: `src/lib/system-prompt.ts` (new subsection near the pipeline block at :90-101)
+
+Add (adjust wording to the file's voice):
+
+```
+### Target account lists
+When the user uploads a target account list (you'll see "list ID ..."):
+1. If no campaign exists or the campaign has no ICP/offering: interview the
+   user first — who do they want to reach (titles/personas)? what are they
+   selling? Keep it to 2-3 questions, then saveCampaign.
+2. linkTargetListToCampaign, then prioritizeTargetAccounts. Present the top
+   slice with scores and the quoted enrichment cost, and ASK before enriching.
+3. On approval, enrichTargetAccounts. It runs in the background — check
+   progress with getTargetList when asked; don't poll in a loop.
+4. After enrichment: contacts were auto-found for qualified accounts. Apply
+   the coverage check (below) before drafting outreach.
+5. "Do more" = prioritize/enrich the next slice. Never enrich the whole list
+   unprompted.
+```
+
+Gate: `pnpm test src/__tests__/email-base-prompt.test.ts` (prompt-length budget test) still green — if the budget trips, tighten wording, don't raise the budget.
+
+Commit: `feat(prompt): target-account-list pipeline guidance`
+
+---
+
+### Task 11: Full sweep + manual E2E
+
+1. `pnpm typecheck && pnpm lint && pnpm test` — all green.
+2. Manual E2E (`pnpm dev`): drop a real messy CSV (odd headers, quoted commas, dupes) into chat → list receipt message; agent interviews → saveCampaign; prioritize → top-slice + cost quote; approve → QStash chain enriches (watch `target_accounts`/`organizations` rows); `getTargetList` progress mid-run; contacts appear on qualified accounts; draft one email end-to-end.
+3. Ops note for PR body: QStash must be configured; the process route is self-chaining (no schedule needed).
+
+Commit: `docs: target-lists plan as built` + push + PR.

--- a/docs/plans/2026-07-30-target-account-lists.md
+++ b/docs/plans/2026-07-30-target-account-lists.md
@@ -154,6 +154,13 @@ export interface TargetAccountRow {
   industry?: string | null;
   location?: string | null;
   description?: string | null;
+  /** Present when the file is contact-per-row (e.g. Apollo/Clay exports). */
+  person?: {
+    name: string;
+    title?: string | null;
+    email?: string | null;
+    linkedin_url?: string | null;
+  } | null;
   /** Everything else from the original row, preserved verbatim. */
   extra?: Record<string, string>;
 }
@@ -171,7 +178,10 @@ Commit with Task 3 (no behavior yet).
 - Create: `src/lib/csv/header-mapper.ts` (server-side Haiku fallback for unrecognized headers)
 - Test: `src/__tests__/company-csv.test.ts`, `src/__tests__/header-mapper.test.ts`
 
-**Step 1: Failing tests for the extraction** — exercise `parseCSV` (quoted fields, commas inside quotes, CRLF), `mapColumns` (aliases: `company_name→name`, `website→domain`, `hq→location`; first-column fallback to name; unmapped headers land in `extra`). Note: `mapColumns` today drops unmapped columns — extend it to collect them into `extra` (that's the only behavior change; `csv-upload.tsx` ignores `extra`).
+**Step 1: Failing tests for the extraction** — exercise `parseCSV` (quoted fields, commas inside quotes, CRLF), `mapColumns` (aliases: `company_name→name`, `website→domain`, `hq→location`; first-column fallback to name; unmapped headers land in `extra`). Two behavior extensions vs today's component code:
+
+1. Unmapped columns are collected into `extra` (today they're dropped; `csv-upload.tsx` ignores `extra`).
+2. **Person-column detection** for contact-per-row exports (Apollo/Clay/CRM): aliases `first_name`+`last_name`/`full_name`/`contact name`→person.name, `title`/`job_title`/`role`→person.title, `email`/`work_email`/`contact email`→person.email, `linkedin`/`linkedin_url`/`person_linkedin`→person.linkedin_url. When person columns exist, each row carries `person`; company fields dedupe across rows at import. Disambiguation rule: a bare `name` column maps to the COMPANY when a separate company column exists, else to the company (companies-only files unchanged); a bare `email` column is the person's. Tests: contact-per-row file (3 rows, 2 companies) maps correctly; companies-only file yields `person: null` everywhere.
 
 **Step 2:** Red. **Step 3:** Move code + add `extra` collection. **Step 4:** Green, plus `pnpm test src/__tests__/import-csv-batching.test.ts` still green (component unchanged behaviorally).
 
@@ -230,6 +240,26 @@ Implementation notes for the executor: `findOrCreateOrganization` builds its own
 **Tests (fakeSupabase):** append dedups within batch by resolved org; upsert carries `onConflict: "list_id,organization_id"`; row_count updated; 413 shape.
 
 Commit: `feat(target-lists): create/append API with org resolution`
+
+---
+
+### Task 4b: Import people from contact-per-row files (TDD)
+
+**Files:**
+
+- Modify: `src/lib/services/target-lists.ts` (extend `appendAccountsToList`)
+- Test: extend `src/__tests__/target-lists-service.test.ts`
+
+When rows carry `person`, after resolving the org:
+
+- `findOrCreatePerson` (knowledge-base.ts — dedup by linkedin_url, fallback name+org) with `organization_id`, `title`, `source: "target_list"`.
+- Email: store on the person as the data-quality schema expects for a user-provided address — **`unchecked` verification status** (imported emails are free suggestions; Hunter proves at send). Executor: read `supabase/migrations/20260801000000_contact_data_quality.sql` and `src/lib/services/affiliation.ts` first and record affiliation provenance the same way the CSV/import path is expected to (`evidence: "csv_import"`-equivalent) — copy the convention, don't invent one.
+- Return shape gains `peopleImported`. Multiple rows for one company must produce one org + N people (test this).
+- NOT linked to any campaign yet — `linkTargetListToCampaign` (Task 6) additionally upserts `campaign_people` for imported people whose org is being linked (status `pending`, same ignore-duplicates pattern).
+
+Tests: contact-per-row batch → 1 org, 3 people, dedup by linkedin_url on re-import; companies-only rows skip people entirely; link tool upserts campaign_people.
+
+Commit: `feat(target-lists): import contacts from contact-per-row files`
 
 ---
 
@@ -331,7 +361,9 @@ Commit: `feat(agent): prioritize target accounts against campaign ICP`
 - Modify: `src/proxy.ts` (add `"/api/target-lists/process(.*)"` to public routes — explicit path, not a wildcard prefix)
 - Test: `src/__tests__/target-list-process.test.ts`
 
-**Tool** `enrichTargetAccounts({ listId, campaignId, organizationIds })`:
+**Tool** `enrichTargetAccounts({ listId, campaignId, organizationIds, skipContactFinding = false })`:
+
+- `skipContactFinding` is for accounts whose imported contacts already match the ICP — the agent decides per tranche (it can split accounts across two calls). The process route passes it through to skip `findContactsForOrganization` and only run company enrichment.
 
 - RLS-verify the list is mine and orgs belong to it; stamp `enrich_requested_at = now()` on those `target_accounts`; publish ONE QStash message `{ listId, campaignId, userId }` to `getBaseUrl() + "/api/target-lists/process"`; return `{ queued: n, note: "Enrichment runs in the background (~1 min/company). Ask me for progress." }`.
 - If QStash env is missing (`getQStashClient` throws), return a clear error naming the integration — don't fall back to inline enrichment.
@@ -417,7 +449,11 @@ When the user uploads a target account list (you'll see "list ID ..."):
    progress with getTargetList when asked; don't poll in a loop.
 4. After enrichment: contacts were auto-found for qualified accounts. Apply
    the coverage check (below) before drafting outreach.
-5. "Do more" = prioritize/enrich the next slice. Never enrich the whole list
+5. If the upload included contacts: compare imported titles to the ICP before
+   enriching. Skip contact-finding (skipContactFinding: true) for accounts
+   whose imported contacts already match — tell the user what that saves.
+   Apply the coverage check where imported contacts look thin.
+6. "Do more" = prioritize/enrich the next slice. Never enrich the whole list
    unprompted.
 ```
 

--- a/docs/plans/2026-07-30-target-account-lists.md
+++ b/docs/plans/2026-07-30-target-account-lists.md
@@ -9,7 +9,14 @@
 
 **Tech Stack:** Next.js 16 App Router, Supabase RLS (Clerk `requesting_user_id()`), QStash, Vercel AI SDK `generateObject` + zod, Vitest.
 
-**Branch:** `feat/target-account-lists` (created, off current main which includes the Gmail transport).
+**Branch:** `feat/target-accounts` (off main @ 42f8a5a, which includes the Gmail transport AND the contact-data-quality work — lazy email verification, affiliation provenance, consolidated contact discovery).
+
+**Re-verified 2026-07-31 against main @ 42f8a5a.** Four amendments vs the original draft:
+
+1. Migration slot is now `20260801000002` (data-quality migrations took 20260801000000/1).
+2. Task 5 shrank: contact-finding was already consolidated into `src/lib/services/contact-discovery.ts` — `findContactsForOrganization(supabase, {organizationId, campaignId, titles, numResults})` already takes a client param. Only `enrichOrganization` still needs extracting from the route.
+3. Task 8's service composes `enrichOrganization` (extracted) + `findContactsForOrganization` (existing) under the admin client.
+4. E2E expectations: discovered contact emails now arrive as `unchecked` by design (owner decision: discovery is free, Hunter verification happens just-in-time inside `claimAndSendDraft`, bounded by the daily send cap). Enrichment output includes affiliation provenance. The tranche flow is unchanged.
 
 **Conventions the executor must follow (from the 2026-07-30 audits):**
 
@@ -25,7 +32,7 @@
 
 **Files:**
 
-- Create: `supabase/migrations/20260731000000_target_account_lists.sql`
+- Create: `supabase/migrations/20260801000002_target_account_lists.sql`
 
 **Step 1: Write it** (shape copied from `20260729000000_email_voice_profiles.sql` — transaction, lock timeouts, named policies, updated_at trigger):
 
@@ -233,9 +240,10 @@ Commit: `feat(target-lists): create/append API with org resolution`
 - Create: `src/lib/services/company-enrichment.ts`
 - Modify: `src/app/api/enrich-company/route.ts` (becomes a thin wrapper)
 
-Mechanical move, no behavior change. From `enrich-company/route.ts` move:
+Mechanical move, no behavior change — SMALLER than originally scoped: contact-finding already lives in `src/lib/services/contact-discovery.ts` (`findContactsForOrganization`, client-parameterized, added by the data-quality work). From `enrich-company/route.ts` move only:
 
-- `enrichOrganization(...)` (route.ts:312) and `findContactsForCompany(...)` (route.ts:166), `getActiveSignalSlugs` (:34) and the four `SIGNAL_SLUG_*` constants (:28-31).
+- `enrichOrganization(...)` (route.ts:200) plus `getActiveSignalSlugs` (:26) and the `SIGNAL_SLUG_*` constants; fold in the thin `findContactsForCompany` wrapper (:165) — it just loads ICP titles and calls `findContactsForOrganization`.
+- Every moved function takes an explicit `SupabaseClient` (they currently call `createClient()` internally — that breaks under the QStash admin client) and returns plain data, not `Response.json` (the route wraps).
 - New exported entry point:
 
 ```ts

--- a/src/__tests__/affiliation.test.ts
+++ b/src/__tests__/affiliation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import {
+  AFFILIATION_SEND_THRESHOLD,
   AFFILIATION_WEIGHT,
   normalizeCompanyName,
   parseLinkedInEmployer,
@@ -183,6 +184,74 @@ describe("recordAffiliation", () => {
     });
 
     expect(people[0].organization_id).toBe("org-a");
+  });
+
+  it("does not let a csv upload move a contact away from a verified employer", async () => {
+    // Machine verification outranks an upload. email_domain (0.95) was earned
+    // by a deliverable mailbox at the employer's own domain; a CSV row is
+    // routinely an AI-generated prospect list or a stale export, so it must
+    // not be able to reassign the contact.
+    seed({
+      organization_id: "org-a",
+      affiliation_source: "email_domain",
+      affiliation_confidence: AFFILIATION_WEIGHT.email_domain,
+    });
+
+    await recordAffiliation(client(), {
+      personId: "p1",
+      organizationId: "org-b",
+      source: "csv_import",
+      evidence: "the user's uploaded target list places them at org-b",
+    });
+
+    expect(people[0].organization_id).toBe("org-a");
+    expect(people[0].affiliation_source).toBe("email_domain");
+  });
+
+  it("does not grant csv_import the human-override move user_entered has", async () => {
+    // Only user_entered bypasses the strictly-stronger rule. An upload is not
+    // a human assertion — if csv_import triggered the override, re-importing
+    // a stale list would silently undo hand-made corrections.
+    seed({
+      organization_id: "org-a",
+      affiliation_source: "user_entered",
+      affiliation_confidence: AFFILIATION_WEIGHT.user_entered,
+    });
+
+    await recordAffiliation(client(), {
+      personId: "p1",
+      organizationId: "org-b",
+      source: "csv_import",
+      evidence: "the user's uploaded target list places them at org-b",
+    });
+
+    expect(people[0].organization_id).toBe("org-a");
+    expect(people[0].affiliation_source).toBe("user_entered");
+  });
+
+  it("puts an imported contact above the send threshold", async () => {
+    // The point of ranking csv_import at 0.85 rather than treating it as
+    // noise: an imported contact is immediately draftable.
+    await recordAffiliation(client(), {
+      personId: "p1",
+      organizationId: "org-a",
+      source: "csv_import",
+      evidence: "the user's uploaded target list places them at org-a",
+    });
+
+    expect(people[0].affiliation_confidence).toBe(
+      AFFILIATION_WEIGHT.csv_import,
+    );
+    expect(AFFILIATION_WEIGHT.csv_import).toBeGreaterThanOrEqual(
+      AFFILIATION_SEND_THRESHOLD,
+    );
+    // And the machine-verification / human ordering that makes it overridable:
+    expect(AFFILIATION_WEIGHT.csv_import).toBeLessThan(
+      AFFILIATION_WEIGHT.email_domain,
+    );
+    expect(AFFILIATION_WEIGHT.csv_import).toBeLessThan(
+      AFFILIATION_WEIGHT.user_entered,
+    );
   });
 
   it("detaches someone when strictly stronger evidence points elsewhere", async () => {

--- a/src/__tests__/company-csv.test.ts
+++ b/src/__tests__/company-csv.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+
+import { COLUMN_MAP, mapColumns, parseCSV } from "@/lib/csv/company-csv";
+
+describe("parseCSV", () => {
+  it("parses headers and rows", () => {
+    const { headers, rows } = parseCSV(
+      "name,domain\nAcme,acme.com\nBeta,beta.io",
+    );
+    expect(headers).toEqual(["name", "domain"]);
+    expect(rows).toEqual([
+      ["Acme", "acme.com"],
+      ["Beta", "beta.io"],
+    ]);
+  });
+
+  it("handles quoted fields with commas and escaped quotes", () => {
+    const { headers, rows } = parseCSV(
+      'name,description\n"Acme, Inc","Makes ""things"", well"',
+    );
+    expect(headers).toEqual(["name", "description"]);
+    expect(rows).toEqual([["Acme, Inc", 'Makes "things", well']]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const { rows } = parseCSV(
+      "name,domain\r\nAcme,acme.com\r\nBeta,beta.io\r\n",
+    );
+    expect(rows).toEqual([
+      ["Acme", "acme.com"],
+      ["Beta", "beta.io"],
+    ]);
+  });
+
+  it("keeps newlines inside quoted fields", () => {
+    const { rows } = parseCSV('name,notes\n"Acme","line one\nline two"');
+    expect(rows).toEqual([["Acme", "line one\nline two"]]);
+  });
+
+  it("drops rows that are entirely empty", () => {
+    const { rows } = parseCSV("name,domain\nAcme,acme.com\n,\n");
+    expect(rows).toEqual([["Acme", "acme.com"]]);
+  });
+
+  it("returns empty shape for empty input", () => {
+    expect(parseCSV("")).toEqual({ headers: [], rows: [] });
+  });
+});
+
+describe("mapColumns — company fields", () => {
+  it("maps common aliases (company_name→name, website→domain, hq→location)", () => {
+    const rows = mapColumns(
+      ["company_name", "website", "hq"],
+      [["Acme", "acme.com", "Berlin"]],
+    );
+    expect(rows[0]).toMatchObject({
+      name: "Acme",
+      domain: "acme.com",
+      location: "Berlin",
+    });
+    expect(COLUMN_MAP["company name"]).toBe("name");
+  });
+
+  it("falls back to the first column when no name column maps", () => {
+    const rows = mapColumns(["brand", "industry"], [["Acme", "SaaS"]]);
+    expect(rows[0].name).toBe("Acme");
+    expect(rows[0].industry).toBe("SaaS");
+  });
+
+  it("derives domain from url when domain is missing", () => {
+    const rows = mapColumns(
+      ["company", "url"],
+      [["Acme", "https://www.acme.com/about"]],
+    );
+    expect(rows[0].domain).toBe("acme.com");
+    expect(rows[0].url).toBe("https://www.acme.com/about");
+  });
+
+  it("collects unmapped columns into extra, keyed by original header", () => {
+    const rows = mapColumns(
+      ["company", "Employee Count", "Funding Stage"],
+      [
+        ["Acme", "120", "Series B"],
+        ["Beta", "", "Seed"],
+      ],
+    );
+    expect(rows[0].extra).toEqual({
+      "Employee Count": "120",
+      "Funding Stage": "Series B",
+    });
+    // empty cells are not preserved as extra keys
+    expect(rows[1].extra).toEqual({ "Funding Stage": "Seed" });
+  });
+
+  it("omits extra when every column is mapped", () => {
+    const rows = mapColumns(["company", "website"], [["Acme", "acme.com"]]);
+    expect(rows[0].extra).toBeUndefined();
+  });
+});
+
+describe("mapColumns — person columns (contact-per-row files)", () => {
+  it("maps a contact-per-row file: 3 rows, 2 companies, person on every row", () => {
+    const rows = mapColumns(
+      [
+        "first_name",
+        "last_name",
+        "title",
+        "email",
+        "linkedin_url",
+        "company",
+        "website",
+      ],
+      [
+        [
+          "Jane",
+          "Doe",
+          "VP Sales",
+          "jane@acme.com",
+          "https://linkedin.com/in/jane",
+          "Acme",
+          "acme.com",
+        ],
+        [
+          "John",
+          "Smith",
+          "CTO",
+          "john@acme.com",
+          "https://linkedin.com/in/john",
+          "Acme",
+          "acme.com",
+        ],
+        [
+          "Ann",
+          "Lee",
+          "CEO",
+          "ann@beta.io",
+          "https://linkedin.com/in/ann",
+          "Beta",
+          "beta.io",
+        ],
+      ],
+    );
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.name)).toEqual(["Acme", "Acme", "Beta"]);
+    expect(new Set(rows.map((r) => r.domain))).toEqual(
+      new Set(["acme.com", "beta.io"]),
+    );
+    expect(rows[0].person).toEqual({
+      name: "Jane Doe",
+      title: "VP Sales",
+      email: "jane@acme.com",
+      linkedin_url: "https://linkedin.com/in/jane",
+    });
+    expect(rows[2].person).toEqual({
+      name: "Ann Lee",
+      title: "CEO",
+      email: "ann@beta.io",
+      linkedin_url: "https://linkedin.com/in/ann",
+    });
+    // person columns do not leak into extra
+    for (const r of rows) expect(r.extra).toBeUndefined();
+  });
+
+  it("maps full_name / job_title / work_email / person_linkedin aliases", () => {
+    const rows = mapColumns(
+      [
+        "full_name",
+        "job_title",
+        "work_email",
+        "person_linkedin",
+        "organization",
+      ],
+      [
+        [
+          "Jane Doe",
+          "Head of Ops",
+          "jane@acme.com",
+          "https://linkedin.com/in/jane",
+          "Acme",
+        ],
+      ],
+    );
+    expect(rows[0].name).toBe("Acme");
+    expect(rows[0].person).toEqual({
+      name: "Jane Doe",
+      title: "Head of Ops",
+      email: "jane@acme.com",
+      linkedin_url: "https://linkedin.com/in/jane",
+    });
+  });
+
+  it("maps 'contact name' and 'contact email' aliases", () => {
+    const rows = mapColumns(
+      ["Contact Name", "Contact Email", "Company"],
+      [["Jane Doe", "jane@acme.com", "Acme"]],
+    );
+    expect(rows[0].name).toBe("Acme");
+    expect(rows[0].person).toEqual({
+      name: "Jane Doe",
+      title: null,
+      email: "jane@acme.com",
+      linkedin_url: null,
+    });
+  });
+
+  it("keeps a bare name column as the COMPANY even alongside person columns", () => {
+    // Clay-style export: "name" is the company, "full_name" is the person.
+    const rows = mapColumns(
+      ["name", "full_name", "email"],
+      [["Acme", "Jane Doe", "jane@acme.com"]],
+    );
+    expect(rows[0].name).toBe("Acme");
+    expect(rows[0].person).toMatchObject({
+      name: "Jane Doe",
+      email: "jane@acme.com",
+    });
+  });
+
+  it("yields person: null on every row of a companies-only file", () => {
+    const rows = mapColumns(
+      ["company", "website", "industry"],
+      [
+        ["Acme", "acme.com", "SaaS"],
+        ["Beta", "beta.io", "Fintech"],
+      ],
+    );
+    for (const r of rows) expect(r.person).toBeNull();
+  });
+
+  it("does not enter person mode without a person-name column", () => {
+    // title/email alone are ambiguous — without a person name they stay extra.
+    const rows = mapColumns(
+      ["company", "title", "email"],
+      [["Acme", "Some Report", "info@acme.com"]],
+    );
+    expect(rows[0].person).toBeNull();
+    expect(rows[0].extra).toEqual({
+      title: "Some Report",
+      email: "info@acme.com",
+    });
+  });
+
+  it("yields person: null on rows where the person name cells are empty", () => {
+    const rows = mapColumns(
+      ["first_name", "last_name", "email", "company"],
+      [
+        ["Jane", "Doe", "jane@acme.com", "Acme"],
+        ["", "", "info@beta.io", "Beta"],
+      ],
+    );
+    expect(rows[0].person).toMatchObject({ name: "Jane Doe" });
+    expect(rows[1].person).toBeNull();
+  });
+});

--- a/src/__tests__/email-pattern.test.ts
+++ b/src/__tests__/email-pattern.test.ts
@@ -31,6 +31,7 @@ interface PersonRow {
   work_email_source: EmailSource | null;
   work_email_confidence: number | null;
   work_email_verified_at: string | null;
+  work_email_verification: string | null;
 }
 interface OrgRow {
   id: string;
@@ -56,6 +57,7 @@ function createFakeSupabase(initial: {
       work_email_source: null,
       work_email_confidence: null,
       work_email_verified_at: null,
+      work_email_verification: null,
       ...p,
     })) as PersonRow[],
     organizations: (initial.organizations ?? []).map((o) => ({
@@ -444,6 +446,64 @@ describe("recordVerifiedEmail", () => {
     });
     expect(tables.people[0].work_email_source).toBe("user_entered");
     expect(tables.people[0].work_email_confidence).toBeCloseTo(1.0);
+  });
+
+  it("does NOT let csv_import displace an existing deliverable address", async () => {
+    // A CSV upload is often AI-generated or a stale export. The address a
+    // provider found — and a verifier has since proven deliverable — must
+    // survive a re-import carrying a different (possibly hallucinated) one.
+    // csv_import (0.5) sits below provider_found (0.75) and team_page (0.7),
+    // so the different-email write is refused and the verdict stays intact.
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "jane@acme.com",
+          work_email_source: "provider_found",
+          work_email_confidence: 0.75,
+          work_email_verification: "deliverable",
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane.doe@acme.com",
+      source: "csv_import",
+    });
+    expect(tables.people[0].work_email).toBe("jane@acme.com");
+    expect(tables.people[0].work_email_source).toBe("provider_found");
+    expect(tables.people[0].work_email_verification).toBe("deliverable");
+  });
+
+  it("writes a csv_import address over a bare exa_search suggestion", async () => {
+    // Below the verified-ish sources but above a string Exa found near a
+    // name: an upload is still an answer about this specific person.
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: "o1",
+          work_email: "j.doe@acme.com",
+          work_email_source: "exa_search",
+          work_email_confidence: 0.3,
+        },
+      ],
+      organizations: [{ id: "o1" }],
+    });
+    await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane.doe@acme.com",
+      source: "csv_import",
+    });
+    expect(tables.people[0].work_email).toBe("jane.doe@acme.com");
+    expect(tables.people[0].work_email_source).toBe("csv_import");
+    // The new address carries no verdict — the send gate's just-in-time
+    // verifier still has to prove it before anything leaves.
+    expect(tables.people[0].work_email_verification).toBeNull();
   });
 
   it("keeps the stronger source on a same-email refresh with weaker source", async () => {

--- a/src/__tests__/header-mapper.test.ts
+++ b/src/__tests__/header-mapper.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * header-mapper is the LLM fallback for CSV headers COLUMN_MAP doesn't
+ * recognize. The invariants: known aliases never cost an LLM call, the model
+ * only ever sees the unknowns (wrapped as untrusted), hallucinated headers are
+ * dropped, and any failure degrades to "ignore" — never a thrown error.
+ */
+
+const generateObjectMock = vi.fn();
+vi.mock("ai", () => ({
+  generateObject: (...args: unknown[]) => generateObjectMock(...args),
+}));
+vi.mock("@ai-sdk/anthropic", () => ({ anthropic: (model: string) => model }));
+// llmTimeout() returns AbortSignal.timeout(...), whose pending timer outlives
+// the test; the timeout is not under test here.
+vi.mock("@/lib/utils/timeout", () => ({ llmTimeout: () => undefined }));
+
+const trackUsageMock = vi.fn();
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: (...args: unknown[]) => trackUsageMock(...args),
+  estimateClaudeCostFromUsage: () => 0.0001,
+}));
+
+import { mapUnknownHeaders } from "@/lib/csv/header-mapper";
+import { MODELS } from "@/lib/ai/models";
+
+function reply(mappings: Array<{ header: string; field: string }>) {
+  generateObjectMock.mockResolvedValue({
+    object: { mappings },
+    usage: { inputTokens: 10, outputTokens: 5 },
+  });
+}
+
+beforeEach(() => {
+  generateObjectMock.mockReset();
+  trackUsageMock.mockReset();
+});
+
+describe("mapUnknownHeaders", () => {
+  it("returns {} for empty input without calling the model", async () => {
+    const out = await mapUnknownHeaders([]);
+    expect(out).toEqual({});
+    expect(generateObjectMock).not.toHaveBeenCalled();
+  });
+
+  it("passes known COLUMN_MAP aliases through without an LLM call", async () => {
+    const out = await mapUnknownHeaders([
+      { header: "Website", samples: ["acme.com"] },
+      { header: "HQ", samples: ["Berlin"] },
+    ]);
+    expect(out).toEqual({ Website: "domain", HQ: "location" });
+    expect(generateObjectMock).not.toHaveBeenCalled();
+  });
+
+  it("sends only the unknown headers to the model, wrapped as untrusted", async () => {
+    reply([{ header: "Web Address", field: "domain" }]);
+
+    const out = await mapUnknownHeaders([
+      { header: "Website", samples: ["acme.com"] },
+      { header: "Web Address", samples: ["beta.io", "gamma.dev"] },
+    ]);
+
+    expect(out).toEqual({ Website: "domain", "Web Address": "domain" });
+    expect(generateObjectMock).toHaveBeenCalledTimes(1);
+
+    const call = generateObjectMock.mock.calls[0][0] as {
+      model: string;
+      prompt: string;
+    };
+    expect(call.model).toBe(MODELS.LIGHT);
+    expect(call.prompt).toContain("<untrusted>");
+    expect(call.prompt).toContain("Web Address");
+    expect(call.prompt).toContain("beta.io");
+    // the already-known header is not sent to the model
+    const untrusted = call.prompt.slice(call.prompt.indexOf("<untrusted>"));
+    expect(untrusted).not.toContain("Website");
+  });
+
+  it("drops hallucinated headers and defaults omitted ones to ignore", async () => {
+    reply([
+      { header: "Ghost Column", field: "name" },
+      { header: "Web Address", field: "domain" },
+    ]);
+
+    const out = await mapUnknownHeaders([
+      { header: "Web Address", samples: ["beta.io"] },
+      { header: "Mystery", samples: ["???"] },
+    ]);
+
+    expect(out).toEqual({ "Web Address": "domain", Mystery: "ignore" });
+    expect(out["Ghost Column"]).toBeUndefined();
+  });
+
+  it("drops mappings whose field is not a canonical value", async () => {
+    reply([{ header: "Web Address", field: "person_email" }]);
+
+    const out = await mapUnknownHeaders([
+      { header: "Web Address", samples: ["beta.io"] },
+    ]);
+
+    expect(out).toEqual({ "Web Address": "ignore" });
+  });
+
+  it("falls back to ignore for every unknown header when the model fails", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Malformed response exercises the same catch as a thrown error without
+    // vitest attributing a mock-thrown error to the test itself.
+    generateObjectMock.mockResolvedValue({ object: null, usage: {} });
+
+    const out = await mapUnknownHeaders([
+      { header: "Website", samples: ["acme.com"] },
+      { header: "Mystery", samples: ["???"] },
+    ]);
+
+    expect(out).toEqual({ Website: "domain", Mystery: "ignore" });
+    quiet.mockRestore();
+  });
+
+  it("tracks usage per call with the csv-header-mapper operation", async () => {
+    reply([{ header: "Web Address", field: "domain" }]);
+
+    await mapUnknownHeaders([{ header: "Web Address", samples: ["beta.io"] }], {
+      userId: "user_1",
+    });
+
+    expect(trackUsageMock).toHaveBeenCalledTimes(1);
+    expect(trackUsageMock.mock.calls[0][0]).toMatchObject({
+      service: "claude",
+      operation: "csv-header-mapper",
+      user_id: "user_1",
+    });
+  });
+});

--- a/src/__tests__/send-gate.test.ts
+++ b/src/__tests__/send-gate.test.ts
@@ -81,6 +81,35 @@ describe("canSendTo", () => {
     ).toEqual({ ok: true });
   });
 
+  it("allows an imported contact once its address verifies — csv_import clears the threshold", () => {
+    // The whole point of ranking csv_import at 0.85: an uploaded contact is
+    // draftable and sendable as-is, without waiting for further enrichment.
+    const result = canSendTo(
+      p({
+        work_email_source: "csv_import",
+        work_email_verification: "deliverable",
+        affiliation_source: "csv_import",
+        affiliation_confidence: AFFILIATION_WEIGHT.csv_import,
+      }),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("does not trust an imported address without verification", () => {
+    // csv_import is deliberately absent from the trusted-source shortcuts:
+    // the just-in-time verifier must still prove an uploaded mailbox.
+    const result = canSendTo(
+      p({
+        work_email_source: "csv_import",
+        work_email_verification: "unchecked",
+        affiliation_source: "csv_import",
+        affiliation_confidence: AFFILIATION_WEIGHT.csv_import,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/never been verified/i);
+  });
+
   it("blocks a verified address at an unconfirmed employer", () => {
     // A real mailbox is not permission to pitch them about a company they may
     // not work for.

--- a/src/__tests__/target-account-scorer.test.ts
+++ b/src/__tests__/target-account-scorer.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * scoreTargetAccounts is the chunked sonnet scorer behind
+ * prioritizeTargetAccounts. Invariants: no accounts means no LLM call,
+ * chunks of 25, the rubric/ICP stay in the trusted block (with ephemeral
+ * cacheControl) while CSV-derived rows are wrapped as untrusted, usage is
+ * tracked per chunk, and hallucinated organizationIds are dropped.
+ */
+
+const generateObjectMock = vi.fn();
+vi.mock("ai", () => ({
+  generateObject: (...args: unknown[]) => generateObjectMock(...args),
+}));
+vi.mock("@ai-sdk/anthropic", () => ({ anthropic: (model: string) => model }));
+// llmTimeout() returns AbortSignal.timeout(...), whose pending timer outlives
+// the test; the timeout is not under test here.
+vi.mock("@/lib/utils/timeout", () => ({ llmTimeout: () => undefined }));
+
+const trackUsageMock = vi.fn();
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: (...args: unknown[]) => trackUsageMock(...args),
+  estimateClaudeCostFromUsage: () => 0.001,
+}));
+
+import { scoreTargetAccounts } from "@/lib/services/target-account-scorer";
+import { MODELS } from "@/lib/ai/models";
+
+interface CapturedCall {
+  model: string;
+  messages: Array<{
+    role: string;
+    content: string;
+    providerOptions?: Record<string, unknown>;
+  }>;
+}
+
+function account(i: number) {
+  return {
+    organizationId: `org_${i}`,
+    name: `Company ${i}`,
+    domain: `co${i}.example.com`,
+    industry: i % 2 === 0 ? "Fintech" : null,
+    location: null,
+    raw: { plan: "growth" },
+  };
+}
+
+const campaign = {
+  id: "camp_1",
+  name: "Q3 UK fintech",
+  icp: { targetTitles: ["CTO", "VP Engineering"], industry: "fintech" },
+  offering: { description: "API monitoring" },
+};
+
+function reply(
+  scores: Array<{ organizationId: string; score: number; reason: string }>,
+) {
+  generateObjectMock.mockResolvedValueOnce({
+    object: { scores },
+    usage: { inputTokens: 100, outputTokens: 50 },
+  });
+}
+
+beforeEach(() => {
+  generateObjectMock.mockReset();
+  trackUsageMock.mockReset();
+});
+
+describe("scoreTargetAccounts", () => {
+  it("returns [] without calling the model when there are no accounts", async () => {
+    const out = await scoreTargetAccounts({
+      campaign,
+      accounts: [],
+      userId: "user_1",
+    });
+    expect(out).toEqual([]);
+    expect(generateObjectMock).not.toHaveBeenCalled();
+    expect(trackUsageMock).not.toHaveBeenCalled();
+  });
+
+  it("splits 26 accounts into 2 chunks of 25 + 1", async () => {
+    reply([]);
+    reply([]);
+
+    const accounts = Array.from({ length: 26 }, (_, i) => account(i));
+    await scoreTargetAccounts({ campaign, accounts, userId: "user_1" });
+
+    expect(generateObjectMock).toHaveBeenCalledTimes(2);
+    const first = generateObjectMock.mock.calls[0][0] as CapturedCall;
+    const second = generateObjectMock.mock.calls[1][0] as CapturedCall;
+    const firstUser = first.messages.find((m) => m.role === "user")!.content;
+    const secondUser = second.messages.find((m) => m.role === "user")!.content;
+    expect(firstUser).toContain("org_24");
+    expect(firstUser).not.toContain("org_25");
+    expect(secondUser).toContain("org_25");
+    expect(secondUser).not.toContain("org_24");
+  });
+
+  it("keeps the rubric + ICP trusted (with cacheControl) and wraps account rows as untrusted", async () => {
+    reply([]);
+
+    await scoreTargetAccounts({
+      campaign,
+      accounts: [account(0)],
+      userId: "user_1",
+    });
+
+    const call = generateObjectMock.mock.calls[0][0] as CapturedCall;
+    expect(call.model).toBe(MODELS.STRUCTURED);
+
+    const system = call.messages.find((m) => m.role === "system")!;
+    // The rubric block is cacheable across chunks.
+    expect(system.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+    // ICP + offering live in the trusted block, with explicit bands.
+    expect(system.content).toContain("CTO");
+    expect(system.content).toContain("API monitoring");
+    expect(system.content).toMatch(/8-10/);
+    expect(system.content).toMatch(/6-7/);
+    expect(system.content).toMatch(/do not invent/i);
+
+    const user = call.messages.find((m) => m.role === "user")!;
+    expect(user.content).toContain("<untrusted>");
+    const untrusted = user.content.slice(user.content.indexOf("<untrusted>"));
+    expect(untrusted).toContain("Company 0");
+    // The ICP never leaks into the untrusted block.
+    expect(untrusted).not.toContain("VP Engineering");
+  });
+
+  it("drops hallucinated organizationIds and passes real ones through", async () => {
+    reply([
+      { organizationId: "org_0", score: 8, reason: "Strong fit" },
+      { organizationId: "org_i_made_up", score: 10, reason: "Nope" },
+    ]);
+
+    const out = await scoreTargetAccounts({
+      campaign,
+      accounts: [account(0), account(1)],
+      userId: "user_1",
+    });
+
+    expect(out).toEqual([
+      { organizationId: "org_0", score: 8, reason: "Strong fit" },
+    ]);
+  });
+
+  it("tracks usage once per chunk with campaign and user attribution", async () => {
+    reply([]);
+    reply([]);
+
+    const accounts = Array.from({ length: 26 }, (_, i) => account(i));
+    await scoreTargetAccounts({ campaign, accounts, userId: "user_1" });
+
+    expect(trackUsageMock).toHaveBeenCalledTimes(2);
+    for (const [entry] of trackUsageMock.mock.calls) {
+      expect(entry).toMatchObject({
+        service: "claude",
+        operation: "prioritize-target-accounts",
+        campaign_id: "camp_1",
+        user_id: "user_1",
+      });
+      expect(entry.estimated_cost_usd).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/__tests__/target-list-process.test.ts
+++ b/src/__tests__/target-list-process.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  verifySignatureMock,
+  getAdminClientMock,
+  publishJSONMock,
+  enrichMock,
+  withActionMock,
+} = vi.hoisted(() => ({
+  verifySignatureMock: vi.fn(),
+  getAdminClientMock: vi.fn(),
+  publishJSONMock: vi.fn(),
+  enrichMock: vi.fn(),
+  withActionMock: vi.fn(
+    (_label: string, fn: () => Promise<unknown>): Promise<unknown> => fn(),
+  ),
+}));
+
+vi.mock("@/lib/services/qstash", () => ({
+  verifyQStashSignature: verifySignatureMock,
+  getQStashClient: () => ({ publishJSON: publishJSONMock }),
+  getBaseUrl: () => "http://localhost:3000",
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: getAdminClientMock,
+}));
+vi.mock("@/lib/services/company-enrichment", () => ({
+  enrichAndFindContacts: enrichMock,
+}));
+vi.mock("@/lib/services/cost-tracker", () => ({
+  withAction: withActionMock,
+}));
+
+import {
+  POST,
+  pickEnrichBatch,
+  countRemaining,
+} from "@/app/api/target-lists/process/route";
+
+/** Same thenable query-builder fake as outreach-sender.test.ts. */
+function fakeSupabase(
+  responses: Array<{ data?: unknown; error?: unknown; count?: number }>,
+) {
+  let i = 0;
+  const calls: Array<{
+    table: string;
+    ops: Array<{ name: string; args: unknown[] }>;
+  }> = [];
+  const from = (table: string) => {
+    const call = { table, ops: [] as Array<{ name: string; args: unknown[] }> };
+    calls.push(call);
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "in",
+      "not",
+      "update",
+      "order",
+      "limit",
+      "single",
+    ]) {
+      builder[name] = (...args: unknown[]) => {
+        call.ops.push({ name, args });
+        return builder;
+      };
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+        resolve,
+        reject,
+      );
+    return builder;
+  };
+  return { client: { from } as never, calls };
+}
+
+function processRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/target-lists/process", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const payload = { listId: "list_1", campaignId: "camp_1", userId: "user_1" };
+
+const rowA = {
+  organization_id: "org_a",
+  organizations: { name: "Acme", enrichment_status: "pending" },
+};
+const rowB = {
+  organization_id: "org_b",
+  organizations: { name: "Beta Corp", enrichment_status: "pending" },
+};
+
+beforeEach(() => {
+  verifySignatureMock.mockReset();
+  verifySignatureMock.mockResolvedValue(payload);
+  getAdminClientMock.mockReset();
+  publishJSONMock.mockReset();
+  publishJSONMock.mockResolvedValue({ messageId: "msg_1" });
+  enrichMock.mockReset();
+  enrichMock.mockResolvedValue({
+    enriched: true,
+    contactsFound: 1,
+    errors: [],
+    enrichmentData: {},
+  });
+  withActionMock.mockClear();
+});
+
+describe("pickEnrichBatch", () => {
+  it("queries stamped rows with pending orgs, oldest first, limited", async () => {
+    const { client, calls } = fakeSupabase([{ data: [rowA, rowB] }]);
+
+    const batch = await pickEnrichBatch(client, "list_1", 2);
+
+    expect(batch).toEqual([
+      { organizationId: "org_a", orgName: "Acme" },
+      { organizationId: "org_b", orgName: "Beta Corp" },
+    ]);
+
+    const call = calls[0];
+    expect(call.table).toBe("target_accounts");
+    expect(call.ops).toContainEqual({
+      name: "eq",
+      args: ["list_id", "list_1"],
+    });
+    expect(call.ops).toContainEqual({
+      name: "not",
+      args: ["enrich_requested_at", "is", null],
+    });
+    expect(call.ops).toContainEqual({
+      name: "eq",
+      args: ["organizations.enrichment_status", "pending"],
+    });
+    expect(call.ops).toContainEqual({
+      name: "order",
+      args: ["enrich_requested_at", { ascending: true }],
+    });
+    expect(call.ops).toContainEqual({ name: "limit", args: [2] });
+  });
+
+  it("throws when the query errors", async () => {
+    const { client } = fakeSupabase([
+      { data: null, error: { message: "boom" } },
+    ]);
+    await expect(pickEnrichBatch(client, "list_1", 2)).rejects.toThrow("boom");
+  });
+});
+
+describe("countRemaining", () => {
+  it("counts with the same filters as the picker", async () => {
+    const { client, calls } = fakeSupabase([{ count: 7 }]);
+
+    const remaining = await countRemaining(client, "list_1");
+
+    expect(remaining).toBe(7);
+    const call = calls[0];
+    expect(call.table).toBe("target_accounts");
+    expect(call.ops).toContainEqual({
+      name: "eq",
+      args: ["list_id", "list_1"],
+    });
+    expect(call.ops).toContainEqual({
+      name: "not",
+      args: ["enrich_requested_at", "is", null],
+    });
+    expect(call.ops).toContainEqual({
+      name: "eq",
+      args: ["organizations.enrichment_status", "pending"],
+    });
+    // Head-only count — no rows shipped back per hop.
+    const select = call.ops.find((op) => op.name === "select");
+    expect(select?.args[1]).toMatchObject({ count: "exact", head: true });
+  });
+});
+
+describe("POST /api/target-lists/process", () => {
+  it("returns 401 when the QStash signature is invalid", async () => {
+    verifySignatureMock.mockRejectedValue(
+      new Error("Invalid QStash signature"),
+    );
+
+    const res = await POST(processRequest(payload));
+
+    expect(res.status).toBe(401);
+    expect(enrichMock).not.toHaveBeenCalled();
+    expect(publishJSONMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the payload is empty", async () => {
+    verifySignatureMock.mockResolvedValue(null);
+
+    const res = await POST(processRequest(payload));
+
+    expect(res.status).toBe(400);
+    expect(enrichMock).not.toHaveBeenCalled();
+  });
+
+  it("enriches the batch under withAction and re-publishes when work remains", async () => {
+    const { client } = fakeSupabase([
+      { data: [rowA, rowB] }, // pickEnrichBatch
+      { count: 3 }, // countRemaining
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+
+    const res = await POST(processRequest(payload));
+    const body = await res.json();
+
+    expect(body).toEqual({ processed: 2, remaining: 3 });
+    expect(enrichMock).toHaveBeenCalledTimes(2);
+    expect(enrichMock).toHaveBeenCalledWith(client, "org_a", "camp_1", {
+      skipContactFinding: false,
+    });
+    expect(withActionMock).toHaveBeenCalledWith(
+      "Enrich target account: Acme",
+      expect.any(Function),
+    );
+    expect(withActionMock).toHaveBeenCalledWith(
+      "Enrich target account: Beta Corp",
+      expect.any(Function),
+    );
+    // Chain continues: same payload, same route.
+    expect(publishJSONMock).toHaveBeenCalledTimes(1);
+    expect(publishJSONMock).toHaveBeenCalledWith({
+      url: "http://localhost:3000/api/target-lists/process",
+      body: payload,
+    });
+  });
+
+  it("does not re-publish when nothing remains", async () => {
+    const { client } = fakeSupabase([
+      { data: [rowA] }, // pickEnrichBatch
+      { count: 0 }, // countRemaining
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+
+    const res = await POST(processRequest(payload));
+    const body = await res.json();
+
+    expect(body).toEqual({ processed: 1, remaining: 0 });
+    expect(publishJSONMock).not.toHaveBeenCalled();
+  });
+
+  it("clears enrich_requested_at on a poison row and keeps processing", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: [rowA, rowB] }, // pickEnrichBatch
+      {}, // poison-row stamp clear
+      { count: 0 }, // countRemaining
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+    enrichMock
+      .mockRejectedValueOnce(new Error("enrichment exploded"))
+      .mockResolvedValueOnce({
+        enriched: true,
+        contactsFound: 0,
+        errors: [],
+        enrichmentData: {},
+      });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST(processRequest(payload));
+    const body = await res.json();
+
+    // Both accounts attempted despite the first blowing up.
+    expect(enrichMock).toHaveBeenCalledTimes(2);
+    expect(body).toEqual({ processed: 2, remaining: 0 });
+
+    // The poison row's stamp is cleared so the chain can't loop on it.
+    const clear = calls[1];
+    expect(clear.table).toBe("target_accounts");
+    expect(clear.ops).toContainEqual({
+      name: "update",
+      args: [{ enrich_requested_at: null }],
+    });
+    expect(clear.ops).toContainEqual({
+      name: "eq",
+      args: ["list_id", "list_1"],
+    });
+    expect(clear.ops).toContainEqual({
+      name: "eq",
+      args: ["organization_id", "org_a"],
+    });
+    errorSpy.mockRestore();
+  });
+
+  it("threads skipContactFinding through to enrichment", async () => {
+    verifySignatureMock.mockResolvedValue({
+      ...payload,
+      skipContactFinding: true,
+    });
+    const { client } = fakeSupabase([
+      { data: [rowA] }, // pickEnrichBatch
+      { count: 0 }, // countRemaining
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+
+    await POST(processRequest({ ...payload, skipContactFinding: true }));
+
+    expect(enrichMock).toHaveBeenCalledWith(client, "org_a", "camp_1", {
+      skipContactFinding: true,
+    });
+  });
+});

--- a/src/__tests__/target-list-process.test.ts
+++ b/src/__tests__/target-list-process.test.ts
@@ -59,6 +59,7 @@ function fakeSupabase(
       "order",
       "limit",
       "single",
+      "maybeSingle",
     ]) {
       builder[name] = (...args: unknown[]) => {
         call.ops.push({ name, args });
@@ -89,12 +90,19 @@ const payload = { listId: "list_1", campaignId: "camp_1", userId: "user_1" };
 
 const rowA = {
   organization_id: "org_a",
+  skip_contact_finding: false,
   organizations: { name: "Acme", enrichment_status: "pending" },
 };
 const rowB = {
   organization_id: "org_b",
+  skip_contact_finding: false,
   organizations: { name: "Beta Corp", enrichment_status: "pending" },
 };
+
+/** Response for a won atomic claim on the given org. */
+const claimWon = (orgId: string) => ({ data: { organization_id: orgId } });
+/** Response for a lost claim — another hop already took the row. */
+const claimLost = { data: null };
 
 beforeEach(() => {
   verifySignatureMock.mockReset();
@@ -113,18 +121,27 @@ beforeEach(() => {
 });
 
 describe("pickEnrichBatch", () => {
-  it("queries stamped rows with pending orgs, oldest first, limited", async () => {
-    const { client, calls } = fakeSupabase([{ data: [rowA, rowB] }]);
+  it("queries stamped rows with pending orgs, oldest first, limited, with the per-row skip flag", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: [{ ...rowA, skip_contact_finding: true }, rowB] },
+    ]);
 
     const batch = await pickEnrichBatch(client, "list_1", 2);
 
     expect(batch).toEqual([
-      { organizationId: "org_a", orgName: "Acme" },
-      { organizationId: "org_b", orgName: "Beta Corp" },
+      { organizationId: "org_a", orgName: "Acme", skipContactFinding: true },
+      {
+        organizationId: "org_b",
+        orgName: "Beta Corp",
+        skipContactFinding: false,
+      },
     ]);
 
     const call = calls[0];
     expect(call.table).toBe("target_accounts");
+    expect(
+      String(call.ops.find((o) => o.name === "select")?.args[0]),
+    ).toContain("skip_contact_finding");
     expect(call.ops).toContainEqual({
       name: "eq",
       args: ["list_id", "list_1"],
@@ -201,9 +218,11 @@ describe("POST /api/target-lists/process", () => {
     expect(enrichMock).not.toHaveBeenCalled();
   });
 
-  it("enriches the batch under withAction and re-publishes when work remains", async () => {
-    const { client } = fakeSupabase([
+  it("claims each row, enriches under withAction, and re-publishes with an incremented attempt", async () => {
+    const { client, calls } = fakeSupabase([
       { data: [rowA, rowB] }, // pickEnrichBatch
+      claimWon("org_a"),
+      claimWon("org_b"),
       { count: 3 }, // countRemaining
     ]);
     getAdminClientMock.mockReturnValue(client);
@@ -224,17 +243,41 @@ describe("POST /api/target-lists/process", () => {
       "Enrich target account: Beta Corp",
       expect.any(Function),
     );
-    // Chain continues: same payload, same route.
+
+    // The claim is a conditional update clearing stamp + flag: only the
+    // caller whose update lands proceeds.
+    const claim = calls[1];
+    expect(claim.table).toBe("target_accounts");
+    expect(claim.ops).toContainEqual({
+      name: "update",
+      args: [{ enrich_requested_at: null, skip_contact_finding: false }],
+    });
+    expect(claim.ops).toContainEqual({
+      name: "eq",
+      args: ["list_id", "list_1"],
+    });
+    expect(claim.ops).toContainEqual({
+      name: "eq",
+      args: ["organization_id", "org_a"],
+    });
+    expect(claim.ops).toContainEqual({
+      name: "not",
+      args: ["enrich_requested_at", "is", null],
+    });
+    expect(claim.ops.some((o) => o.name === "maybeSingle")).toBe(true);
+
+    // Chain continues: same payload plus the hop counter.
     expect(publishJSONMock).toHaveBeenCalledTimes(1);
     expect(publishJSONMock).toHaveBeenCalledWith({
       url: "http://localhost:3000/api/target-lists/process",
-      body: payload,
+      body: { ...payload, attempt: 2 },
     });
   });
 
   it("does not re-publish when nothing remains", async () => {
     const { client } = fakeSupabase([
       { data: [rowA] }, // pickEnrichBatch
+      claimWon("org_a"),
       { count: 0 }, // countRemaining
     ]);
     getAdminClientMock.mockReturnValue(client);
@@ -246,10 +289,31 @@ describe("POST /api/target-lists/process", () => {
     expect(publishJSONMock).not.toHaveBeenCalled();
   });
 
-  it("clears enrich_requested_at on a poison row and keeps processing", async () => {
+  it("skips a row whose claim was lost to a concurrent hop", async () => {
+    const { client } = fakeSupabase([
+      { data: [rowA, rowB] }, // pickEnrichBatch
+      claimLost, // org_a already claimed elsewhere
+      claimWon("org_b"),
+      { count: 0 }, // countRemaining
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+
+    const res = await POST(processRequest(payload));
+    const body = await res.json();
+
+    // Only the won claim is processed — no double enrichment.
+    expect(body).toEqual({ processed: 1, remaining: 0 });
+    expect(enrichMock).toHaveBeenCalledTimes(1);
+    expect(enrichMock).toHaveBeenCalledWith(client, "org_b", "camp_1", {
+      skipContactFinding: false,
+    });
+  });
+
+  it("logs a poison row without re-stamping and keeps processing", async () => {
     const { client, calls } = fakeSupabase([
       { data: [rowA, rowB] }, // pickEnrichBatch
-      {}, // poison-row stamp clear
+      claimWon("org_a"),
+      claimWon("org_b"),
       { count: 0 }, // countRemaining
     ]);
     getAdminClientMock.mockReturnValue(client);
@@ -269,40 +333,79 @@ describe("POST /api/target-lists/process", () => {
     // Both accounts attempted despite the first blowing up.
     expect(enrichMock).toHaveBeenCalledTimes(2);
     expect(body).toEqual({ processed: 2, remaining: 0 });
+    expect(errorSpy).toHaveBeenCalled();
 
-    // The poison row's stamp is cleared so the chain can't loop on it.
-    const clear = calls[1];
-    expect(clear.table).toBe("target_accounts");
-    expect(clear.ops).toContainEqual({
-      name: "update",
-      args: [{ enrich_requested_at: null }],
-    });
-    expect(clear.ops).toContainEqual({
-      name: "eq",
-      args: ["list_id", "list_1"],
-    });
-    expect(clear.ops).toContainEqual({
-      name: "eq",
-      args: ["organization_id", "org_a"],
-    });
+    // The claim already cleared the stamp; the failure path must NOT write
+    // it back (re-stamping is the poison-loop). The only target_accounts
+    // updates are the two claims.
+    const stampWrites = calls.filter(
+      (c) =>
+        c.table === "target_accounts" &&
+        c.ops.some(
+          (o) =>
+            o.name === "update" &&
+            (o.args[0] as Record<string, unknown>).enrich_requested_at !== null,
+        ),
+    );
+    expect(stampWrites).toHaveLength(0);
     errorSpy.mockRestore();
   });
 
-  it("threads skipContactFinding through to enrichment", async () => {
-    verifySignatureMock.mockResolvedValue({
-      ...payload,
-      skipContactFinding: true,
-    });
+  it("uses each row's own skip flag, not a chain-level one", async () => {
     const { client } = fakeSupabase([
-      { data: [rowA] }, // pickEnrichBatch
+      {
+        data: [{ ...rowA, skip_contact_finding: true }, rowB], // pickEnrichBatch
+      },
+      claimWon("org_a"),
+      claimWon("org_b"),
       { count: 0 }, // countRemaining
     ]);
     getAdminClientMock.mockReturnValue(client);
 
-    await POST(processRequest({ ...payload, skipContactFinding: true }));
+    await POST(processRequest(payload));
 
     expect(enrichMock).toHaveBeenCalledWith(client, "org_a", "camp_1", {
       skipContactFinding: true,
+    });
+    expect(enrichMock).toHaveBeenCalledWith(client, "org_b", "camp_1", {
+      skipContactFinding: false,
+    });
+  });
+
+  it("refuses to re-publish past the attempt ceiling", async () => {
+    verifySignatureMock.mockResolvedValue({ ...payload, attempt: 200 });
+    const { client } = fakeSupabase([
+      { data: [] }, // pickEnrichBatch — queue stuck, nothing pickable
+      { count: 5 }, // countRemaining still positive
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST(processRequest({ ...payload, attempt: 200 }));
+    const body = await res.json();
+
+    expect(body).toEqual({ processed: 0, remaining: 5 });
+    expect(publishJSONMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("HARD CEILING"),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("increments an existing attempt counter on re-publish", async () => {
+    verifySignatureMock.mockResolvedValue({ ...payload, attempt: 7 });
+    const { client } = fakeSupabase([
+      { data: [rowA] }, // pickEnrichBatch
+      claimWon("org_a"),
+      { count: 1 }, // countRemaining
+    ]);
+    getAdminClientMock.mockReturnValue(client);
+
+    await POST(processRequest({ ...payload, attempt: 7 }));
+
+    expect(publishJSONMock).toHaveBeenCalledWith({
+      url: "http://localhost:3000/api/target-lists/process",
+      body: { ...payload, attempt: 8 },
     });
   });
 });

--- a/src/__tests__/target-list-tools.test.ts
+++ b/src/__tests__/target-list-tools.test.ts
@@ -1,0 +1,403 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Target-list agent tools. Invariants under test:
+ * - getTargetList reports the counts the agent quotes progress from.
+ * - linkTargetListToCampaign bulk-upserts campaign_organizations with the
+ *   exact onConflict key + ignoreDuplicates, upserts campaign_people for
+ *   imported contacts (status "pending"), and is idempotent.
+ * - prioritizeTargetAccounts hard-gates on a missing ICP with ZERO LLM
+ *   calls, requires the list to be linked, only scores unscored rows, and
+ *   writes score/reason/status keyed by organizationId.
+ */
+
+const h = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  auth: vi.fn(),
+  scoreTargetAccounts: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: h.createClient,
+}));
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: h.auth,
+}));
+vi.mock("@/lib/services/target-account-scorer", () => ({
+  scoreTargetAccounts: h.scoreTargetAccounts,
+}));
+
+import {
+  getTargetLists,
+  getTargetList,
+  linkTargetListToCampaign,
+  prioritizeTargetAccounts,
+} from "@/lib/tools/target-list-tools";
+
+const LIST = "11111111-1111-1111-1111-111111111111";
+const CAMPAIGN = "22222222-2222-2222-2222-222222222222";
+
+interface RecordedCall {
+  table: string;
+  ops: Array<{ name: string; args: unknown[] }>;
+}
+
+/**
+ * Thenable query-builder fake (outreach-sender.test.ts pattern): every
+ * chained method records itself, awaiting the chain pops the next queued
+ * response.
+ */
+function fakeSupabase(
+  responses: Array<{ data?: unknown; error?: unknown; count?: number }>,
+) {
+  let i = 0;
+  const calls: RecordedCall[] = [];
+
+  const from = (table: string) => {
+    const call: RecordedCall = { table, ops: [] };
+    calls.push(call);
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "not",
+      "order",
+      "limit",
+      "range",
+      "update",
+      "upsert",
+      "insert",
+      "single",
+      "maybeSingle",
+    ]) {
+      builder[name] = (...args: unknown[]) => {
+        call.ops.push({ name, args });
+        return builder;
+      };
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+        resolve,
+        reject,
+      );
+    return builder;
+  };
+
+  return { client: { from } as never, calls };
+}
+
+function op(calls: RecordedCall[], table: string, name: string) {
+  const call = calls.find(
+    (c) => c.table === table && c.ops.some((o) => o.name === name),
+  );
+  return call?.ops.find((o) => o.name === name);
+}
+
+const run = <T>(tool: { execute?: unknown }, input: Record<string, unknown>) =>
+  (tool.execute as (i: unknown, o: unknown) => Promise<T>)(input, {} as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.auth.mockResolvedValue({ userId: "user_1" });
+  h.scoreTargetAccounts.mockResolvedValue([]);
+});
+
+describe("getTargetLists", () => {
+  it("lists mine newest first", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: [{ id: LIST, name: "Q3 targets", row_count: 40 }] },
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{ lists: unknown[] }>(getTargetLists, {});
+
+    expect(result.lists).toHaveLength(1);
+    expect(op(calls, "target_account_lists", "order")?.args).toEqual([
+      "created_at",
+      { ascending: false },
+    ]);
+  });
+});
+
+describe("getTargetList", () => {
+  it("returns meta, first accounts, and total/enriched/queued counts", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: { id: LIST, name: "Q3 targets", row_count: 3 } },
+      {
+        data: [
+          {
+            organization_id: "org_1",
+            enrich_requested_at: null,
+            organization: {
+              name: "Acme",
+              domain: "acme.com",
+              enrichment_status: "enriched",
+            },
+          },
+        ],
+      },
+      { count: 3 }, // total
+      { count: 1 }, // enriched
+      { count: 2 }, // queued
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      list: { name: string };
+      accounts: Array<Record<string, unknown>>;
+      counts: { total: number; enriched: number; enrichQueued: number };
+    }>(getTargetList, { listId: LIST });
+
+    expect(result.list.name).toBe("Q3 targets");
+    expect(result.accounts).toEqual([
+      {
+        organizationId: "org_1",
+        name: "Acme",
+        domain: "acme.com",
+        enrichmentStatus: "enriched",
+        enrichQueued: false,
+      },
+    ]);
+    expect(result.counts).toEqual({ total: 3, enriched: 1, enrichQueued: 2 });
+    expect(op(calls, "target_accounts", "limit")?.args).toEqual([25]);
+  });
+});
+
+describe("linkTargetListToCampaign", () => {
+  it("bulk-upserts campaign_organizations and campaign_people with the right onConflict", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: { id: LIST, name: "Q3 targets" } },
+      { data: [{ organization_id: "org_1" }, { organization_id: "org_2" }] },
+      { data: [{ organization_id: "org_1" }, { organization_id: "org_2" }] },
+      { data: [{ id: "p1" }] },
+      { data: [{ person_id: "p1" }] },
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      linked: number;
+      alreadyLinked: number;
+      peopleLinked: number;
+    }>(linkTargetListToCampaign, { listId: LIST, campaignId: CAMPAIGN });
+
+    expect(result.linked).toBe(2);
+    expect(result.alreadyLinked).toBe(0);
+    expect(result.peopleLinked).toBe(1);
+
+    const orgUpsert = op(calls, "campaign_organizations", "upsert")!;
+    expect(orgUpsert.args[0]).toEqual([
+      { campaign_id: CAMPAIGN, organization_id: "org_1" },
+      { campaign_id: CAMPAIGN, organization_id: "org_2" },
+    ]);
+    expect(orgUpsert.args[1]).toEqual({
+      onConflict: "campaign_id,organization_id",
+      ignoreDuplicates: true,
+    });
+
+    const peopleUpsert = op(calls, "campaign_people", "upsert")!;
+    expect(peopleUpsert.args[0]).toEqual([
+      { campaign_id: CAMPAIGN, person_id: "p1", status: "pending" },
+    ]);
+    expect(peopleUpsert.args[1]).toEqual({
+      onConflict: "campaign_id,person_id",
+      ignoreDuplicates: true,
+    });
+  });
+
+  it("is idempotent: a second call reports alreadyLinked", async () => {
+    const { client } = fakeSupabase([
+      { data: { id: LIST, name: "Q3 targets" } },
+      { data: [{ organization_id: "org_1" }, { organization_id: "org_2" }] },
+      { data: [] }, // duplicates ignored — nothing inserted
+      { data: [{ id: "p1" }] },
+      { data: [] },
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      linked: number;
+      alreadyLinked: number;
+      peopleLinked: number;
+    }>(linkTargetListToCampaign, { listId: LIST, campaignId: CAMPAIGN });
+
+    expect(result).toMatchObject({
+      linked: 0,
+      alreadyLinked: 2,
+      peopleLinked: 0,
+    });
+  });
+});
+
+describe("prioritizeTargetAccounts", () => {
+  const campaignRow = (icp: Record<string, unknown>) => ({
+    data: {
+      id: CAMPAIGN,
+      name: "Q3 UK fintech",
+      icp,
+      offering: { description: "API monitoring" },
+    },
+  });
+
+  const accountRow = (id: string, name: string) => ({
+    organization_id: id,
+    raw: {},
+    organization: {
+      id,
+      name,
+      domain: `${name.toLowerCase()}.com`,
+      industry: null,
+      location: null,
+    },
+  });
+
+  it("hard-gates on missing ICP with zero LLM calls", async () => {
+    const { client, calls } = fakeSupabase([campaignRow({})]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{ error?: string }>(prioritizeTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+    });
+
+    expect(result.error).toMatch(/no ICP/i);
+    expect(result.error).toMatch(/saveCampaign/);
+    expect(h.scoreTargetAccounts).not.toHaveBeenCalled();
+    // Short-circuits before touching the list at all.
+    expect(calls.map((c) => c.table)).toEqual(["campaigns"]);
+  });
+
+  it("requires the list to be linked first", async () => {
+    const { client } = fakeSupabase([
+      campaignRow({ targetTitles: ["CTO"] }),
+      { data: [accountRow("org_a", "Acme")] },
+      { data: [] }, // no campaign_organizations memberships
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{ error?: string }>(prioritizeTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+    });
+
+    expect(result.error).toMatch(/linkTargetListToCampaign/);
+    expect(h.scoreTargetAccounts).not.toHaveBeenCalled();
+  });
+
+  it("scores only unscored rows and writes score/reason/status keyed by organizationId", async () => {
+    const { client, calls } = fakeSupabase([
+      campaignRow({ targetTitles: ["CTO"] }),
+      {
+        data: [
+          accountRow("org_a", "Acme"),
+          accountRow("org_b", "Beta"),
+          accountRow("org_c", "Gamma"),
+        ],
+      },
+      {
+        data: [
+          { organization_id: "org_a", relevance_score: 7, score_reason: "old" },
+          { organization_id: "org_b", relevance_score: 0, score_reason: null },
+          {
+            organization_id: "org_c",
+            relevance_score: null,
+            score_reason: null,
+          },
+        ],
+      },
+      { data: null }, // update org_b
+      { data: null }, // update org_c
+      { data: [{ organization_id: "org_b" }, { organization_id: "org_b" }] }, // imported contacts
+    ]);
+    h.createClient.mockResolvedValue(client);
+    h.scoreTargetAccounts.mockResolvedValue([
+      { organizationId: "org_b", score: 8, reason: "Strong fit" },
+      { organizationId: "org_c", score: 3, reason: "Weak fit" },
+    ]);
+
+    const result = await run<{
+      scored: number;
+      topSlice: Array<Record<string, unknown>>;
+      estimatedEnrichCostUsd: number;
+    }>(prioritizeTargetAccounts, { listId: LIST, campaignId: CAMPAIGN });
+
+    // org_a (already scored) never reaches the scorer.
+    const scorerInput = h.scoreTargetAccounts.mock.calls[0][0] as {
+      campaign: { id: string };
+      accounts: Array<{ organizationId: string }>;
+      userId: string;
+    };
+    expect(scorerInput.campaign.id).toBe(CAMPAIGN);
+    expect(scorerInput.userId).toBe("user_1");
+    expect(scorerInput.accounts.map((a) => a.organizationId)).toEqual([
+      "org_b",
+      "org_c",
+    ]);
+
+    // Writes keyed by organizationId on the campaign membership.
+    const updates = calls.filter(
+      (c) =>
+        c.table === "campaign_organizations" &&
+        c.ops.some((o) => o.name === "update"),
+    );
+    expect(updates).toHaveLength(2);
+    expect(updates[0].ops.find((o) => o.name === "update")?.args[0]).toEqual({
+      relevance_score: 8,
+      score_reason: "Strong fit",
+      status: "qualified",
+    });
+    expect(
+      updates[0].ops.filter((o) => o.name === "eq").map((o) => o.args),
+    ).toEqual([
+      ["campaign_id", CAMPAIGN],
+      ["organization_id", "org_b"],
+    ]);
+    expect(updates[1].ops.find((o) => o.name === "update")?.args[0]).toEqual({
+      relevance_score: 3,
+      score_reason: "Weak fit",
+      status: "disqualified",
+    });
+
+    // Top slice: ceil(3 * 0.1) = 1, best score first, with contact coverage.
+    expect(result.scored).toBe(2);
+    expect(result.topSlice).toHaveLength(1);
+    expect(result.topSlice[0]).toMatchObject({
+      organizationId: "org_b",
+      name: "Beta",
+      score: 8,
+      reason: "Strong fit",
+      importedContacts: 2,
+    });
+    expect(result.estimatedEnrichCostUsd).toBeCloseTo(0.08);
+  });
+
+  it("skips the LLM entirely when every linked row is already scored", async () => {
+    const { client } = fakeSupabase([
+      campaignRow({ targetTitles: ["CTO"] }),
+      { data: [accountRow("org_a", "Acme")] },
+      {
+        data: [
+          { organization_id: "org_a", relevance_score: 9, score_reason: "hot" },
+        ],
+      },
+      { data: [{ organization_id: "org_a" }] }, // imported contacts for slice
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      scored: number;
+      topSlice: Array<Record<string, unknown>>;
+    }>(prioritizeTargetAccounts, { listId: LIST, campaignId: CAMPAIGN });
+
+    expect(h.scoreTargetAccounts).not.toHaveBeenCalled();
+    expect(result.scored).toBe(0);
+    expect(result.topSlice[0]).toMatchObject({
+      organizationId: "org_a",
+      score: 9,
+    });
+  });
+});

--- a/src/__tests__/target-list-tools.test.ts
+++ b/src/__tests__/target-list-tools.test.ts
@@ -15,6 +15,8 @@ const h = vi.hoisted(() => ({
   createClient: vi.fn(),
   auth: vi.fn(),
   scoreTargetAccounts: vi.fn(),
+  getQStashClient: vi.fn(),
+  publishJSON: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -26,16 +28,24 @@ vi.mock("@clerk/nextjs/server", () => ({
 vi.mock("@/lib/services/target-account-scorer", () => ({
   scoreTargetAccounts: h.scoreTargetAccounts,
 }));
+vi.mock("@/lib/services/qstash", () => ({
+  getQStashClient: h.getQStashClient,
+  getBaseUrl: () => "http://localhost:3000",
+}));
 
 import {
   getTargetLists,
   getTargetList,
   linkTargetListToCampaign,
   prioritizeTargetAccounts,
+  enrichTargetAccounts,
 } from "@/lib/tools/target-list-tools";
 
 const LIST = "11111111-1111-1111-1111-111111111111";
 const CAMPAIGN = "22222222-2222-2222-2222-222222222222";
+const ORG_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const ORG_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ORG_C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
 
 interface RecordedCall {
   table: string;
@@ -105,6 +115,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.auth.mockResolvedValue({ userId: "user_1" });
   h.scoreTargetAccounts.mockResolvedValue([]);
+  h.publishJSON.mockResolvedValue({ messageId: "msg_1" });
+  h.getQStashClient.mockReturnValue({ publishJSON: h.publishJSON });
 });
 
 describe("getTargetLists", () => {
@@ -165,6 +177,23 @@ describe("getTargetList", () => {
     ]);
     expect(result.counts).toEqual({ total: 3, enriched: 1, enrichQueued: 2 });
     expect(op(calls, "target_accounts", "limit")?.args).toEqual([25]);
+
+    // enrichQueued mirrors the processor's picker: stamped AND org still
+    // pending — otherwise it overstates in-flight work forever.
+    const queuedCall = calls.find(
+      (c) =>
+        c.table === "target_accounts" &&
+        c.ops.some(
+          (o) =>
+            o.name === "not" &&
+            o.args[0] === "enrich_requested_at" &&
+            o.args[2] === null,
+        ),
+    );
+    expect(queuedCall?.ops).toContainEqual({
+      name: "eq",
+      args: ["organizations.enrichment_status", "pending"],
+    });
   });
 });
 
@@ -206,6 +235,14 @@ describe("linkTargetListToCampaign", () => {
     expect(peopleUpsert.args[1]).toEqual({
       onConflict: "campaign_id,person_id",
       ignoreDuplicates: true,
+    });
+
+    // Orgs live in a shared pool: only list-imported contacts ride along,
+    // never people other campaigns/users discovered at the same companies.
+    const peopleSelect = calls.find((c) => c.table === "people");
+    expect(peopleSelect?.ops).toContainEqual({
+      name: "eq",
+      args: ["source", "target_list"],
     });
   });
 
@@ -399,5 +436,186 @@ describe("prioritizeTargetAccounts", () => {
       organizationId: "org_a",
       score: 9,
     });
+  });
+});
+
+describe("enrichTargetAccounts", () => {
+  const listRow = { data: { id: LIST, name: "Q3 targets" } };
+  const campaignRow = { data: { id: CAMPAIGN } };
+  const verifyRow = (id: string, status = "pending") => ({
+    organization_id: id,
+    organization: { enrichment_status: status },
+  });
+
+  it("errors when the campaign is not found (or not mine) before touching rows", async () => {
+    const { client, calls } = fakeSupabase([
+      listRow,
+      { data: null, error: { message: "0 rows" } }, // campaign lookup
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{ error?: string }>(enrichTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+      organizationIds: [ORG_A],
+    });
+
+    expect(result.error).toMatch(/campaign not found/i);
+    expect(h.publishJSON).not.toHaveBeenCalled();
+    expect(op(calls, "target_accounts", "update")).toBeUndefined();
+  });
+
+  it("rejects organizations that are not on the list, without stamping", async () => {
+    const { client, calls } = fakeSupabase([
+      listRow,
+      campaignRow,
+      { data: [verifyRow(ORG_A)] }, // ORG_B missing from the list
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{ error?: string }>(enrichTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+      organizationIds: [ORG_A, ORG_B],
+    });
+
+    expect(result.error).toMatch(/not in this list/);
+    expect(result.error).toContain(ORG_B);
+    expect(h.publishJSON).not.toHaveBeenCalled();
+    expect(op(calls, "target_accounts", "update")).toBeUndefined();
+  });
+
+  it("checks QStash config BEFORE stamping any rows", async () => {
+    h.getQStashClient.mockImplementation(() => {
+      throw new Error("QSTASH_TOKEN is not set");
+    });
+    const { client, calls } = fakeSupabase([
+      listRow,
+      campaignRow,
+      { data: [verifyRow(ORG_A)] },
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{ error?: string }>(enrichTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+      organizationIds: [ORG_A],
+    });
+
+    expect(result.error).toMatch(/QStash/);
+    // No stamped queue left behind that nothing will ever drain.
+    expect(op(calls, "target_accounts", "update")).toBeUndefined();
+    expect(h.publishJSON).not.toHaveBeenCalled();
+  });
+
+  it("stamps the per-row skip flag and publishes a payload WITHOUT skipContactFinding", async () => {
+    const { client, calls } = fakeSupabase([
+      listRow,
+      campaignRow,
+      { data: [verifyRow(ORG_A), verifyRow(ORG_B)] },
+      {}, // stamp update
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      queued: number;
+      skippedNotPending: Array<Record<string, string>>;
+    }>(enrichTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+      organizationIds: [ORG_A, ORG_B],
+      skipContactFinding: true,
+    });
+
+    expect(result.queued).toBe(2);
+    expect(result.skippedNotPending).toEqual([]);
+
+    // The flag lands on the rows…
+    const stamp = calls.find(
+      (c) =>
+        c.table === "target_accounts" && c.ops.some((o) => o.name === "update"),
+    )!;
+    const stampArgs = stamp.ops.find((o) => o.name === "update")!
+      .args[0] as Record<string, unknown>;
+    expect(stampArgs.skip_contact_finding).toBe(true);
+    expect(stampArgs.enrich_requested_at).toEqual(expect.any(String));
+    expect(stamp.ops).toContainEqual({
+      name: "in",
+      args: ["organization_id", [ORG_A, ORG_B]],
+    });
+
+    // …and NOT in the chain payload (exact match asserts absence): a
+    // chain-level flag cross-contaminates concurrent tranches.
+    expect(h.publishJSON).toHaveBeenCalledTimes(1);
+    expect(h.publishJSON).toHaveBeenCalledWith({
+      url: "http://localhost:3000/api/target-lists/process",
+      body: { listId: LIST, campaignId: CAMPAIGN, userId: "user_1" },
+    });
+  });
+
+  it("stamps only pending orgs and reports the rest as skippedNotPending", async () => {
+    const { client, calls } = fakeSupabase([
+      listRow,
+      campaignRow,
+      {
+        data: [
+          verifyRow(ORG_A, "pending"),
+          verifyRow(ORG_B, "enriched"),
+          verifyRow(ORG_C, "failed"),
+        ],
+      },
+      {}, // stamp update (ORG_A only)
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      queued: number;
+      skippedNotPending: Array<{ organizationId: string; status: string }>;
+    }>(enrichTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+      organizationIds: [ORG_A, ORG_B, ORG_C],
+    });
+
+    expect(result.queued).toBe(1);
+    expect(result.skippedNotPending).toEqual([
+      { organizationId: ORG_B, status: "enriched" },
+      { organizationId: ORG_C, status: "failed" },
+    ]);
+
+    const stamp = calls.find(
+      (c) =>
+        c.table === "target_accounts" && c.ops.some((o) => o.name === "update"),
+    )!;
+    expect(stamp.ops).toContainEqual({
+      name: "in",
+      args: ["organization_id", [ORG_A]],
+    });
+    expect(h.publishJSON).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues nothing (and skips QStash) when no org is pending", async () => {
+    const { client, calls } = fakeSupabase([
+      listRow,
+      campaignRow,
+      { data: [verifyRow(ORG_A, "enriched")] },
+    ]);
+    h.createClient.mockResolvedValue(client);
+
+    const result = await run<{
+      queued: number;
+      skippedNotPending: Array<{ organizationId: string; status: string }>;
+    }>(enrichTargetAccounts, {
+      listId: LIST,
+      campaignId: CAMPAIGN,
+      organizationIds: [ORG_A],
+    });
+
+    expect(result.queued).toBe(0);
+    expect(result.skippedNotPending).toEqual([
+      { organizationId: ORG_A, status: "enriched" },
+    ]);
+    expect(op(calls, "target_accounts", "update")).toBeUndefined();
+    expect(h.publishJSON).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/target-lists-service.test.ts
+++ b/src/__tests__/target-lists-service.test.ts
@@ -336,6 +336,32 @@ describe("appendAccountsToList", () => {
     });
   });
 
+  it("skips junk that is not email-shaped but still imports the person", async () => {
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] },
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      {
+        name: "Acme",
+        domain: "acme.com",
+        person: { name: "Ada Lovelace", title: "CTO", email: "n/a" },
+      },
+      {
+        name: "Acme",
+        domain: "acme.com",
+        person: { name: "Grace Hopper", email: "see notes @ CRM" },
+      },
+    ]);
+
+    expect(result).toMatchObject({ imported: 1, peopleImported: 2 });
+    expect(findOrCreatePersonMock).toHaveBeenCalledTimes(2);
+    // Neither "n/a" nor "see notes @ CRM" reaches recordVerifiedEmail.
+    expect(verifiedEmails).toHaveLength(0);
+  });
+
   it("still imports people when the account already exists (linkedin-deduped downstream)", async () => {
     // Re-import of the same file: the account upsert returns no rows.
     const { client } = fakeSupabase([{ data: [] }]);

--- a/src/__tests__/target-lists-service.test.ts
+++ b/src/__tests__/target-lists-service.test.ts
@@ -155,6 +155,8 @@ describe("appendAccountsToList", () => {
       failed: 0,
       peopleImported: 0,
     });
+    // Companies-only rows import zero people.
+    expect(findOrCreatePersonMock).not.toHaveBeenCalled();
     expect(findOrCreateOrgMock).toHaveBeenCalledTimes(2);
     expect(findOrCreateOrgMock).toHaveBeenCalledWith(
       expect.objectContaining({ name: "Acme", source: "target_list" }),
@@ -252,6 +254,141 @@ describe("appendAccountsToList", () => {
     expect(findOrCreateOrgMock).toHaveBeenCalledWith(
       expect.objectContaining({ name: "Acme", domain: "acme.com" }),
     );
+  });
+
+  it("imports one org and three people from contact-per-row rows", async () => {
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] }, // one account upsert for the shared company
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    const rows: TargetAccountRow[] = [
+      {
+        name: "Acme",
+        domain: "acme.com",
+        person: {
+          name: "Ada Lovelace",
+          title: "CTO",
+          email: "ada@acme.com",
+          linkedin_url: "https://www.linkedin.com/in/ada",
+        },
+      },
+      {
+        name: "Acme",
+        domain: "acme.com",
+        person: {
+          name: "Grace Hopper",
+          title: "VP Eng",
+          email: "grace@acme.com",
+          linkedin_url: "https://www.linkedin.com/in/grace",
+        },
+      },
+      {
+        name: "Acme",
+        domain: "acme.com",
+        person: { name: "Alan Turing", title: null, email: null },
+      },
+    ];
+
+    const result = await appendAccountsToList(client, "list-1", rows);
+
+    expect(result).toEqual({
+      imported: 1,
+      skipped: 0,
+      failed: 0,
+      peopleImported: 3,
+    });
+    expect(findOrCreateOrgMock).toHaveBeenCalledTimes(1);
+
+    // People land via findOrCreatePerson with the org, title and source —
+    // and the caller's supabase client (knowledge-base convention).
+    expect(findOrCreatePersonMock).toHaveBeenCalledTimes(3);
+    expect(findOrCreatePersonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Ada Lovelace",
+        title: "CTO",
+        linkedin_url: "https://www.linkedin.com/in/ada",
+        work_email: "ada@acme.com",
+        organization_id: "org_acme.com",
+        source: "target_list",
+      }),
+      client,
+    );
+
+    // Affiliation provenance: the user's own upload names the employer.
+    expect(affiliations).toHaveLength(3);
+    for (const a of affiliations) {
+      expect(a).toMatchObject({
+        organizationId: "org_acme.com",
+        source: "user_entered",
+      });
+      expect(String(a.evidence)).toContain("csv_import");
+    }
+
+    // Imported addresses are free suggestions: recorded with a non-trusted
+    // source so the send gate's just-in-time verifier still proves them
+    // (data-quality convention — verification stays unchecked until send).
+    expect(verifiedEmails).toHaveLength(2);
+    expect(verifiedEmails[0]).toMatchObject({
+      email: "ada@acme.com",
+      source: "provider_found",
+    });
+  });
+
+  it("still imports people when the account already exists (linkedin-deduped downstream)", async () => {
+    // Re-import of the same file: the account upsert returns no rows.
+    const { client } = fakeSupabase([{ data: [] }]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      {
+        name: "Acme",
+        domain: "acme.com",
+        person: {
+          name: "Ada Lovelace",
+          linkedin_url: "https://www.linkedin.com/in/ada",
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 1,
+      failed: 0,
+      peopleImported: 1,
+    });
+    // Dedup on re-import is by linkedin_url, inside findOrCreatePerson —
+    // the service must pass the URL through for that to hold.
+    expect(findOrCreatePersonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        linkedin_url: "https://www.linkedin.com/in/ada",
+      }),
+      client,
+    );
+  });
+
+  it("refuses to attach people to a domain-less org", async () => {
+    findOrCreateOrgMock.mockResolvedValue({
+      id: "org_nodomain",
+      domain: null,
+    } as never);
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] },
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      {
+        name: "Acme",
+        person: { name: "Ada Lovelace", email: "ada@acme.com" },
+      },
+    ]);
+
+    // The account still imports; the person does not (canHoldPeople).
+    expect(result).toMatchObject({ imported: 1, peopleImported: 0 });
+    expect(findOrCreatePersonMock).not.toHaveBeenCalled();
+    expect(affiliations).toHaveLength(0);
   });
 
   it("skips the header mapper when no row carries extra", async () => {

--- a/src/__tests__/target-lists-service.test.ts
+++ b/src/__tests__/target-lists-service.test.ts
@@ -316,23 +316,26 @@ describe("appendAccountsToList", () => {
       client,
     );
 
-    // Affiliation provenance: the user's own upload names the employer.
+    // Affiliation provenance: an upload is a suggestion, not a human
+    // assertion — csv_import, never user_entered, so Signal's own
+    // verification (email_domain) and explicit human edits both outrank it.
     expect(affiliations).toHaveLength(3);
     for (const a of affiliations) {
       expect(a).toMatchObject({
         organizationId: "org_acme.com",
-        source: "user_entered",
+        source: "csv_import",
       });
-      expect(String(a.evidence)).toContain("csv_import");
+      expect(String(a.evidence)).toContain("uploaded target list");
     }
 
-    // Imported addresses are free suggestions: recorded with a non-trusted
-    // source so the send gate's just-in-time verifier still proves them
-    // (data-quality convention — verification stays unchecked until send).
+    // Imported addresses are free suggestions: recorded as csv_import — below
+    // every verified-ish source, so an upload can never displace an
+    // established address — and the send gate's just-in-time verifier still
+    // proves them (verification stays unchecked until send).
     expect(verifiedEmails).toHaveLength(2);
     expect(verifiedEmails[0]).toMatchObject({
       email: "ada@acme.com",
-      source: "provider_found",
+      source: "csv_import",
     });
   });
 

--- a/src/__tests__/target-lists-service.test.ts
+++ b/src/__tests__/target-lists-service.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  findOrCreateOrganization,
+  findOrCreatePerson,
+} from "@/lib/services/knowledge-base";
+import { mapUnknownHeaders } from "@/lib/csv/header-mapper";
+import type { TargetAccountRow } from "@/lib/types/target-list";
+
+/**
+ * appendAccountsToList: rows resolve to the global organizations pool
+ * (domain-deduped), land in target_accounts behind the (list_id,
+ * organization_id) unique constraint, and bump the list's row_count.
+ * Contact-per-row files additionally import people (Task 4b).
+ */
+
+const h = vi.hoisted(() => ({
+  getSupabaseAndUser: vi.fn(),
+  capture: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAndUser: h.getSupabaseAndUser,
+}));
+vi.mock("@/lib/posthog-server", () => ({
+  getPostHogClient: () => ({ capture: h.capture }),
+}));
+vi.mock("@/lib/services/knowledge-base", () => ({
+  findOrCreateOrganization: vi.fn(),
+  findOrCreatePerson: vi.fn(),
+  normalizeDomain: (d: string) =>
+    d
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/^www\./, ""),
+  canHoldPeople: (org: { domain?: string | null }) => Boolean(org.domain),
+}));
+const affiliations: Array<Record<string, unknown>> = [];
+vi.mock("@/lib/services/affiliation", () => ({
+  recordAffiliation: vi.fn(async (_c: unknown, a: Record<string, unknown>) => {
+    affiliations.push(a);
+  }),
+}));
+const verifiedEmails: Array<Record<string, unknown>> = [];
+vi.mock("@/lib/services/email-pattern", () => ({
+  recordVerifiedEmail: vi.fn(
+    async (_c: unknown, a: Record<string, unknown>) => {
+      verifiedEmails.push(a);
+    },
+  ),
+}));
+vi.mock("@/lib/csv/header-mapper", () => ({
+  mapUnknownHeaders: vi.fn(),
+}));
+
+import {
+  appendAccountsToList,
+  MAX_ROWS_PER_REQUEST,
+} from "@/lib/services/target-lists";
+import { POST as postAccounts } from "@/app/api/target-lists/[id]/accounts/route";
+
+const findOrCreateOrgMock = vi.mocked(findOrCreateOrganization);
+const findOrCreatePersonMock = vi.mocked(findOrCreatePerson);
+const mapUnknownHeadersMock = vi.mocked(mapUnknownHeaders);
+
+interface RecordedCall {
+  table: string;
+  ops: Array<{ name: string; args: unknown[] }>;
+}
+
+/**
+ * Thenable query-builder fake (outreach-sender.test.ts pattern): every chained
+ * method records itself; awaiting a chain pops the next queued response.
+ */
+function fakeSupabase(
+  responses: Array<{ data?: unknown; error?: unknown; count?: number }>,
+) {
+  let i = 0;
+  const calls: RecordedCall[] = [];
+
+  const from = (table: string) => {
+    const call: RecordedCall = { table, ops: [] };
+    calls.push(call);
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "order",
+      "update",
+      "insert",
+      "upsert",
+      "single",
+      "maybeSingle",
+    ]) {
+      builder[name] = (...args: unknown[]) => {
+        call.ops.push({ name, args });
+        return builder;
+      };
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+        resolve,
+        reject,
+      );
+    return builder;
+  };
+
+  return { client: { from } as never, calls };
+}
+
+function ops(calls: RecordedCall[], table: string, op: string) {
+  return calls
+    .filter((c) => c.table === table)
+    .flatMap((c) => c.ops.filter((o) => o.name === op));
+}
+
+beforeEach(() => {
+  affiliations.length = 0;
+  verifiedEmails.length = 0;
+  findOrCreateOrgMock.mockReset();
+  findOrCreatePersonMock.mockReset();
+  mapUnknownHeadersMock.mockReset();
+  mapUnknownHeadersMock.mockResolvedValue({});
+  h.getSupabaseAndUser.mockReset();
+  h.capture.mockReset();
+  findOrCreateOrgMock.mockImplementation(
+    async (d) =>
+      ({ id: `org_${d.domain ?? d.name}`, domain: d.domain }) as never,
+  );
+  findOrCreatePersonMock.mockImplementation(
+    async (d) => ({ id: `per_${d.name}`, name: d.name }) as never,
+  );
+});
+
+describe("appendAccountsToList", () => {
+  it("resolves rows to orgs and upserts with onConflict list_id,organization_id", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: [{ id: "ta_1" }] }, // upsert acme
+      { data: [{ id: "ta_2" }] }, // upsert globex
+      { data: { row_count: 5 } }, // row_count read
+      {}, // row_count update
+    ]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      { name: "Acme", domain: "acme.com" },
+      { name: "Globex", domain: "globex.com" },
+    ]);
+
+    expect(result).toEqual({
+      imported: 2,
+      skipped: 0,
+      failed: 0,
+      peopleImported: 0,
+    });
+    expect(findOrCreateOrgMock).toHaveBeenCalledTimes(2);
+    expect(findOrCreateOrgMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Acme", source: "target_list" }),
+    );
+
+    const upserts = ops(calls, "target_accounts", "upsert");
+    expect(upserts).toHaveLength(2);
+    for (const u of upserts) {
+      expect(u.args[1]).toEqual({
+        onConflict: "list_id,organization_id",
+        ignoreDuplicates: true,
+      });
+      expect(u.args[0]).toMatchObject({ list_id: "list-1" });
+    }
+
+    // row_count incremented by imported, read-modify-write.
+    const updates = ops(calls, "target_account_lists", "update");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].args[0]).toEqual({ row_count: 7 });
+  });
+
+  it("dedups rows within the batch by resolved org", async () => {
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] },
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      { name: "Acme", domain: "www.Acme.com" },
+      { name: "Acme Inc", url: "https://acme.com/about" }, // same apex domain
+    ]);
+
+    expect(result).toMatchObject({ imported: 1, skipped: 1, failed: 0 });
+    expect(findOrCreateOrgMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts an account already in the list as skipped and leaves row_count alone", async () => {
+    // ignoreDuplicates upsert returns no rows for an existing account.
+    const { client, calls } = fakeSupabase([{ data: [] }]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      { name: "Acme", domain: "acme.com" },
+    ]);
+
+    expect(result).toMatchObject({ imported: 0, skipped: 1, failed: 0 });
+    expect(ops(calls, "target_account_lists", "update")).toHaveLength(0);
+  });
+
+  it("counts failed org resolutions without aborting the batch", async () => {
+    findOrCreateOrgMock.mockImplementation(async (d) => {
+      if (d.name === "Broken") throw new Error("boom");
+      return { id: `org_${d.domain}`, domain: d.domain } as never;
+    });
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] },
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    const result = await appendAccountsToList(client, "list-1", [
+      { name: "Acme", domain: "acme.com" },
+      { name: "Broken", domain: "broken.com" },
+    ]);
+
+    expect(result).toMatchObject({ imported: 1, skipped: 0, failed: 1 });
+  });
+
+  it("runs the header mapper once for unmapped headers and folds mapped fields in", async () => {
+    mapUnknownHeadersMock.mockResolvedValue({
+      "web address": "domain",
+      notes: "ignore",
+    });
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] },
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    await appendAccountsToList(client, "list-1", [
+      {
+        name: "Acme",
+        extra: { "web address": "acme.com", notes: "met at conf" },
+      },
+    ]);
+
+    expect(mapUnknownHeadersMock).toHaveBeenCalledTimes(1);
+    expect(mapUnknownHeadersMock).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ header: "web address" }),
+        expect.objectContaining({ header: "notes" }),
+      ]),
+      expect.anything(),
+    );
+    expect(findOrCreateOrgMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Acme", domain: "acme.com" }),
+    );
+  });
+
+  it("skips the header mapper when no row carries extra", async () => {
+    const { client } = fakeSupabase([
+      { data: [{ id: "ta_1" }] },
+      { data: { row_count: 0 } },
+      {},
+    ]);
+
+    await appendAccountsToList(client, "list-1", [
+      { name: "Acme", domain: "acme.com" },
+    ]);
+
+    expect(mapUnknownHeadersMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/target-lists/[id]/accounts", () => {
+  function request(body: unknown): Request {
+    return new Request("http://localhost/api/target-lists/list-1/accounts", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const routeParams = { params: Promise.resolve({ id: "list-1" }) };
+
+  it("rejects payloads over the row cap with 413", async () => {
+    h.getSupabaseAndUser.mockResolvedValue({
+      supabase: fakeSupabase([]).client,
+      user: { id: "user_1", email: "" },
+    });
+    const rows: TargetAccountRow[] = Array.from(
+      { length: MAX_ROWS_PER_REQUEST + 1 },
+      (_, i) => ({ name: `Co ${i}`, domain: `co${i}.com` }),
+    );
+
+    const res = await postAccounts(request({ rows }), routeParams);
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain(String(MAX_ROWS_PER_REQUEST));
+    expect(findOrCreateOrgMock).not.toHaveBeenCalled();
+  });
+
+  it("401s without a session", async () => {
+    h.getSupabaseAndUser.mockResolvedValue(null);
+    const res = await postAccounts(
+      request({ rows: [{ name: "Acme" }] }),
+      routeParams,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("403s when the list belongs to someone else", async () => {
+    const { client } = fakeSupabase([
+      { data: { id: "list-1", user_id: "someone_else" } },
+    ]);
+    h.getSupabaseAndUser.mockResolvedValue({
+      supabase: client,
+      user: { id: "user_1", email: "" },
+    });
+
+    const res = await postAccounts(
+      request({ rows: [{ name: "Acme" }] }),
+      routeParams,
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/enrich-company/route.ts
+++ b/src/app/api/enrich-company/route.ts
@@ -1,59 +1,10 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
 import { withAction } from "@/lib/services/cost-tracker";
-import { createClient, getSupabaseAndUser } from "@/lib/supabase/server";
-import {
-  summarizeSearchResults,
-  summarizeWebsite,
-} from "@/lib/services/enrichment-summarizer";
-import { ExaService } from "@/lib/services/exa-service";
-import { filterRelevantResults } from "@/lib/services/relevance-filter";
-import { WebExtractionService } from "@/lib/services/web-extraction-service";
-import {
-  mergeEnrichmentData,
-  isRecentlyEnriched,
-} from "@/lib/services/knowledge-base";
-import { findContactsForOrganization } from "@/lib/services/contact-discovery";
-import { type CompanyContext } from "@/lib/services/contact-filter";
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { enrichAndFindContacts } from "@/lib/services/company-enrichment";
 
 export const maxDuration = 120;
-
-/** Signal slugs that map to company-level enrichment operations */
-const SIGNAL_SLUG_PRODUCT = "product-launches";
-const SIGNAL_SLUG_FUNDING = "funding-news";
-const SIGNAL_SLUG_EXECUTIVE = "executive-changes";
-const SIGNAL_SLUG_GOOGLE_REVIEWS = "google-reviews";
-
-/** Returns active signal slugs, or null if signals haven't been configured for this campaign */
-async function getActiveSignalSlugs(
-  campaignId: string,
-): Promise<Set<string> | null> {
-  const supabase = await createClient();
-
-  // Check if any campaign_signals records exist at all
-  const { data: allSignals } = await supabase
-    .from("campaign_signals")
-    .select("id")
-    .eq("campaign_id", campaignId)
-    .limit(1);
-
-  // No signal config at all -- run everything (not configured yet)
-  if (!allSignals || allSignals.length === 0) return null;
-
-  const { data } = await supabase
-    .from("campaign_signals")
-    .select("signal_id, signals(slug)")
-    .eq("campaign_id", campaignId)
-    .eq("enabled", true);
-
-  if (!data) return new Set();
-  return new Set(
-    data
-      .map((row: Record<string, unknown>) => {
-        const signal = row.signals as { slug: string } | null;
-        return signal?.slug;
-      })
-      .filter((s): s is string => !!s),
-  );
-}
 
 export async function POST(request: Request) {
   const ctx = await getSupabaseAndUser();
@@ -94,11 +45,6 @@ export async function POST(request: Request) {
     }
   }
 
-  // Resolve active signal slugs for this campaign
-  const activeSlugs = campaignId
-    ? await getActiveSignalSlugs(campaignId)
-    : null; // null = run all (no campaign context)
-
   // companyId is a campaign_organizations link ID -- resolve the organization.
   // Join through campaigns.user_id so we can also verify ownership when
   // campaignId wasn't explicitly supplied.
@@ -126,9 +72,9 @@ export async function POST(request: Request) {
     }
 
     return enrichOrganization(
+      supabase,
       org as Record<string, unknown>,
       companyId,
-      activeSlugs,
       campaignId,
     );
   }
@@ -152,298 +98,42 @@ export async function POST(request: Request) {
   const org = link.organization as unknown as Record<string, unknown>;
   const orgId = link.organization_id;
 
-  return enrichOrganization(org, orgId, activeSlugs, campaignId, companyId);
+  return enrichOrganization(supabase, org, orgId, campaignId);
 }
 
 /**
- * Thin wrapper over the shared discovery path.
- *
- * This function used to be a third near-identical copy of the contact-finding
- * logic (alongside the findContacts tool and /api/find-contacts), so a fix in
- * any one of them left the same bug live in the other two.
+ * Delegates to the company-enrichment service and wraps its result in the
+ * route's response shape. `withAction` lives here (not in the service) so
+ * cost attribution stays with the caller — the QStash target-list processor
+ * wraps the same service in its own action.
  */
-async function findContactsForCompany(
-  orgId: string,
-  company: CompanyContext,
-  campaignId: string,
-): Promise<{ totalFound: number }> {
-  const supabase = await createClient();
-
-  const { data: campaign } = await supabase
-    .from("campaigns")
-    .select("icp")
-    .eq("id", campaignId)
-    .single();
-
-  const icp = campaign?.icp as Record<string, unknown> | null;
-  const targetTitles = (icp?.targetTitles as string[] | undefined) || [];
-  // Bound to avoid per-user Exa spend blowouts.
-  const boundedTitles = targetTitles.slice(0, 5);
-
-  try {
-    const result = await findContactsForOrganization(supabase, {
-      organizationId: orgId,
-      campaignId,
-      titles: boundedTitles,
-      numResults: 3,
-    });
-    if (result.error) {
-      console.warn(`[enrich-company] ${company.name}: ${result.error}`);
-    }
-    return { totalFound: result.totalFound };
-  } catch (err) {
-    console.error("[enrich-company] contact discovery failed:", err);
-    return { totalFound: 0 };
-  }
-}
-
 async function enrichOrganization(
+  supabase: SupabaseClient,
   org: Record<string, unknown>,
   orgId: string,
-  activeSlugs: Set<string> | null,
   campaignId?: string,
-  linkId?: string,
 ) {
   return withAction(`Enrich company: ${org.name}`, async () => {
-    // Check recency
-    const recent = await isRecentlyEnriched("organizations", orgId);
-    if (recent) {
-      // Still find contacts even if enrichment is cached
-      let contactsFound = 0;
-      if (campaignId) {
-        const companyCtx: CompanyContext = {
-          name: org.name as string,
-          domain: (org.domain as string) || null,
-          industry: (org.industry as string) || null,
-          location: (org.location as string) || null,
-          description: (org.description as string) || null,
-        };
-        const result = await findContactsForCompany(
-          orgId,
-          companyCtx,
-          campaignId,
-        );
-        contactsFound = result.totalFound;
-      }
+    const result = await enrichAndFindContacts(
+      supabase,
+      orgId,
+      campaignId ?? null,
+    );
+
+    if (!result.enriched) {
       return Response.json({
         companyId: orgId,
-        enrichmentData: org.enrichment_data,
+        enrichmentData: result.enrichmentData,
         skipped: true,
-        contactsFound,
+        contactsFound: result.contactsFound,
       });
-    }
-
-    // Website extraction always runs -- it's core enrichment, not a signal.
-    // Exa searches are gated by active signals when configured.
-    const runProduct = !activeSlugs || activeSlugs.has(SIGNAL_SLUG_PRODUCT);
-    const runFunding = !activeSlugs || activeSlugs.has(SIGNAL_SLUG_FUNDING);
-    const runExecutive = !activeSlugs || activeSlugs.has(SIGNAL_SLUG_EXECUTIVE);
-    const runGoogleReviews =
-      !activeSlugs || activeSlugs.has(SIGNAL_SLUG_GOOGLE_REVIEWS);
-
-    const exa = new ExaService();
-    const extractor = new WebExtractionService();
-    const errors: string[] = [];
-
-    const companyUrl =
-      (org.url as string) || (org.domain ? `https://${org.domain}` : null);
-
-    const contextParts: string[] = [];
-    if (org.industry) contextParts.push(org.industry as string);
-    if (org.location) contextParts.push(org.location as string);
-    const context = contextParts.length > 0 ? ` ${contextParts.join(" ")}` : "";
-    const domainHint = org.domain ? ` ${org.domain}` : "";
-    const specificName = `"${org.name}"${domainHint}${context}`;
-
-    const companyDomain =
-      (org.domain as string) ||
-      (companyUrl ? new URL(companyUrl).hostname : null);
-
-    // Website extraction always runs; Exa searches gated by signals
-    const operations = await Promise.allSettled([
-      companyUrl
-        ? extractor.extract(companyUrl, { includeLinks: false })
-        : Promise.resolve(null),
-      runProduct
-        ? exa.search(
-            companyDomain
-              ? `${org.name} products services`
-              : `${specificName} product services offering`,
-            {
-              numResults: 5,
-              includeText: true,
-              ...(companyDomain ? { includeDomains: [companyDomain] } : {}),
-            },
-          )
-        : Promise.resolve({ results: [] }),
-      runFunding
-        ? exa.search(`${specificName} funding news announcement`, {
-            numResults: 5,
-            includeText: true,
-            category: "news",
-          })
-        : Promise.resolve({ results: [] }),
-      runExecutive
-        ? exa.search(`${specificName} executive leadership team changes`, {
-            numResults: 5,
-            includeText: true,
-          })
-        : Promise.resolve({ results: [] }),
-      runGoogleReviews
-        ? (async () => {
-            const { GooglePlacesService } =
-              await import("@/lib/services/google-places-service");
-            const service = new GooglePlacesService();
-            return service.getPlaceReviews(
-              org.name as string,
-              (org.location as string) || undefined,
-              (org.domain as string) || undefined,
-            );
-          })()
-        : Promise.resolve(null),
-    ]);
-
-    const [
-      websiteResult,
-      productResult,
-      fundingResult,
-      executiveResult,
-      googleReviewsResult,
-    ] = operations;
-
-    const enrichmentData: Record<string, unknown> = {
-      enrichedAt: new Date().toISOString(),
-    };
-
-    if (websiteResult.status === "fulfilled" && websiteResult.value?.success) {
-      const wd = websiteResult.value.data;
-      const summary = await summarizeWebsite({
-        companyName: org.name as string,
-        title: wd.title,
-        description: wd.description,
-        content: wd.content,
-      });
-      enrichmentData.website = {
-        title: wd.title,
-        description: wd.description,
-        content: wd.content.slice(0, 3000),
-        summary: summary ?? undefined,
-        openGraph: wd.openGraph,
-      };
-    } else if (websiteResult.status === "rejected") {
-      errors.push(`Website: ${websiteResult.reason?.message || "Failed"}`);
-    }
-
-    const searches: Array<{
-      category: string;
-      query: string;
-      results: Array<{
-        title: string;
-        url: string;
-        publishedDate: string | null;
-        text: string | null;
-      }>;
-    }> = [];
-
-    const searchEntries: Array<
-      [string, boolean, PromiseSettledResult<unknown>]
-    > = [
-      ["product", runProduct, productResult],
-      ["funding", runFunding, fundingResult],
-      ["executive", runExecutive, executiveResult],
-    ];
-
-    for (const [label, enabled, result] of searchEntries) {
-      if (!enabled) continue;
-      if (result.status === "fulfilled") {
-        const value = result.value as {
-          results: Array<{
-            title: string;
-            url: string;
-            publishedDate: string | null;
-            text: string | null;
-          }>;
-        };
-        const mapped = value.results.map((r) => ({
-          title: r.title,
-          url: r.url,
-          publishedDate: r.publishedDate,
-          text: r.text?.slice(0, 2000) || null,
-        }));
-        const filtered = await filterRelevantResults(
-          org.name as string,
-          companyDomain,
-          mapped,
-        );
-        const topResults = filtered.slice(0, 3);
-        const summarized = await summarizeSearchResults(
-          org.name as string,
-          label,
-          topResults,
-        );
-        searches.push({
-          category: label,
-          query: `${org.name} ${label}`,
-          results: summarized,
-        });
-      } else {
-        errors.push(`Search (${label}): ${result.reason?.message || "Failed"}`);
-      }
-    }
-
-    enrichmentData.searches = searches;
-
-    // Google Reviews
-    if (
-      googleReviewsResult.status === "fulfilled" &&
-      googleReviewsResult.value?.found
-    ) {
-      const gr = googleReviewsResult.value;
-      enrichmentData.googleReviews = {
-        rating: gr.rating,
-        reviewCount: gr.userRatingCount,
-        googleMapsUrl: gr.googleMapsUri,
-        topReviews: gr.reviews.slice(0, 5),
-        fetchedAt: new Date().toISOString(),
-      };
-    } else if (googleReviewsResult.status === "rejected") {
-      errors.push(
-        `Google Reviews: ${googleReviewsResult.reason?.message || "Failed"}`,
-      );
-    }
-
-    if (errors.length > 0) enrichmentData.errors = errors;
-
-    await mergeEnrichmentData("organizations", orgId, enrichmentData);
-
-    // Also find contacts if we have campaign context
-    let contactsFound = 0;
-    if (campaignId) {
-      try {
-        const companyCtx: CompanyContext = {
-          name: org.name as string,
-          domain: (org.domain as string) || null,
-          industry: (org.industry as string) || null,
-          location: (org.location as string) || null,
-          description: (org.description as string) || null,
-        };
-        const result = await findContactsForCompany(
-          orgId,
-          companyCtx,
-          campaignId,
-        );
-        contactsFound = result.totalFound;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Unknown";
-        errors.push(`Find contacts: ${msg}`);
-      }
     }
 
     return Response.json({
       companyId: orgId,
-      enrichmentData,
-      contactsFound,
-      errors: errors.length > 0 ? errors : undefined,
+      enrichmentData: result.enrichmentData,
+      contactsFound: result.contactsFound,
+      errors: result.errors.length > 0 ? result.errors : undefined,
     });
   }); // end withAction
 }

--- a/src/app/api/target-lists/[id]/accounts/route.ts
+++ b/src/app/api/target-lists/[id]/accounts/route.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+
+import { getPostHogClient } from "@/lib/posthog-server";
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import {
+  appendAccountsToList,
+  MAX_ROWS_PER_REQUEST,
+} from "@/lib/services/target-lists";
+
+export const maxDuration = 60;
+
+const PersonSchema = z.object({
+  name: z.string().min(1),
+  title: z.string().nullish(),
+  email: z.string().nullish(),
+  linkedin_url: z.string().nullish(),
+});
+
+const RowSchema = z.object({
+  name: z.string(),
+  domain: z.string().nullish(),
+  url: z.string().nullish(),
+  industry: z.string().nullish(),
+  location: z.string().nullish(),
+  description: z.string().nullish(),
+  person: PersonSchema.nullish(),
+  extra: z.record(z.string(), z.string()).optional(),
+});
+
+const Body = z.object({
+  rows: z
+    .array(RowSchema)
+    .min(1, "rows array is required and must not be empty"),
+});
+
+/** Append a batch of parsed CSV rows to a target account list. */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: listId } = await params;
+
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase, user } = ctx;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // Cheap length guard before full validation, same shape as import-csv.
+  const rawRows = (body as { rows?: unknown } | null)?.rows;
+  if (Array.isArray(rawRows) && rawRows.length > MAX_ROWS_PER_REQUEST) {
+    return Response.json(
+      {
+        error: `Too many rows (${rawRows.length}). Send at most ${MAX_ROWS_PER_REQUEST} per request and batch the rest.`,
+      },
+      { status: 413 },
+    );
+  }
+
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+      { status: 400 },
+    );
+  }
+
+  // Verify the list exists and belongs to the signed-in user (defense in
+  // depth on top of RLS).
+  const { data: list, error: listError } = await supabase
+    .from("target_account_lists")
+    .select("id, user_id")
+    .eq("id", listId)
+    .single();
+
+  if (listError || !list) {
+    return Response.json({ error: "List not found" }, { status: 404 });
+  }
+  if (list.user_id !== user.id) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await appendAccountsToList(
+    supabase,
+    listId,
+    parsed.data.rows,
+    {
+      userId: user.id,
+    },
+  );
+
+  const posthog = getPostHogClient();
+  posthog.capture({
+    distinctId: user.id,
+    event: "target_list_accounts_imported",
+    properties: {
+      list_id: listId,
+      imported: result.imported,
+      skipped: result.skipped,
+      failed: result.failed,
+      people_imported: result.peopleImported,
+      total: parsed.data.rows.length,
+    },
+  });
+
+  return Response.json(result);
+}

--- a/src/app/api/target-lists/process/route.ts
+++ b/src/app/api/target-lists/process/route.ts
@@ -23,8 +23,9 @@ const BATCH_PER_INVOCATION = 2;
 /**
  * Target-list enrichment processor — one hop of a self-draining QStash chain.
  * The enrichTargetAccounts tool stamps target_accounts.enrich_requested_at
- * and publishes one message here; each hop enriches a small batch and
- * re-publishes the same payload while stamped, still-pending work remains.
+ * and publishes one message here; each hop claims and enriches a small batch
+ * and re-publishes (incrementing `attempt`, hard-capped) while stamped,
+ * still-pending work remains.
  *
  * The route is public (QStash can't send Clerk cookies), so the signature
  * check is the only auth — everything below runs on the admin client.
@@ -34,12 +35,22 @@ interface ProcessPayload {
   listId: string;
   campaignId: string;
   userId: string;
-  skipContactFinding?: boolean;
+  /** Hop counter for the self-publishing chain; absent on the first hop. */
+  attempt?: number;
 }
+
+/**
+ * Hard ceiling on chain length. At 2 accounts/hop this covers a 400-account
+ * tranche — far beyond any real approval — so hitting it means the chain is
+ * re-publishing without draining. Refuse to continue rather than loop forever.
+ */
+const MAX_CHAIN_ATTEMPTS = 200;
 
 export interface EnrichBatchItem {
   organizationId: string;
   orgName: string;
+  /** Per-row flag stamped by enrichTargetAccounts (never chain-level). */
+  skipContactFinding: boolean;
 }
 
 /**
@@ -54,7 +65,9 @@ export async function pickEnrichBatch(
 ): Promise<EnrichBatchItem[]> {
   const { data, error } = await supabase
     .from("target_accounts")
-    .select("organization_id, organizations!inner(name, enrichment_status)")
+    .select(
+      "organization_id, skip_contact_finding, organizations!inner(name, enrichment_status)",
+    )
     .eq("list_id", listId)
     .not("enrich_requested_at", "is", null)
     .eq("organizations.enrichment_status", "pending")
@@ -68,6 +81,7 @@ export async function pickEnrichBatch(
     return {
       organizationId: row.organization_id as string,
       orgName: org?.name ?? "(unknown)",
+      skipContactFinding: Boolean(row.skip_contact_finding),
     };
   });
 }
@@ -113,7 +127,25 @@ export async function POST(request: Request) {
     BATCH_PER_INVOCATION,
   );
 
+  let processed = 0;
   for (const account of work) {
+    // Atomically claim the row before enriching (outreach-sender pattern):
+    // overlapping hops both pick it, but only the one whose conditional
+    // update lands proceeds — the loser skips. Clearing the stamp up front
+    // also means a poison row can never loop the chain: on failure the org
+    // stays non-enriched and is simply dropped from the queue (logged below,
+    // deliberately NOT re-stamped).
+    const { data: claimed } = await supabase
+      .from("target_accounts")
+      .update({ enrich_requested_at: null, skip_contact_finding: false })
+      .eq("list_id", body.listId)
+      .eq("organization_id", account.organizationId)
+      .not("enrich_requested_at", "is", null)
+      .select("organization_id")
+      .maybeSingle();
+    if (!claimed) continue;
+
+    processed++;
     try {
       await withAction(`Enrich target account: ${account.orgName}`, () =>
         enrichAndFindContacts(
@@ -121,32 +153,36 @@ export async function POST(request: Request) {
           account.organizationId,
           body.campaignId,
           {
-            skipContactFinding: body.skipContactFinding ?? false,
+            skipContactFinding: account.skipContactFinding,
           },
         ),
       );
     } catch (err) {
       console.error(
-        `[target-lists/process] enrich failed for org ${account.organizationId}:`,
+        `[target-lists/process] enrich failed for org ${account.organizationId} ` +
+          `(list ${body.listId}) — dropped from the queue, will not retry:`,
         err,
       );
-      // Org enrichment_status stays 'pending'/'failed'; do not retry here —
-      // clear enrich_requested_at so the chain can't loop on a poison row.
-      await supabase
-        .from("target_accounts")
-        .update({ enrich_requested_at: null })
-        .eq("list_id", body.listId)
-        .eq("organization_id", account.organizationId);
     }
   }
 
   const remaining = await countRemaining(supabase, body.listId);
   if (remaining > 0) {
-    await getQStashClient().publishJSON({
-      url: getBaseUrl() + "/api/target-lists/process",
-      body,
-    });
+    const attempt = body.attempt ?? 1;
+    if (attempt >= MAX_CHAIN_ATTEMPTS) {
+      console.error(
+        `[target-lists/process] HARD CEILING: chain for list ${body.listId} ` +
+          `reached attempt ${attempt} with ${remaining} account(s) remaining — ` +
+          "refusing to re-publish. The queue is stuck; investigate why stamped " +
+          "rows are not draining.",
+      );
+    } else {
+      await getQStashClient().publishJSON({
+        url: getBaseUrl() + "/api/target-lists/process",
+        body: { ...body, attempt: attempt + 1 },
+      });
+    }
   }
 
-  return NextResponse.json({ processed: work.length, remaining });
+  return NextResponse.json({ processed, remaining });
 }

--- a/src/app/api/target-lists/process/route.ts
+++ b/src/app/api/target-lists/process/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { getAdminClient } from "@/lib/supabase/admin";
+import {
+  verifyQStashSignature,
+  getQStashClient,
+  getBaseUrl,
+} from "@/lib/services/qstash";
+import { withAction } from "@/lib/services/cost-tracker";
+import { enrichAndFindContacts } from "@/lib/services/company-enrichment";
+
+// Enrichment is ~1 min/company (website extraction + Exa + summarization),
+// so give each hop real headroom for its small batch.
+export const maxDuration = 120;
+
+/**
+ * Keep hops small: two accounts per invocation stays comfortably inside
+ * maxDuration and the chain re-publishes itself until the list drains.
+ */
+const BATCH_PER_INVOCATION = 2;
+
+/**
+ * Target-list enrichment processor — one hop of a self-draining QStash chain.
+ * The enrichTargetAccounts tool stamps target_accounts.enrich_requested_at
+ * and publishes one message here; each hop enriches a small batch and
+ * re-publishes the same payload while stamped, still-pending work remains.
+ *
+ * The route is public (QStash can't send Clerk cookies), so the signature
+ * check is the only auth — everything below runs on the admin client.
+ */
+
+interface ProcessPayload {
+  listId: string;
+  campaignId: string;
+  userId: string;
+  skipContactFinding?: boolean;
+}
+
+export interface EnrichBatchItem {
+  organizationId: string;
+  orgName: string;
+}
+
+/**
+ * Next batch of work: stamped rows whose org is still enrichment-pending,
+ * oldest request first. The join filter means orgs already enriched via the
+ * shared pool drain from the queue instantly, without spend — desired.
+ */
+export async function pickEnrichBatch(
+  supabase: SupabaseClient,
+  listId: string,
+  n: number,
+): Promise<EnrichBatchItem[]> {
+  const { data, error } = await supabase
+    .from("target_accounts")
+    .select("organization_id, organizations!inner(name, enrichment_status)")
+    .eq("list_id", listId)
+    .not("enrich_requested_at", "is", null)
+    .eq("organizations.enrichment_status", "pending")
+    .order("enrich_requested_at", { ascending: true })
+    .limit(n);
+  if (error) {
+    throw new Error(`Failed to pick enrichment batch: ${error.message}`);
+  }
+  return (data ?? []).map((row: Record<string, unknown>) => {
+    const org = row.organizations as { name: string } | null;
+    return {
+      organizationId: row.organization_id as string,
+      orgName: org?.name ?? "(unknown)",
+    };
+  });
+}
+
+/** Same filters as the picker, count only — decides whether to chain on. */
+export async function countRemaining(
+  supabase: SupabaseClient,
+  listId: string,
+): Promise<number> {
+  const { count, error } = await supabase
+    .from("target_accounts")
+    .select("organization_id, organizations!inner(enrichment_status)", {
+      count: "exact",
+      head: true,
+    })
+    .eq("list_id", listId)
+    .not("enrich_requested_at", "is", null)
+    .eq("organizations.enrichment_status", "pending");
+  if (error) {
+    throw new Error(`Failed to count remaining work: ${error.message}`);
+  }
+  return count ?? 0;
+}
+
+export async function POST(request: Request) {
+  let payload: ProcessPayload | null;
+  try {
+    payload = await verifyQStashSignature<ProcessPayload>(request);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Invalid signature";
+    return NextResponse.json({ error: msg }, { status: 401 });
+  }
+  if (!payload) {
+    return NextResponse.json({ error: "Missing payload" }, { status: 400 });
+  }
+
+  const supabase = getAdminClient();
+  const body = payload;
+
+  const work = await pickEnrichBatch(
+    supabase,
+    body.listId,
+    BATCH_PER_INVOCATION,
+  );
+
+  for (const account of work) {
+    try {
+      await withAction(`Enrich target account: ${account.orgName}`, () =>
+        enrichAndFindContacts(
+          supabase,
+          account.organizationId,
+          body.campaignId,
+          {
+            skipContactFinding: body.skipContactFinding ?? false,
+          },
+        ),
+      );
+    } catch (err) {
+      console.error(
+        `[target-lists/process] enrich failed for org ${account.organizationId}:`,
+        err,
+      );
+      // Org enrichment_status stays 'pending'/'failed'; do not retry here —
+      // clear enrich_requested_at so the chain can't loop on a poison row.
+      await supabase
+        .from("target_accounts")
+        .update({ enrich_requested_at: null })
+        .eq("list_id", body.listId)
+        .eq("organization_id", account.organizationId);
+    }
+  }
+
+  const remaining = await countRemaining(supabase, body.listId);
+  if (remaining > 0) {
+    await getQStashClient().publishJSON({
+      url: getBaseUrl() + "/api/target-lists/process",
+      body,
+    });
+  }
+
+  return NextResponse.json({ processed: work.length, remaining });
+}

--- a/src/app/api/target-lists/route.ts
+++ b/src/app/api/target-lists/route.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+import { getPostHogClient } from "@/lib/posthog-server";
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+
+const CreateBody = z.object({
+  name: z.string().trim().min(1, "name is required").max(200),
+  original_filename: z.string().max(300).nullish(),
+});
+
+/** Create a target account list. Rows are appended separately in batches. */
+export async function POST(request: Request) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase, user } = ctx;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = CreateBody.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+      { status: 400 },
+    );
+  }
+
+  const { data: list, error } = await supabase
+    .from("target_account_lists")
+    .insert({
+      user_id: user.id,
+      name: parsed.data.name,
+      original_filename: parsed.data.original_filename ?? null,
+    })
+    .select("*")
+    .single();
+
+  if (error || !list) {
+    return Response.json(
+      { error: `Failed to create list: ${error?.message ?? "unknown error"}` },
+      { status: 500 },
+    );
+  }
+
+  const posthog = getPostHogClient();
+  posthog.capture({
+    distinctId: user.id,
+    event: "target_list_created",
+    properties: {
+      list_id: list.id,
+      has_filename: Boolean(parsed.data.original_filename),
+    },
+  });
+
+  return Response.json(list);
+}
+
+/** List the signed-in user's target account lists, newest first. */
+export async function GET() {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase, user } = ctx;
+
+  // RLS already scopes rows to the owner; the eq is defense in depth, same as
+  // import-csv's ownership re-check.
+  const { data: lists, error } = await supabase
+    .from("target_account_lists")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return Response.json(
+      { error: `Failed to load lists: ${error.message}` },
+      { status: 500 },
+    );
+  }
+
+  return Response.json({ lists: lists ?? [] });
+}

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useChat } from "@ai-sdk/react";
 import { SquarePen } from "lucide-react";
 
 import { useAuth } from "@clerk/nextjs";
+import { toast } from "sonner";
 
 import { ChatErrorBanner } from "@/components/chat/chat-error-banner";
 import { ChatInput } from "@/components/chat/chat-input";
@@ -18,6 +19,7 @@ import { useStreaming } from "@/lib/streaming-context";
 import { loadChat, saveChat } from "@/lib/services/chat-history";
 import { createClient } from "@/lib/supabase/client";
 import { apiFetch } from "@/lib/api-fetch";
+import { mapColumns, parseCSV } from "@/lib/csv/company-csv";
 
 // ---------------------------------------------------------------------------
 // Inner component -- only rendered after initial messages are loaded so that
@@ -134,9 +136,95 @@ function ChatView({
     setInput("");
   };
 
-  const onCsvUpload = (content: string, fileName: string) => {
-    const msg = `I'm uploading a CSV file (${fileName}). Please review the data and help me import it into the active campaign.\n\n\`\`\`csv\n${content}\n\`\`\``;
-    sendMessage({ text: msg }, requestOptions);
+  // CSV uploads become a target account list (server-side), not pasted CSV in
+  // the chat context. The agent only receives a one-line receipt with the
+  // list ID and works the list through the target-list tools.
+  const onCsvUpload = async (content: string, fileName: string) => {
+    const { headers, rows } = parseCSV(content);
+    if (headers.length === 0 || rows.length === 0) {
+      toast.error("No rows found in that CSV");
+      return;
+    }
+    const accounts = mapColumns(headers, rows);
+    const listName = fileName.replace(/\.[^./\\]+$/, "").trim() || fileName;
+
+    let listId: string;
+    try {
+      const res = await apiFetch("/api/target-lists", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: listName, original_filename: fileName }),
+      });
+      const data = (await res.json().catch(() => null)) as {
+        id?: string;
+        error?: string;
+      } | null;
+      if (!res.ok || !data?.id) {
+        throw new Error(data?.error ?? "Failed to create the target list");
+      }
+      listId = data.id;
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create the target list",
+      );
+      return;
+    }
+
+    const BATCH_SIZE = 500;
+    const totalBatches = Math.ceil(accounts.length / BATCH_SIZE);
+    const totals = { imported: 0, skipped: 0, failed: 0, peopleImported: 0 };
+    const progressToastId =
+      totalBatches > 1
+        ? toast.loading(`Importing ${accounts.length} rows...`)
+        : undefined;
+
+    for (let i = 0; i < totalBatches; i++) {
+      const batch = accounts.slice(i * BATCH_SIZE, (i + 1) * BATCH_SIZE);
+      if (progressToastId !== undefined) {
+        toast.loading(`Importing batch ${i + 1} of ${totalBatches}...`, {
+          id: progressToastId,
+        });
+      }
+      try {
+        const res = await apiFetch(`/api/target-lists/${listId}/accounts`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ rows: batch }),
+        });
+        if (!res.ok) throw new Error();
+        const result = (await res.json()) as {
+          imported?: number;
+          skipped?: number;
+          failed?: number;
+          peopleImported?: number;
+        };
+        totals.imported += result.imported ?? 0;
+        totals.skipped += result.skipped ?? 0;
+        totals.failed += result.failed ?? 0;
+        totals.peopleImported += result.peopleImported ?? 0;
+      } catch {
+        totals.failed += batch.length;
+      }
+    }
+
+    if (progressToastId !== undefined) toast.dismiss(progressToastId);
+
+    if (totals.imported === 0 && totals.skipped === 0) {
+      toast.error("Import failed", {
+        description: "No rows could be imported. Check the file and try again.",
+      });
+      return;
+    }
+
+    let text = `I've uploaded a target account list "${fileName}" — ${totals.imported} companies imported (${totals.skipped} duplicates skipped), list ID ${listId}.`;
+    if (totals.peopleImported > 0) {
+      text += ` The file also included ${totals.peopleImported} contacts, now attached to their accounts.`;
+    }
+    if (totals.failed > 0) {
+      text += ` Note: ${totals.failed} rows failed to import.`;
+    }
+    text += " Please help me work this list.";
+    sendMessage({ text }, requestOptions);
   };
 
   const router = useRouter();

--- a/src/components/campaign/csv-upload.tsx
+++ b/src/components/campaign/csv-upload.tsx
@@ -11,166 +11,18 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { apiFetch } from "@/lib/api-fetch";
+import { COLUMN_MAP, mapColumns, parseCSV } from "@/lib/csv/company-csv";
 import { MAX_ROWS_PER_REQUEST } from "@/lib/import-limits";
-
-interface ParsedCompany {
-  name: string;
-  domain: string | null;
-  url: string | null;
-  industry: string | null;
-  location: string | null;
-  description: string | null;
-}
+import type { TargetAccountRow } from "@/lib/types/target-list";
 
 interface CsvUploadProps {
   campaignId: string;
   onImported: () => void;
 }
 
-// Column name aliases for auto-mapping
-const COLUMN_MAP: Record<string, keyof ParsedCompany> = {
-  name: "name",
-  company: "name",
-  company_name: "name",
-  "company name": "name",
-  organization: "name",
-  domain: "domain",
-  website: "domain",
-  "website url": "domain",
-  site: "domain",
-  url: "url",
-  link: "url",
-  industry: "industry",
-  sector: "industry",
-  vertical: "industry",
-  location: "location",
-  city: "location",
-  country: "location",
-  hq: "location",
-  headquarters: "location",
-  region: "location",
-  geography: "location",
-  description: "description",
-  about: "description",
-  summary: "description",
-  overview: "description",
-};
-
-function parseCSV(text: string): { headers: string[]; rows: string[][] } {
-  const lines: string[] = [];
-  let current = "";
-  let inQuotes = false;
-
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    if (ch === '"') {
-      if (inQuotes && text[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-    } else if (
-      (ch === "\n" || (ch === "\r" && text[i + 1] === "\n")) &&
-      !inQuotes
-    ) {
-      lines.push(current);
-      current = "";
-      if (ch === "\r") i++;
-    } else {
-      current += ch;
-    }
-  }
-  if (current.trim()) lines.push(current);
-
-  if (lines.length === 0) return { headers: [], rows: [] };
-
-  const splitRow = (line: string): string[] => {
-    const cells: string[] = [];
-    let cell = "";
-    let q = false;
-    for (let i = 0; i < line.length; i++) {
-      const ch = line[i];
-      if (ch === '"') {
-        if (q && line[i + 1] === '"') {
-          cell += '"';
-          i++;
-        } else {
-          q = !q;
-        }
-      } else if (ch === "," && !q) {
-        cells.push(cell.trim());
-        cell = "";
-      } else {
-        cell += ch;
-      }
-    }
-    cells.push(cell.trim());
-    return cells;
-  };
-
-  const headers = splitRow(lines[0]);
-  const rows = lines
-    .slice(1)
-    .map(splitRow)
-    .filter((r) => r.some((c) => c));
-
-  return { headers, rows };
-}
-
-function mapColumns(headers: string[], rows: string[][]): ParsedCompany[] {
-  // Map header index to field
-  const mapping: Array<keyof ParsedCompany | null> = headers.map((h) => {
-    const normalized = h.toLowerCase().trim();
-    return COLUMN_MAP[normalized] ?? null;
-  });
-
-  // If no "name" column was found, try the first column
-  if (!mapping.includes("name") && headers.length > 0) {
-    mapping[0] = "name";
-  }
-
-  return rows.map((row) => {
-    const company: ParsedCompany = {
-      name: "",
-      domain: null,
-      url: null,
-      industry: null,
-      location: null,
-      description: null,
-    };
-
-    for (let i = 0; i < row.length; i++) {
-      const field = mapping[i];
-      if (field && row[i]) {
-        if (field === "name") {
-          company.name = row[i];
-        } else {
-          company[field] = row[i];
-        }
-      }
-    }
-
-    // If url is set but domain isn't, try extracting domain
-    if (!company.domain && company.url) {
-      try {
-        company.domain = new URL(
-          company.url.startsWith("http")
-            ? company.url
-            : `https://${company.url}`,
-        ).hostname.replace("www.", "");
-      } catch {
-        // skip
-      }
-    }
-
-    return company;
-  });
-}
-
 export function CsvUpload({ campaignId, onImported }: CsvUploadProps) {
   const [open, setOpen] = useState(false);
-  const [companies, setCompanies] = useState<ParsedCompany[]>([]);
+  const [companies, setCompanies] = useState<TargetAccountRow[]>([]);
   const [headers, setHeaders] = useState<string[]>([]);
   const [importing, setImporting] = useState(false);
   const [result, setResult] = useState<{

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -4,9 +4,12 @@ import { useEffect, useRef } from "react";
 
 import { ArrowUp, Paperclip, Square } from "lucide-react";
 import posthog from "posthog-js";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+
+const MAX_CSV_SIZE_BYTES = 5 * 1024 * 1024;
 
 interface ChatInputProps {
   input: string;
@@ -66,6 +69,13 @@ export function ChatInput({
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !onCsvUpload) return;
+    if (file.size > MAX_CSV_SIZE_BYTES) {
+      toast.error("CSV is too large", {
+        description: "Files up to 5 MB are supported. Split it and try again.",
+      });
+      e.target.value = "";
+      return;
+    }
     posthog.capture("csv_uploaded", {
       file_name: file.name,
       file_size_bytes: file.size,

--- a/src/components/ui/provenance-badge.tsx
+++ b/src/components/ui/provenance-badge.tsx
@@ -149,6 +149,7 @@ const AFFILIATION_LABEL: Record<string, string> = {
   email_domain: "verified email at the company's domain",
   team_page: "listed on the company's own website",
   linkedin_profile: "their LinkedIn profile names this company",
+  csv_import: "your uploaded list places them here",
   llm_verified: "checked against their profile",
   search_stamp: "only appeared in a search for this company",
 };

--- a/src/lib/csv/company-csv.ts
+++ b/src/lib/csv/company-csv.ts
@@ -1,0 +1,270 @@
+import type { TargetAccountRow } from "@/lib/types/target-list";
+
+/**
+ * Shared company-CSV parsing: a dependency-free parser plus header→field
+ * mapping. Moved out of src/components/campaign/csv-upload.tsx so target-list
+ * imports (chat upload, API routes) reuse the exact same behavior.
+ *
+ * Extensions over the original component code:
+ * 1. Unmapped columns are preserved verbatim in `extra` (the campaign CSV
+ *    dialog simply ignores them).
+ * 2. Contact-per-row exports (Apollo/Clay/CRM) are detected via person-name
+ *    columns; each row then carries a `person`. A bare `name` column always
+ *    maps to the COMPANY — person names come only from explicit person
+ *    aliases — and a bare `email` column belongs to the person.
+ */
+
+export const CANONICAL_FIELDS = [
+  "name",
+  "domain",
+  "url",
+  "industry",
+  "location",
+  "description",
+] as const;
+
+export type CanonicalField = (typeof CANONICAL_FIELDS)[number];
+
+// Column name aliases for auto-mapping (company fields)
+export const COLUMN_MAP: Record<string, CanonicalField> = {
+  name: "name",
+  company: "name",
+  company_name: "name",
+  "company name": "name",
+  organization: "name",
+  domain: "domain",
+  website: "domain",
+  "website url": "domain",
+  site: "domain",
+  url: "url",
+  link: "url",
+  industry: "industry",
+  sector: "industry",
+  vertical: "industry",
+  location: "location",
+  city: "location",
+  country: "location",
+  hq: "location",
+  headquarters: "location",
+  region: "location",
+  geography: "location",
+  description: "description",
+  about: "description",
+  summary: "description",
+  overview: "description",
+};
+
+type PersonField =
+  | "first_name"
+  | "last_name"
+  | "full_name"
+  | "title"
+  | "email"
+  | "linkedin_url";
+
+/** Aliases for contact-per-row exports. Person mode only activates when a
+ * person-NAME column exists; title/email/linkedin alone stay in `extra`. */
+const PERSON_COLUMN_MAP: Record<string, PersonField> = {
+  first_name: "first_name",
+  "first name": "first_name",
+  firstname: "first_name",
+  last_name: "last_name",
+  "last name": "last_name",
+  lastname: "last_name",
+  full_name: "full_name",
+  "full name": "full_name",
+  fullname: "full_name",
+  "contact name": "full_name",
+  contact_name: "full_name",
+  title: "title",
+  job_title: "title",
+  "job title": "title",
+  role: "title",
+  email: "email",
+  work_email: "email",
+  "work email": "email",
+  "contact email": "email",
+  contact_email: "email",
+  linkedin: "linkedin_url",
+  linkedin_url: "linkedin_url",
+  "linkedin url": "linkedin_url",
+  person_linkedin: "linkedin_url",
+  "person linkedin": "linkedin_url",
+};
+
+const PERSON_NAME_FIELDS: ReadonlySet<PersonField> = new Set([
+  "first_name",
+  "last_name",
+  "full_name",
+]);
+
+export function parseCSV(text: string): {
+  headers: string[];
+  rows: string[][];
+} {
+  const lines: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  // First pass only splits lines; quotes are preserved verbatim so splitRow
+  // below can still tell quoted commas from cell separators.
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        current += '""';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+        current += '"';
+      }
+    } else if (
+      (ch === "\n" || (ch === "\r" && text[i + 1] === "\n")) &&
+      !inQuotes
+    ) {
+      lines.push(current);
+      current = "";
+      if (ch === "\r") i++;
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) lines.push(current);
+
+  if (lines.length === 0) return { headers: [], rows: [] };
+
+  const splitRow = (line: string): string[] => {
+    const cells: string[] = [];
+    let cell = "";
+    let q = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (ch === '"') {
+        if (q && line[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          q = !q;
+        }
+      } else if (ch === "," && !q) {
+        cells.push(cell.trim());
+        cell = "";
+      } else {
+        cell += ch;
+      }
+    }
+    cells.push(cell.trim());
+    return cells;
+  };
+
+  const headers = splitRow(lines[0]);
+  const rows = lines
+    .slice(1)
+    .map(splitRow)
+    .filter((r) => r.some((c) => c));
+
+  return { headers, rows };
+}
+
+export function mapColumns(
+  headers: string[],
+  rows: string[][],
+): TargetAccountRow[] {
+  const normalized = headers.map((h) => h.toLowerCase().trim());
+
+  // Company-field mapping (identical to the original component logic).
+  const mapping: Array<CanonicalField | null> = normalized.map(
+    (h) => COLUMN_MAP[h] ?? null,
+  );
+
+  // Person columns only take effect when the file has a person-NAME column —
+  // that is what marks a contact-per-row export. A bare `name` column always
+  // maps to the company (COLUMN_MAP claims it above).
+  const personCandidates: Array<PersonField | null> = normalized.map((h, i) =>
+    mapping[i] === null ? (PERSON_COLUMN_MAP[h] ?? null) : null,
+  );
+  const personMode = personCandidates.some(
+    (f) => f !== null && PERSON_NAME_FIELDS.has(f),
+  );
+  const personMapping: Array<PersonField | null> = personMode
+    ? personCandidates
+    : normalized.map(() => null);
+
+  // If no "name" column was found, try the first column — unless it already
+  // carries a person field (only possible in person mode, new behavior).
+  if (!mapping.includes("name") && headers.length > 0 && !personMapping[0]) {
+    mapping[0] = "name";
+  }
+
+  return rows.map((row) => {
+    const account: TargetAccountRow = {
+      name: "",
+      domain: null,
+      url: null,
+      industry: null,
+      location: null,
+      description: null,
+      person: null,
+    };
+    const person = {
+      first_name: "",
+      last_name: "",
+      full_name: "",
+      title: "",
+      email: "",
+      linkedin_url: "",
+    };
+    let extra: Record<string, string> | undefined;
+
+    for (let i = 0; i < row.length; i++) {
+      const field = mapping[i];
+      if (field && row[i]) {
+        if (field === "name") {
+          account.name = row[i];
+        } else {
+          account[field] = row[i];
+        }
+        continue;
+      }
+      const personField = personMapping[i];
+      if (personField) {
+        if (row[i]) person[personField] = row[i];
+        continue;
+      }
+      if (row[i]) {
+        extra ??= {};
+        extra[headers[i]] = row[i];
+      }
+    }
+
+    // If url is set but domain isn't, try extracting domain
+    if (!account.domain && account.url) {
+      try {
+        account.domain = new URL(
+          account.url.startsWith("http")
+            ? account.url
+            : `https://${account.url}`,
+        ).hostname.replace("www.", "");
+      } catch {
+        // skip
+      }
+    }
+
+    if (personMode) {
+      const personName =
+        person.full_name ||
+        [person.first_name, person.last_name].filter(Boolean).join(" ");
+      if (personName) {
+        account.person = {
+          name: personName,
+          title: person.title || null,
+          email: person.email || null,
+          linkedin_url: person.linkedin_url || null,
+        };
+      }
+    }
+
+    if (extra) account.extra = extra;
+    return account;
+  });
+}

--- a/src/lib/csv/header-mapper.ts
+++ b/src/lib/csv/header-mapper.ts
@@ -1,0 +1,121 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { llmTimeout } from "@/lib/utils/timeout";
+import { z } from "zod";
+import { MODELS } from "@/lib/ai/models";
+import {
+  estimateClaudeCostFromUsage,
+  trackUsage,
+} from "@/lib/services/cost-tracker";
+import { UNTRUSTED_NOTICE, wrapUntrusted } from "@/lib/prompt-safety";
+import {
+  CANONICAL_FIELDS,
+  COLUMN_MAP,
+  type CanonicalField,
+} from "@/lib/csv/company-csv";
+
+/**
+ * LLM fallback for CSV headers COLUMN_MAP didn't recognize: given each header
+ * plus a few sample values, ask Haiku to map it to a canonical company field
+ * or "ignore". Known aliases are resolved from COLUMN_MAP first and never
+ * cost an LLM call. Falls back to "ignore" for every unknown header on any
+ * error (permissive-fallback convention from relevance-filter.ts).
+ */
+
+export interface HeaderSample {
+  header: string;
+  /** Up to ~3 sample values from the column, for disambiguation. */
+  samples: string[];
+}
+
+export type HeaderMapping = CanonicalField | "ignore";
+
+const VALID_FIELDS = new Set<string>([...CANONICAL_FIELDS, "ignore"]);
+
+const ResponseSchema = z.object({
+  mappings: z.array(
+    z.object({
+      header: z.string(),
+      field: z.enum([...CANONICAL_FIELDS, "ignore"] as [string, ...string[]]),
+    }),
+  ),
+});
+
+export async function mapUnknownHeaders(
+  headers: HeaderSample[],
+  context?: { campaignId?: string; userId?: string },
+): Promise<Record<string, HeaderMapping>> {
+  const result: Record<string, HeaderMapping> = {};
+  if (headers.length === 0) return result;
+
+  // COLUMN_MAP first: known aliases pass through without an LLM call.
+  const unknown: HeaderSample[] = [];
+  for (const h of headers) {
+    const known = COLUMN_MAP[h.header.toLowerCase().trim()];
+    if (known) {
+      result[h.header] = known;
+    } else {
+      unknown.push(h);
+    }
+  }
+  if (unknown.length === 0) return result;
+
+  // Default every unknown to "ignore"; the model upgrades what it recognizes.
+  for (const h of unknown) result[h.header] = "ignore";
+
+  const lines = unknown.map(
+    (h) =>
+      `header: ${h.header}\nsamples: ${h.samples.slice(0, 3).join(" | ") || "(none)"}`,
+  );
+
+  try {
+    const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
+      model: anthropic(MODELS.LIGHT),
+      schema: ResponseSchema,
+      prompt: `You are mapping CSV column headers from a user-uploaded company list to canonical fields.
+
+${UNTRUSTED_NOTICE}
+
+Map each header below to exactly one of: ${CANONICAL_FIELDS.join(", ")}, ignore.
+- "name" is the company name, "domain" a bare domain like acme.com, "url" a full link.
+- Use the sample values to disambiguate (e.g. a column of city names is "location").
+- Use "ignore" for anything that is not clearly one of the canonical company fields (ids, dates, scores, personal names, emails, free-form notes).
+
+Return a mapping for every header, using the header text exactly as given.
+
+Headers:
+${wrapUntrusted(lines.join("\n\n"))}`,
+    });
+
+    trackUsage({
+      service: "claude",
+      operation: "csv-header-mapper",
+      tokens_input: usage.inputTokens ?? 0,
+      tokens_output: usage.outputTokens ?? 0,
+      estimated_cost_usd: estimateClaudeCostFromUsage("haiku", usage),
+      campaign_id: context?.campaignId,
+      user_id: context?.userId,
+      metadata: {
+        model: MODELS.LIGHT,
+        headerCount: unknown.length,
+      },
+    });
+
+    const inputHeaders = new Set(unknown.map((h) => h.header));
+    for (const m of object.mappings) {
+      // Drop hallucinated headers and out-of-enum fields.
+      if (!inputHeaders.has(m.header)) continue;
+      if (!VALID_FIELDS.has(m.field)) continue;
+      result[m.header] = m.field as HeaderMapping;
+    }
+  } catch (err) {
+    console.error(
+      "[header-mapper] LLM mapping failed, ignoring unknown headers:",
+      err,
+    );
+    // result already holds "ignore" for every unknown header.
+  }
+
+  return result;
+}

--- a/src/lib/services/affiliation.ts
+++ b/src/lib/services/affiliation.ts
@@ -22,6 +22,7 @@ export type AffiliationSource =
   | "email_domain"
   | "team_page"
   | "linkedin_profile"
+  | "csv_import"
   | "llm_verified"
   | "search_stamp";
 
@@ -37,6 +38,16 @@ export const AFFILIATION_WEIGHT: Record<AffiliationSource, number> = {
   email_domain: 0.95,
   /** Listed on the company's own website. They published it about themselves. */
   team_page: 0.9,
+  /**
+   * The user's uploaded target list places them at this company. Deliberately
+   * NOT ranked as a human assertion: uploads are routinely AI-generated
+   * prospect lists or stale exports from another tool, so the claim is
+   * secondhand at best. Above the send threshold — an imported contact is
+   * actionable as-is — but below email_domain, so Signal's own verification
+   * can correct a bad upload, and below user_entered, so it never triggers
+   * the human-override move.
+   */
+  csv_import: 0.85,
   /** Their LinkedIn profile names this employer. */
   linkedin_profile: 0.8,
   /** An LLM read the evidence and judged them an employee. */

--- a/src/lib/services/company-enrichment.ts
+++ b/src/lib/services/company-enrichment.ts
@@ -116,6 +116,16 @@ async function findContactsForCompany(
   }
 }
 
+export interface EnrichmentOptions {
+  /**
+   * Skip contact discovery and only run company enrichment — for accounts
+   * whose imported contacts already match the ICP. Deliberately a separate
+   * flag rather than `campaignId: null`: the campaign also gates which
+   * signal searches run, and that gating must survive a contacts-only skip.
+   */
+  skipContactFinding?: boolean;
+}
+
 /**
  * Enrich an organization (website extraction + signal-gated Exa searches +
  * Google reviews) and, when campaign context exists, find contacts for it.
@@ -127,6 +137,7 @@ export async function enrichAndFindContacts(
   supabase: SupabaseClient,
   organizationId: string,
   campaignId: string | null,
+  options?: EnrichmentOptions,
 ): Promise<CompanyEnrichmentResult> {
   const { data: orgRow, error: orgError } = await supabase
     .from("organizations")
@@ -142,6 +153,7 @@ export async function enrichAndFindContacts(
 
   const org = orgRow as Record<string, unknown>;
   const orgId = organizationId;
+  const findContactsEnabled = !options?.skipContactFinding;
 
   // Resolve active signal slugs for this campaign
   const activeSlugs = campaignId
@@ -153,7 +165,7 @@ export async function enrichAndFindContacts(
   if (recent) {
     // Still find contacts even if enrichment is cached
     let contactsFound = 0;
-    if (campaignId) {
+    if (campaignId && findContactsEnabled) {
       const companyCtx: CompanyContext = {
         name: org.name as string,
         domain: (org.domain as string) || null,
@@ -367,7 +379,7 @@ export async function enrichAndFindContacts(
 
   // Also find contacts if we have campaign context
   let contactsFound = 0;
-  if (campaignId) {
+  if (campaignId && findContactsEnabled) {
     try {
       const companyCtx: CompanyContext = {
         name: org.name as string,

--- a/src/lib/services/company-enrichment.ts
+++ b/src/lib/services/company-enrichment.ts
@@ -1,0 +1,398 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  summarizeSearchResults,
+  summarizeWebsite,
+} from "@/lib/services/enrichment-summarizer";
+import { ExaService } from "@/lib/services/exa-service";
+import { filterRelevantResults } from "@/lib/services/relevance-filter";
+import { WebExtractionService } from "@/lib/services/web-extraction-service";
+import {
+  mergeEnrichmentData,
+  isRecentlyEnriched,
+} from "@/lib/services/knowledge-base";
+import { findContactsForOrganization } from "@/lib/services/contact-discovery";
+import { type CompanyContext } from "@/lib/services/contact-filter";
+
+/**
+ * Company enrichment as a service, extracted from /api/enrich-company so the
+ * QStash target-list processor can run it under the admin client. Every
+ * function takes an explicit SupabaseClient — nothing here builds its own.
+ *
+ * Cost attribution (`withAction`) deliberately stays with the CALLERS: the
+ * enrich-company route and the QStash route each wrap this in their own
+ * action so spend lands on the right label.
+ */
+
+/** Signal slugs that map to company-level enrichment operations */
+const SIGNAL_SLUG_PRODUCT = "product-launches";
+const SIGNAL_SLUG_FUNDING = "funding-news";
+const SIGNAL_SLUG_EXECUTIVE = "executive-changes";
+const SIGNAL_SLUG_GOOGLE_REVIEWS = "google-reviews";
+
+export interface CompanyEnrichmentResult {
+  /** False when the 7-day recency check skipped re-enrichment. */
+  enriched: boolean;
+  contactsFound: number;
+  errors: string[];
+  /**
+   * The freshly built enrichment payload, or the organization's stored
+   * enrichment_data when the recency check skipped. Surfaced so the route
+   * can keep its exact response shape.
+   */
+  enrichmentData: unknown;
+}
+
+/** Returns active signal slugs, or null if signals haven't been configured for this campaign */
+async function getActiveSignalSlugs(
+  supabase: SupabaseClient,
+  campaignId: string,
+): Promise<Set<string> | null> {
+  // Check if any campaign_signals records exist at all
+  const { data: allSignals } = await supabase
+    .from("campaign_signals")
+    .select("id")
+    .eq("campaign_id", campaignId)
+    .limit(1);
+
+  // No signal config at all -- run everything (not configured yet)
+  if (!allSignals || allSignals.length === 0) return null;
+
+  const { data } = await supabase
+    .from("campaign_signals")
+    .select("signal_id, signals(slug)")
+    .eq("campaign_id", campaignId)
+    .eq("enabled", true);
+
+  if (!data) return new Set();
+  return new Set(
+    data
+      .map((row: Record<string, unknown>) => {
+        const signal = row.signals as { slug: string } | null;
+        return signal?.slug;
+      })
+      .filter((s): s is string => !!s),
+  );
+}
+
+/**
+ * Thin wrapper over the shared discovery path.
+ *
+ * This function used to be a third near-identical copy of the contact-finding
+ * logic (alongside the findContacts tool and /api/find-contacts), so a fix in
+ * any one of them left the same bug live in the other two.
+ */
+async function findContactsForCompany(
+  supabase: SupabaseClient,
+  orgId: string,
+  company: CompanyContext,
+  campaignId: string,
+): Promise<{ totalFound: number }> {
+  const { data: campaign } = await supabase
+    .from("campaigns")
+    .select("icp")
+    .eq("id", campaignId)
+    .single();
+
+  const icp = campaign?.icp as Record<string, unknown> | null;
+  const targetTitles = (icp?.targetTitles as string[] | undefined) || [];
+  // Bound to avoid per-user Exa spend blowouts.
+  const boundedTitles = targetTitles.slice(0, 5);
+
+  try {
+    const result = await findContactsForOrganization(supabase, {
+      organizationId: orgId,
+      campaignId,
+      titles: boundedTitles,
+      numResults: 3,
+    });
+    if (result.error) {
+      console.warn(`[company-enrichment] ${company.name}: ${result.error}`);
+    }
+    return { totalFound: result.totalFound };
+  } catch (err) {
+    console.error("[company-enrichment] contact discovery failed:", err);
+    return { totalFound: 0 };
+  }
+}
+
+/**
+ * Enrich an organization (website extraction + signal-gated Exa searches +
+ * Google reviews) and, when campaign context exists, find contacts for it.
+ *
+ * The 7-day recency skip applies only to enrichment — contact-finding still
+ * runs on the skip path.
+ */
+export async function enrichAndFindContacts(
+  supabase: SupabaseClient,
+  organizationId: string,
+  campaignId: string | null,
+): Promise<CompanyEnrichmentResult> {
+  const { data: orgRow, error: orgError } = await supabase
+    .from("organizations")
+    .select("*")
+    .eq("id", organizationId)
+    .single();
+
+  if (orgError || !orgRow) {
+    throw new Error(
+      `Organization not found: ${orgError?.message ?? "unknown"}`,
+    );
+  }
+
+  const org = orgRow as Record<string, unknown>;
+  const orgId = organizationId;
+
+  // Resolve active signal slugs for this campaign
+  const activeSlugs = campaignId
+    ? await getActiveSignalSlugs(supabase, campaignId)
+    : null; // null = run all (no campaign context)
+
+  // Check recency
+  const recent = await isRecentlyEnriched("organizations", orgId, 7, supabase);
+  if (recent) {
+    // Still find contacts even if enrichment is cached
+    let contactsFound = 0;
+    if (campaignId) {
+      const companyCtx: CompanyContext = {
+        name: org.name as string,
+        domain: (org.domain as string) || null,
+        industry: (org.industry as string) || null,
+        location: (org.location as string) || null,
+        description: (org.description as string) || null,
+      };
+      const result = await findContactsForCompany(
+        supabase,
+        orgId,
+        companyCtx,
+        campaignId,
+      );
+      contactsFound = result.totalFound;
+    }
+    return {
+      enriched: false,
+      contactsFound,
+      errors: [],
+      enrichmentData: org.enrichment_data,
+    };
+  }
+
+  // Website extraction always runs -- it's core enrichment, not a signal.
+  // Exa searches are gated by active signals when configured.
+  const runProduct = !activeSlugs || activeSlugs.has(SIGNAL_SLUG_PRODUCT);
+  const runFunding = !activeSlugs || activeSlugs.has(SIGNAL_SLUG_FUNDING);
+  const runExecutive = !activeSlugs || activeSlugs.has(SIGNAL_SLUG_EXECUTIVE);
+  const runGoogleReviews =
+    !activeSlugs || activeSlugs.has(SIGNAL_SLUG_GOOGLE_REVIEWS);
+
+  const exa = new ExaService();
+  const extractor = new WebExtractionService();
+  const errors: string[] = [];
+
+  const companyUrl =
+    (org.url as string) || (org.domain ? `https://${org.domain}` : null);
+
+  const contextParts: string[] = [];
+  if (org.industry) contextParts.push(org.industry as string);
+  if (org.location) contextParts.push(org.location as string);
+  const context = contextParts.length > 0 ? ` ${contextParts.join(" ")}` : "";
+  const domainHint = org.domain ? ` ${org.domain}` : "";
+  const specificName = `"${org.name}"${domainHint}${context}`;
+
+  const companyDomain =
+    (org.domain as string) ||
+    (companyUrl ? new URL(companyUrl).hostname : null);
+
+  // Website extraction always runs; Exa searches gated by signals
+  const operations = await Promise.allSettled([
+    companyUrl
+      ? extractor.extract(companyUrl, { includeLinks: false })
+      : Promise.resolve(null),
+    runProduct
+      ? exa.search(
+          companyDomain
+            ? `${org.name} products services`
+            : `${specificName} product services offering`,
+          {
+            numResults: 5,
+            includeText: true,
+            ...(companyDomain ? { includeDomains: [companyDomain] } : {}),
+          },
+        )
+      : Promise.resolve({ results: [] }),
+    runFunding
+      ? exa.search(`${specificName} funding news announcement`, {
+          numResults: 5,
+          includeText: true,
+          category: "news",
+        })
+      : Promise.resolve({ results: [] }),
+    runExecutive
+      ? exa.search(`${specificName} executive leadership team changes`, {
+          numResults: 5,
+          includeText: true,
+        })
+      : Promise.resolve({ results: [] }),
+    runGoogleReviews
+      ? (async () => {
+          const { GooglePlacesService } =
+            await import("@/lib/services/google-places-service");
+          const service = new GooglePlacesService();
+          return service.getPlaceReviews(
+            org.name as string,
+            (org.location as string) || undefined,
+            (org.domain as string) || undefined,
+          );
+        })()
+      : Promise.resolve(null),
+  ]);
+
+  const [
+    websiteResult,
+    productResult,
+    fundingResult,
+    executiveResult,
+    googleReviewsResult,
+  ] = operations;
+
+  const enrichmentData: Record<string, unknown> = {
+    enrichedAt: new Date().toISOString(),
+  };
+
+  if (websiteResult.status === "fulfilled" && websiteResult.value?.success) {
+    const wd = websiteResult.value.data;
+    const summary = await summarizeWebsite({
+      companyName: org.name as string,
+      title: wd.title,
+      description: wd.description,
+      content: wd.content,
+    });
+    enrichmentData.website = {
+      title: wd.title,
+      description: wd.description,
+      content: wd.content.slice(0, 3000),
+      summary: summary ?? undefined,
+      openGraph: wd.openGraph,
+    };
+  } else if (websiteResult.status === "rejected") {
+    errors.push(`Website: ${websiteResult.reason?.message || "Failed"}`);
+  }
+
+  const searches: Array<{
+    category: string;
+    query: string;
+    results: Array<{
+      title: string;
+      url: string;
+      publishedDate: string | null;
+      text: string | null;
+    }>;
+  }> = [];
+
+  const searchEntries: Array<[string, boolean, PromiseSettledResult<unknown>]> =
+    [
+      ["product", runProduct, productResult],
+      ["funding", runFunding, fundingResult],
+      ["executive", runExecutive, executiveResult],
+    ];
+
+  for (const [label, enabled, result] of searchEntries) {
+    if (!enabled) continue;
+    if (result.status === "fulfilled") {
+      const value = result.value as {
+        results: Array<{
+          title: string;
+          url: string;
+          publishedDate: string | null;
+          text: string | null;
+        }>;
+      };
+      const mapped = value.results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        publishedDate: r.publishedDate,
+        text: r.text?.slice(0, 2000) || null,
+      }));
+      const filtered = await filterRelevantResults(
+        org.name as string,
+        companyDomain,
+        mapped,
+      );
+      const topResults = filtered.slice(0, 3);
+      const summarized = await summarizeSearchResults(
+        org.name as string,
+        label,
+        topResults,
+      );
+      searches.push({
+        category: label,
+        query: `${org.name} ${label}`,
+        results: summarized,
+      });
+    } else {
+      errors.push(`Search (${label}): ${result.reason?.message || "Failed"}`);
+    }
+  }
+
+  enrichmentData.searches = searches;
+
+  // Google Reviews
+  if (
+    googleReviewsResult.status === "fulfilled" &&
+    googleReviewsResult.value?.found
+  ) {
+    const gr = googleReviewsResult.value;
+    enrichmentData.googleReviews = {
+      rating: gr.rating,
+      reviewCount: gr.userRatingCount,
+      googleMapsUrl: gr.googleMapsUri,
+      topReviews: gr.reviews.slice(0, 5),
+      fetchedAt: new Date().toISOString(),
+    };
+  } else if (googleReviewsResult.status === "rejected") {
+    errors.push(
+      `Google Reviews: ${googleReviewsResult.reason?.message || "Failed"}`,
+    );
+  }
+
+  if (errors.length > 0) enrichmentData.errors = errors;
+
+  await mergeEnrichmentData(
+    "organizations",
+    orgId,
+    enrichmentData,
+    "enriched",
+    supabase,
+  );
+
+  // Also find contacts if we have campaign context
+  let contactsFound = 0;
+  if (campaignId) {
+    try {
+      const companyCtx: CompanyContext = {
+        name: org.name as string,
+        domain: (org.domain as string) || null,
+        industry: (org.industry as string) || null,
+        location: (org.location as string) || null,
+        description: (org.description as string) || null,
+      };
+      const result = await findContactsForCompany(
+        supabase,
+        orgId,
+        companyCtx,
+        campaignId,
+      );
+      contactsFound = result.totalFound;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown";
+      errors.push(`Find contacts: ${msg}`);
+    }
+  }
+
+  return {
+    enriched: true,
+    contactsFound,
+    errors,
+    enrichmentData,
+  };
+}

--- a/src/lib/services/contact-discovery.ts
+++ b/src/lib/services/contact-discovery.ts
@@ -222,14 +222,17 @@ export async function findContactsForOrganization(
           continue;
         }
 
-        const person = await findOrCreatePerson({
-          name: dp.name,
-          title: dp.title,
-          linkedin_url: linkedinUrl,
-          work_email: dp.email,
-          organization_id: organizationId,
-          source: "website",
-        });
+        const person = await findOrCreatePerson(
+          {
+            name: dp.name,
+            title: dp.title,
+            linkedin_url: linkedinUrl,
+            work_email: dp.email,
+            organization_id: organizationId,
+            source: "website",
+          },
+          supabase,
+        );
 
         const evidence = `listed on ${org.domain}`;
         await recordAffiliation(supabase, {
@@ -247,7 +250,8 @@ export async function findContactsForOrganization(
           });
         }
 
-        if (campaignId) await linkPersonToCampaign(person.id, campaignId);
+        if (campaignId)
+          await linkPersonToCampaign(person.id, campaignId, supabase);
         if (linkedinUrl) existingUrls.add(linkedinUrl);
 
         verifiedCount++;
@@ -378,13 +382,16 @@ export async function findContactsForOrganization(
       const source: AffiliationSource =
         judged.verdict === "verified" ? "llm_verified" : "search_stamp";
 
-      const person = await findOrCreatePerson({
-        name: judged.name,
-        title: judged.title,
-        linkedin_url: candidate.linkedinUrl,
-        organization_id: attachTo,
-        source: "exa",
-      });
+      const person = await findOrCreatePerson(
+        {
+          name: judged.name,
+          title: judged.title,
+          linkedin_url: candidate.linkedinUrl,
+          organization_id: attachTo,
+          source: "exa",
+        },
+        supabase,
+      );
 
       await recordAffiliation(supabase, {
         personId: person.id,
@@ -400,7 +407,8 @@ export async function findContactsForOrganization(
       if (judged.verdict === "verified") verifiedCount++;
       else uncertainCount++;
 
-      if (campaignId) await linkPersonToCampaign(person.id, campaignId);
+      if (campaignId)
+        await linkPersonToCampaign(person.id, campaignId, supabase);
 
       contacts.push({
         id: person.id,

--- a/src/lib/services/email-pattern.ts
+++ b/src/lib/services/email-pattern.ts
@@ -9,6 +9,7 @@ export type EmailSource =
   | "team_page"
   | "exa_search"
   | "provider_found"
+  | "csv_import"
   | "pattern_derived";
 
 export interface VerifiedEmail {
@@ -29,6 +30,14 @@ export const SOURCE_WEIGHT: Record<EmailSource, number> = {
   // page — and well above exa_search for the same reason.
   provider_found: 0.75,
   team_page: 0.7,
+  // An address the user's uploaded target list carried. Better than a string
+  // Exa found near a name, but below team_page and provider_found: uploads
+  // are often AI-generated or stale exports, so an import must never displace
+  // an address one of those sources established — in particular one a
+  // verifier has since confirmed deliverable (recordVerifiedEmail refuses a
+  // different-address write from a weaker source). Not in the JIT skip list
+  // either, so the send gate still proves the mailbox before anything leaves.
+  csv_import: 0.5,
   exa_search: 0.3,
   // A guess, by construction. Zero weight keeps derived addresses out of the
   // evidence that infers the pattern they came from.

--- a/src/lib/services/knowledge-base.ts
+++ b/src/lib/services/knowledge-base.ts
@@ -1,4 +1,5 @@
 import { getDomain } from "tldts";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import type { Organization, Person } from "@/lib/types/campaign";
 
@@ -167,17 +168,22 @@ export async function findOrCreateOrganization(data: {
  * Find an existing person by LinkedIn URL (primary) or name+org (fallback),
  * or create a new one. Returns the person record.
  */
-export async function findOrCreatePerson(data: {
-  name: string;
-  linkedin_url?: string | null;
-  work_email?: string | null;
-  personal_email?: string | null;
-  twitter_url?: string | null;
-  title?: string | null;
-  organization_id?: string | null;
-  source?: string | null;
-}): Promise<Person> {
-  const supabase = await createClient();
+export async function findOrCreatePerson(
+  data: {
+    name: string;
+    linkedin_url?: string | null;
+    work_email?: string | null;
+    personal_email?: string | null;
+    twitter_url?: string | null;
+    title?: string | null;
+    organization_id?: string | null;
+    source?: string | null;
+  },
+  client?: SupabaseClient,
+): Promise<Person> {
+  // Callers running outside a Clerk session (e.g. QStash processors) must
+  // pass their own client; defaults to the RLS request client otherwise.
+  const supabase = client ?? (await createClient());
   const normalizedLinkedin = data.linkedin_url
     ? normalizeLinkedInUrl(data.linkedin_url)
     : null;
@@ -317,8 +323,9 @@ export async function linkOrganizationToCampaign(
 export async function linkPersonToCampaign(
   personId: string,
   campaignId: string,
+  client?: SupabaseClient,
 ): Promise<{ id: string }> {
-  const supabase = await createClient();
+  const supabase = client ?? (await createClient());
 
   const { data, error } = await supabase
     .from("campaign_people")
@@ -343,8 +350,9 @@ export async function mergeEnrichmentData(
   id: string,
   newData: Record<string, unknown>,
   status: "enriched" | "failed" = "enriched",
+  client?: SupabaseClient,
 ): Promise<void> {
-  const supabase = await createClient();
+  const supabase = client ?? (await createClient());
 
   // Fetch existing enrichment_data
   const { data: existing } = await supabase
@@ -389,8 +397,9 @@ export async function isRecentlyEnriched(
   table: "organizations" | "people",
   id: string,
   maxAgeDays: number = 7,
+  client?: SupabaseClient,
 ): Promise<boolean> {
-  const supabase = await createClient();
+  const supabase = client ?? (await createClient());
 
   const { data } = await supabase
     .from(table)

--- a/src/lib/services/knowledge-base.ts
+++ b/src/lib/services/knowledge-base.ts
@@ -378,7 +378,11 @@ export async function mergeEnrichmentData(
     }
   }
 
-  await supabase
+  // Throw on failure: a swallowed error here leaves enrichment_status stuck
+  // at 'pending' with the caller believing the work landed — the target-list
+  // chain would then re-pick the org forever. Callers' per-account error
+  // handling owns the failure.
+  const { error: updateError } = await supabase
     .from(table)
     .update({
       enrichment_data: merged,
@@ -387,6 +391,11 @@ export async function mergeEnrichmentData(
         status === "enriched" ? new Date().toISOString() : undefined,
     })
     .eq("id", id);
+  if (updateError) {
+    throw new Error(
+      `Failed to persist enrichment for ${table}/${id}: ${updateError.message}`,
+    );
+  }
 }
 
 /**

--- a/src/lib/services/target-account-scorer.ts
+++ b/src/lib/services/target-account-scorer.ts
@@ -1,0 +1,170 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { llmTimeout } from "@/lib/utils/timeout";
+import { MODELS } from "@/lib/ai/models";
+import {
+  estimateClaudeCostFromUsage,
+  trackUsage,
+} from "@/lib/services/cost-tracker";
+import {
+  UNTRUSTED_NOTICE,
+  stringify,
+  wrapUntrusted,
+} from "@/lib/prompt-safety";
+import type { ICP } from "@/lib/types/campaign";
+
+/**
+ * Chunked ICP-fit scorer for target-account lists (structural clone of
+ * department-classifier.ts). Scores CSV-imported companies against the
+ * campaign ICP/offering from base data only — no enrichment has happened
+ * yet, so the rubric explicitly forbids inventing facts.
+ */
+
+const CHUNK_SIZE = 25;
+
+/** Cap the raw-CSV context per account so one wide row can't blow the prompt. */
+const MAX_RAW_CHARS = 400;
+
+export interface TargetAccountToScore {
+  organizationId: string;
+  name: string;
+  domain: string | null;
+  industry: string | null;
+  location: string | null;
+  /** Original CSV row, verbatim — may carry extra columns worth scoring on. */
+  raw: Record<string, string>;
+}
+
+export interface TargetAccountScore {
+  organizationId: string;
+  score: number;
+  reason: string;
+}
+
+const ResponseSchema = z.object({
+  scores: z.array(
+    z.object({
+      organizationId: z.string(),
+      score: z.number().min(1).max(10).describe("ICP fit score 1-10"),
+      reason: z
+        .string()
+        .describe(
+          "One short sentence (under 140 characters) grounded ONLY in the data provided",
+        ),
+    }),
+  ),
+});
+
+function buildRubric(campaign: {
+  name: string;
+  icp: ICP;
+  offering: unknown;
+}): string {
+  return `You are triaging a user-uploaded target account list against a sales campaign's Ideal Customer Profile. Score each company's ICP fit from 1-10.
+
+Campaign: ${stringify(campaign.name)}
+ICP: ${JSON.stringify(campaign.icp)}
+Offering: ${JSON.stringify(campaign.offering)}
+
+Score bands:
+- 8-10: strong ICP fit — industry, size/stage, geography, and likely pain all line up. Prioritize.
+- 6-7: plausible fit — matches on some dimensions, worth enriching to confirm.
+- 5 or below: weak fit or insufficient signal in the data given.
+
+Rules:
+- Score ONLY from the base data given below. These companies are not enriched yet — do not invent facts, funding rounds, headcounts, or news.
+- Sparse data is not disqualifying by itself, but do not score above 7 without at least one concrete matching dimension.
+- reason: one sentence, under 140 characters, citing the specific fields that drove the score.
+- Return a score for every company, keyed by its organizationId exactly as given.
+
+${UNTRUSTED_NOTICE}`;
+}
+
+function accountLines(chunk: TargetAccountToScore[]): string {
+  return chunk
+    .map((a) => {
+      const extra = JSON.stringify(a.raw ?? {});
+      return [
+        `organizationId: ${a.organizationId}`,
+        `name: ${stringify(a.name)}`,
+        `domain: ${stringify(a.domain ?? "(unknown)")}`,
+        a.industry ? `industry: ${stringify(a.industry)}` : null,
+        a.location ? `location: ${stringify(a.location)}` : null,
+        extra !== "{}" ? `csv_row: ${extra.slice(0, MAX_RAW_CHARS)}` : null,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n\n");
+}
+
+export async function scoreTargetAccounts(input: {
+  campaign: { id: string; name: string; icp: ICP; offering: unknown };
+  accounts: TargetAccountToScore[];
+  userId: string;
+}): Promise<TargetAccountScore[]> {
+  const { campaign, accounts, userId } = input;
+  if (accounts.length === 0) return [];
+
+  const chunks: TargetAccountToScore[][] = [];
+  for (let i = 0; i < accounts.length; i += CHUNK_SIZE) {
+    chunks.push(accounts.slice(i, i + CHUNK_SIZE));
+  }
+
+  const rubric = buildRubric(campaign);
+  const results: TargetAccountScore[] = [];
+
+  for (const chunk of chunks) {
+    const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
+      model: anthropic(MODELS.STRUCTURED),
+      schema: ResponseSchema,
+      messages: [
+        {
+          role: "system",
+          content: rubric,
+          // The rubric + ICP block is identical across chunks (and across
+          // re-runs within ~5 min) — cache it.
+          providerOptions: {
+            anthropic: { cacheControl: { type: "ephemeral" } },
+          },
+        },
+        {
+          role: "user",
+          content: `Companies to score:\n${wrapUntrusted(accountLines(chunk))}`,
+        },
+      ],
+    });
+
+    trackUsage({
+      service: "claude",
+      operation: "prioritize-target-accounts",
+      tokens_input: usage.inputTokens ?? 0,
+      tokens_output: usage.outputTokens ?? 0,
+      estimated_cost_usd: estimateClaudeCostFromUsage("sonnet", usage),
+      metadata: {
+        model: MODELS.STRUCTURED,
+        chunkSize: chunk.length,
+        cache_creation_tokens: usage.inputTokenDetails?.cacheWriteTokens,
+        cache_read_tokens: usage.inputTokenDetails?.cacheReadTokens,
+      },
+      campaign_id: campaign.id,
+      user_id: userId,
+    });
+
+    // Drop hallucinated organizationIds — only ids we sent may come back.
+    const sent = new Set(chunk.map((a) => a.organizationId));
+    for (const s of object.scores) {
+      if (sent.has(s.organizationId)) {
+        results.push({
+          organizationId: s.organizationId,
+          score: s.score,
+          reason: s.reason,
+        });
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/lib/services/target-lists.ts
+++ b/src/lib/services/target-lists.ts
@@ -64,9 +64,10 @@ interface Candidate {
  *
  * Contact-per-row files (rows carrying `person`) additionally import people:
  * one org + N contacts per company, deduped by linkedin_url / name+org inside
- * findOrCreatePerson, with affiliation provenance (`user_entered`, the upload
- * is the user's own claim) and the email stored as an unchecked suggestion the
- * send gate verifies just-in-time. People are NOT linked to any campaign here
+ * findOrCreatePerson, with affiliation provenance (`csv_import` — an upload
+ * is a suggestion Signal's own verification may override, not a human
+ * assertion) and the email stored as an unchecked suggestion the send gate
+ * verifies just-in-time. People are NOT linked to any campaign here
  * — linkTargetListToCampaign owns that.
  */
 export async function appendAccountsToList(
@@ -181,25 +182,30 @@ export async function appendAccountsToList(
               supabase,
             );
 
-            // The user's own upload names this employer — that is a human
-            // assertion, same rank as assigning the contact by hand.
+            // The upload names this employer, but a CSV is often an
+            // AI-generated prospect list or a stale export — a suggestion,
+            // not a human assertion. csv_import (0.85) keeps the contact
+            // above the send threshold while letting email_domain
+            // verification or an explicit human edit override a bad upload.
             await recordAffiliation(supabase, {
               personId: person.id,
               organizationId: org.id,
-              source: "user_entered",
-              evidence: `csv_import: the user's uploaded target list places them at ${candidate.name}`,
+              source: "csv_import",
+              evidence: `the user's uploaded target list places them at ${candidate.name}`,
             });
 
-            // Imported addresses are free suggestions, not proof: record them
-            // with a non-trusted source so verification stays unchecked and
-            // the send gate's just-in-time verifier proves the mailbox before
-            // anything leaves (lazy-verification convention). Junk that isn't
-            // even email-shaped is skipped silently — the person still imports.
+            // Imported addresses are free suggestions, not proof: csv_import
+            // ranks below every verified-ish source, so an upload can never
+            // displace an address a scrape or provider established, and
+            // verification stays unchecked so the send gate's just-in-time
+            // verifier proves the mailbox before anything leaves
+            // (lazy-verification convention). Junk that isn't even
+            // email-shaped is skipped silently — the person still imports.
             if (p.email && EMAIL_SHAPE.test(p.email)) {
               await recordVerifiedEmail(supabase, {
                 personId: person.id,
                 email: p.email,
-                source: "provider_found",
+                source: "csv_import",
               });
             }
             people++;

--- a/src/lib/services/target-lists.ts
+++ b/src/lib/services/target-lists.ts
@@ -21,6 +21,9 @@ export const MAX_ROWS_PER_REQUEST = 500;
 /** Same chunked parallelism as import-csv (route.ts:164-179). */
 const CHUNK_SIZE = 10;
 
+/** Minimal email shape gate — CSVs carry junk like "n/a" or "see notes". */
+const EMAIL_SHAPE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
 export interface AppendAccountsResult {
   imported: number;
   skipped: number;
@@ -190,8 +193,9 @@ export async function appendAccountsToList(
             // Imported addresses are free suggestions, not proof: record them
             // with a non-trusted source so verification stays unchecked and
             // the send gate's just-in-time verifier proves the mailbox before
-            // anything leaves (lazy-verification convention).
-            if (p.email) {
+            // anything leaves (lazy-verification convention). Junk that isn't
+            // even email-shaped is skipped silently — the person still imports.
+            if (p.email && EMAIL_SHAPE.test(p.email)) {
               await recordVerifiedEmail(supabase, {
                 personId: person.id,
                 email: p.email,

--- a/src/lib/services/target-lists.ts
+++ b/src/lib/services/target-lists.ts
@@ -1,0 +1,223 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  findOrCreateOrganization,
+  normalizeDomain,
+} from "@/lib/services/knowledge-base";
+import {
+  mapUnknownHeaders,
+  type HeaderMapping,
+  type HeaderSample,
+} from "@/lib/csv/header-mapper";
+import type { TargetAccountRow } from "@/lib/types/target-list";
+
+/** Row cap per append request — mirror import-limits.ts. */
+export const MAX_ROWS_PER_REQUEST = 500;
+
+/** Same chunked parallelism as import-csv (route.ts:164-179). */
+const CHUNK_SIZE = 10;
+
+export interface AppendAccountsResult {
+  imported: number;
+  skipped: number;
+  failed: number;
+  peopleImported: number;
+}
+
+/** One company after in-batch grouping, ready to resolve + insert. */
+interface Candidate {
+  name: string;
+  domain: string | null;
+  url: string | null;
+  industry: string | null;
+  location: string | null;
+  description: string | null;
+  /** Original row content, preserved verbatim on the target_accounts row. */
+  raw: Record<string, string>;
+}
+
+/**
+ * Resolve rows to organizations (domain-deduped globally via
+ * findOrCreateOrganization) and insert target_accounts. Dedup within the list
+ * is by organization_id via the (list_id, organization_id) unique constraint —
+ * on-conflict-do-nothing, counted as skipped. Chunks of 10 like import-csv.
+ *
+ * When rows carry unmapped headers in `extra`, the LLM header mapper runs once
+ * for the whole batch and mapped fields are folded into empty canonical slots.
+ */
+export async function appendAccountsToList(
+  supabase: SupabaseClient,
+  listId: string,
+  rows: TargetAccountRow[],
+  opts: { userId?: string } = {},
+): Promise<AppendAccountsResult> {
+  const headerMapping = await resolveExtraHeaders(rows, opts.userId);
+
+  // Pass 1 (sequential, cheap): fold extras, normalize, dedup into candidates.
+  // Same reasoning as import-csv: domain-less rows dedup by normalized name
+  // because findOrCreateOrganization's matching can't serialize two identical
+  // rows racing in the same parallel chunk.
+  let skipped = 0;
+  const groups = new Map<string, Candidate>();
+
+  for (const row of rows) {
+    const folded = foldExtra(row, headerMapping);
+    const name = folded.name?.trim();
+    if (!name) {
+      skipped++;
+      continue;
+    }
+
+    let domain: string | null = folded.domain?.trim() || null;
+    if (!domain && folded.url) {
+      try {
+        domain = new URL(
+          folded.url.startsWith("http") ? folded.url : `https://${folded.url}`,
+        ).hostname;
+      } catch {
+        // unusable URL — leave the row domain-less
+      }
+    }
+    if (domain) domain = normalizeDomain(domain);
+
+    const key = domain ?? `name:${name.toLowerCase()}`;
+    if (groups.has(key)) {
+      skipped++;
+      continue;
+    }
+
+    groups.set(key, {
+      name,
+      domain,
+      url: folded.url?.trim() || (domain ? `https://${domain}` : null),
+      industry: folded.industry?.trim() || null,
+      location: folded.location?.trim() || null,
+      description: folded.description?.trim() || null,
+      raw: buildRaw(folded, row.extra),
+    });
+  }
+
+  // Pass 2 (parallel chunks): resolve orgs + upsert accounts. Org creation
+  // recovers from 23505 races and the account insert ignores duplicates, so
+  // chunk-internal parallelism is safe.
+  let imported = 0;
+  let failed = 0;
+  const peopleImported = 0;
+  const candidates = [...groups.values()];
+
+  for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
+    const chunk = candidates.slice(i, i + CHUNK_SIZE);
+    const results = await Promise.allSettled(
+      chunk.map(async (candidate) => {
+        const org = await findOrCreateOrganization({
+          name: candidate.name,
+          domain: candidate.domain,
+          url: candidate.url,
+          industry: candidate.industry,
+          location: candidate.location,
+          description: candidate.description,
+          source: "target_list",
+        });
+
+        const { data: upserted, error } = await supabase
+          .from("target_accounts")
+          .upsert(
+            { list_id: listId, organization_id: org.id, raw: candidate.raw },
+            { onConflict: "list_id,organization_id", ignoreDuplicates: true },
+          )
+          .select("id");
+        if (error) {
+          throw new Error(`Failed to insert target account: ${error.message}`);
+        }
+
+        // ignoreDuplicates returns no row when the account already existed.
+        return { inserted: (upserted?.length ?? 0) > 0 };
+      }),
+    );
+
+    for (const r of results) {
+      if (r.status === "fulfilled") {
+        if (r.value.inserted) imported++;
+        else skipped++;
+      } else {
+        failed++;
+        console.error("[target-lists] row failed:", r.reason);
+      }
+    }
+  }
+
+  // Read-modify-write is fine under one owner (RLS scopes the list to them).
+  if (imported > 0) {
+    const { data: list } = await supabase
+      .from("target_account_lists")
+      .select("row_count")
+      .eq("id", listId)
+      .single();
+    await supabase
+      .from("target_account_lists")
+      .update({ row_count: (list?.row_count ?? 0) + imported })
+      .eq("id", listId);
+  }
+
+  return { imported, skipped, failed, peopleImported };
+}
+
+/**
+ * One header-mapper call per batch: collect every header seen in `extra`
+ * (with up to 3 sample values each) and ask for canonical assignments.
+ * Returns {} when nothing is unmapped, so callers pay no LLM cost.
+ */
+async function resolveExtraHeaders(
+  rows: TargetAccountRow[],
+  userId?: string,
+): Promise<Record<string, HeaderMapping>> {
+  const samplesByHeader = new Map<string, string[]>();
+  for (const row of rows) {
+    for (const [header, value] of Object.entries(row.extra ?? {})) {
+      const samples = samplesByHeader.get(header) ?? [];
+      if (value && samples.length < 3) samples.push(value);
+      samplesByHeader.set(header, samples);
+    }
+  }
+  if (samplesByHeader.size === 0) return {};
+
+  const headerSamples: HeaderSample[] = [...samplesByHeader].map(
+    ([header, samples]) => ({ header, samples }),
+  );
+  return mapUnknownHeaders(headerSamples, { userId });
+}
+
+/** Fold header-mapped extra values into canonical fields the row left empty. */
+function foldExtra(
+  row: TargetAccountRow,
+  mapping: Record<string, HeaderMapping>,
+): TargetAccountRow {
+  if (!row.extra) return row;
+  const folded = { ...row };
+  for (const [header, value] of Object.entries(row.extra)) {
+    const field = mapping[header];
+    if (!field || field === "ignore" || !value) continue;
+    if (!folded[field]) folded[field] = value;
+  }
+  return folded;
+}
+
+/** The original CSV row, verbatim: canonical fields plus everything unmapped. */
+function buildRaw(
+  row: TargetAccountRow,
+  extra: Record<string, string> | undefined,
+): Record<string, string> {
+  const raw: Record<string, string> = {};
+  for (const field of [
+    "name",
+    "domain",
+    "url",
+    "industry",
+    "location",
+    "description",
+  ] as const) {
+    const value = row[field];
+    if (value) raw[field] = value;
+  }
+  return { ...raw, ...extra };
+}

--- a/src/lib/services/target-lists.ts
+++ b/src/lib/services/target-lists.ts
@@ -1,9 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import {
+  canHoldPeople,
   findOrCreateOrganization,
+  findOrCreatePerson,
   normalizeDomain,
 } from "@/lib/services/knowledge-base";
+import { recordAffiliation } from "@/lib/services/affiliation";
+import { recordVerifiedEmail } from "@/lib/services/email-pattern";
 import {
   mapUnknownHeaders,
   type HeaderMapping,
@@ -24,6 +28,14 @@ export interface AppendAccountsResult {
   peopleImported: number;
 }
 
+/** A contact carried by a contact-per-row export (Apollo/Clay/CRM). */
+interface PersonRow {
+  name: string;
+  title: string | null;
+  email: string | null;
+  linkedin_url: string | null;
+}
+
 /** One company after in-batch grouping, ready to resolve + insert. */
 interface Candidate {
   name: string;
@@ -34,6 +46,8 @@ interface Candidate {
   description: string | null;
   /** Original row content, preserved verbatim on the target_accounts row. */
   raw: Record<string, string>;
+  /** Contacts from every row that grouped into this company. */
+  people: PersonRow[];
 }
 
 /**
@@ -44,6 +58,13 @@ interface Candidate {
  *
  * When rows carry unmapped headers in `extra`, the LLM header mapper runs once
  * for the whole batch and mapped fields are folded into empty canonical slots.
+ *
+ * Contact-per-row files (rows carrying `person`) additionally import people:
+ * one org + N contacts per company, deduped by linkedin_url / name+org inside
+ * findOrCreatePerson, with affiliation provenance (`user_entered`, the upload
+ * is the user's own claim) and the email stored as an unchecked suggestion the
+ * send gate verifies just-in-time. People are NOT linked to any campaign here
+ * — linkTargetListToCampaign owns that.
  */
 export async function appendAccountsToList(
   supabase: SupabaseClient,
@@ -81,8 +102,13 @@ export async function appendAccountsToList(
     if (domain) domain = normalizeDomain(domain);
 
     const key = domain ?? `name:${name.toLowerCase()}`;
-    if (groups.has(key)) {
-      skipped++;
+    const person = sanitizePerson(row.person);
+    const existing = groups.get(key);
+    if (existing) {
+      // Contact-per-row files legitimately repeat the company: later rows
+      // contribute their person to the group instead of counting as dups.
+      if (person) existing.people.push(person);
+      else skipped++;
       continue;
     }
 
@@ -94,6 +120,7 @@ export async function appendAccountsToList(
       location: folded.location?.trim() || null,
       description: folded.description?.trim() || null,
       raw: buildRaw(folded, row.extra),
+      people: person ? [person] : [],
     });
   }
 
@@ -102,7 +129,7 @@ export async function appendAccountsToList(
   // chunk-internal parallelism is safe.
   let imported = 0;
   let failed = 0;
-  const peopleImported = 0;
+  let peopleImported = 0;
   const candidates = [...groups.values()];
 
   for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
@@ -130,8 +157,53 @@ export async function appendAccountsToList(
           throw new Error(`Failed to insert target account: ${error.message}`);
         }
 
+        // People import runs even when the account already existed (a
+        // re-import should still pick up new contacts); dedup happens inside
+        // findOrCreatePerson via linkedin_url / name+org. Domain-less orgs
+        // never hold people (canHoldPeople) — two same-named companies are
+        // indistinguishable without a domain, so attaching contacts is how
+        // the wrong people end up pooled under the right name.
+        let people = 0;
+        if (candidate.people.length > 0 && canHoldPeople(org)) {
+          for (const p of candidate.people) {
+            const person = await findOrCreatePerson(
+              {
+                name: p.name,
+                title: p.title,
+                linkedin_url: p.linkedin_url,
+                work_email: p.email,
+                organization_id: org.id,
+                source: "target_list",
+              },
+              supabase,
+            );
+
+            // The user's own upload names this employer — that is a human
+            // assertion, same rank as assigning the contact by hand.
+            await recordAffiliation(supabase, {
+              personId: person.id,
+              organizationId: org.id,
+              source: "user_entered",
+              evidence: `csv_import: the user's uploaded target list places them at ${candidate.name}`,
+            });
+
+            // Imported addresses are free suggestions, not proof: record them
+            // with a non-trusted source so verification stays unchecked and
+            // the send gate's just-in-time verifier proves the mailbox before
+            // anything leaves (lazy-verification convention).
+            if (p.email) {
+              await recordVerifiedEmail(supabase, {
+                personId: person.id,
+                email: p.email,
+                source: "provider_found",
+              });
+            }
+            people++;
+          }
+        }
+
         // ignoreDuplicates returns no row when the account already existed.
-        return { inserted: (upserted?.length ?? 0) > 0 };
+        return { inserted: (upserted?.length ?? 0) > 0, people };
       }),
     );
 
@@ -139,6 +211,7 @@ export async function appendAccountsToList(
       if (r.status === "fulfilled") {
         if (r.value.inserted) imported++;
         else skipped++;
+        peopleImported += r.value.people;
       } else {
         failed++;
         console.error("[target-lists] row failed:", r.reason);
@@ -185,6 +258,18 @@ async function resolveExtraHeaders(
     ([header, samples]) => ({ header, samples }),
   );
   return mapUnknownHeaders(headerSamples, { userId });
+}
+
+/** Trim a row's person into a PersonRow, or null when there is no usable name. */
+function sanitizePerson(person: TargetAccountRow["person"]): PersonRow | null {
+  const name = person?.name?.trim();
+  if (!name) return null;
+  return {
+    name,
+    title: person?.title?.trim() || null,
+    email: person?.email?.trim() || null,
+    linkedin_url: person?.linkedin_url?.trim() || null,
+  };
 }
 
 /** Fold header-mapped extra values into canonical fields the row left empty. */

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -94,6 +94,15 @@ When the user kicks off research on a batch of companies, run the full pipeline 
 
 After the batch is complete, present a single summary table showing companies, their scores, the contacts found, and each contact's priority score. This gives the user the full picture in one view instead of drip-feeding partial results.
 
+### Target Account Lists
+When the user uploads a target account list (the message will include "list ID ..."):
+1. If no campaign exists, or the campaign has no ICP/offering, interview the user first -- who do they want to reach (titles/personas)? what are they selling? Keep it to 2-3 questions, then \`saveCampaign\`
+2. Call \`linkTargetListToCampaign\`, then \`prioritizeTargetAccounts\`. Present the top slice with scores and the quoted enrichment cost, and ASK before enriching
+3. On approval, call \`enrichTargetAccounts\`. It runs in the background -- check progress with \`getTargetList\` when the user asks; don't poll in a loop
+4. After enrichment, contacts were auto-found for qualified accounts. Apply the coverage check (see Contact Finding Details) before drafting outreach
+5. If the upload included contacts, compare the imported titles to the ICP before enriching. Pass \`skipContactFinding: true\` for accounts whose imported contacts already match -- and tell the user what that saves. Apply the coverage check where imported contacts look thin
+6. "Do more" means prioritize/enrich the next slice. Never enrich the whole list unprompted
+
 ### Company Enrichment Details
 - \`enrichCompany\` fetches the company website and runs 3 targeted Exa searches (product/features, funding/news, team/size)
 - **Hiring research**: After enriching a company, call \`scrapeJobListings\` with the company's domain. This uses Stagehand (AI browser automation via Browserbase) to navigate the company's website, find their careers/jobs page automatically, and extract structured job listings. Hiring data is a key signal -- companies actively hiring for roles related to the user's offering are prime targets.

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -72,6 +72,12 @@ import {
   draftEmailsForSequence,
   getSequenceStatus,
 } from "./sequence-tools";
+import {
+  getTargetLists,
+  getTargetList,
+  linkTargetListToCampaign,
+  prioritizeTargetAccounts,
+} from "./target-list-tools";
 import { getPostHogClient } from "@/lib/posthog-server";
 
 const rawTools = {
@@ -135,6 +141,10 @@ const rawTools = {
   draftSequenceEmails,
   draftEmailsForSequence,
   getSequenceStatus,
+  getTargetLists,
+  getTargetList,
+  linkTargetListToCampaign,
+  prioritizeTargetAccounts,
 };
 
 type ToolCtx = { userId?: string; campaignId?: string | null };

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -77,6 +77,7 @@ import {
   getTargetList,
   linkTargetListToCampaign,
   prioritizeTargetAccounts,
+  enrichTargetAccounts,
 } from "./target-list-tools";
 import { getPostHogClient } from "@/lib/posthog-server";
 
@@ -145,6 +146,7 @@ const rawTools = {
   getTargetList,
   linkTargetListToCampaign,
   prioritizeTargetAccounts,
+  enrichTargetAccounts,
 };
 
 type ToolCtx = { userId?: string; campaignId?: string | null };

--- a/src/lib/tools/target-list-tools.ts
+++ b/src/lib/tools/target-list-tools.ts
@@ -132,11 +132,18 @@ export const getTargetList = tool({
       .eq("list_id", input.listId)
       .eq("organizations.enrichment_status", "enriched");
 
+    // Same join + filters as the processor's picker (pickEnrichBatch): only
+    // stamped rows whose org is still pending are real in-flight work —
+    // already-enriched orgs drain instantly and must not count as queued.
     const { count: enrichQueued } = await supabase
       .from("target_accounts")
-      .select("id", { count: "exact", head: true })
+      .select("id, organizations!inner(enrichment_status)", {
+        count: "exact",
+        head: true,
+      })
       .eq("list_id", input.listId)
-      .not("enrich_requested_at", "is", null);
+      .not("enrich_requested_at", "is", null)
+      .eq("organizations.enrichment_status", "pending");
 
     const accounts = (accountRows ?? []).map((row) => {
       const org = row.organization as unknown as {
@@ -205,13 +212,16 @@ export const linkTargetListToCampaign = tool({
     }
 
     // Contacts imported with the list (contact-per-row files) ride along:
-    // link people at these orgs so outreach machinery can see them.
+    // link people at these orgs so outreach machinery can see them. Only
+    // list-imported contacts — the orgs live in a shared pool, and people
+    // discovered by other campaigns/users must not be swept into this one.
     const personIds: string[] = [];
     for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
       const { data, error } = await supabase
         .from("people")
         .select("id")
-        .in("organization_id", ids);
+        .in("organization_id", ids)
+        .eq("source", "target_list");
       if (error)
         throw new Error(`Failed to load imported contacts: ${error.message}`);
       personIds.push(...(data ?? []).map((p: { id: string }) => p.id));
@@ -347,20 +357,23 @@ export const prioritizeTargetAccounts = tool({
         })
       : [];
 
-    // Persist: existing scoring rubric — qualified at >= 6.
-    await Promise.all(
-      results.map((r) =>
-        supabase
-          .from("campaign_organizations")
-          .update({
-            relevance_score: r.score,
-            score_reason: r.reason,
-            status: r.score >= 6 ? "qualified" : "disqualified",
-          })
-          .eq("campaign_id", input.campaignId)
-          .eq("organization_id", r.organizationId),
-      ),
-    );
+    // Persist: existing scoring rubric — qualified at >= 6. Sequential
+    // chunks of 20 so a big list can't fire hundreds of parallel updates.
+    for (const batch of chunk(results, 20)) {
+      await Promise.all(
+        batch.map((r) =>
+          supabase
+            .from("campaign_organizations")
+            .update({
+              relevance_score: r.score,
+              score_reason: r.reason,
+              status: r.score >= 6 ? "qualified" : "disqualified",
+            })
+            .eq("campaign_id", input.campaignId)
+            .eq("organization_id", r.organizationId),
+        ),
+      );
+    }
 
     // Top slice across everything now scored (fresh + previously scored).
     const scoreByOrg = new Map<string, { score: number; reason: string }>();
@@ -451,26 +464,75 @@ export const enrichTargetAccounts = tool({
     const supabase = await createClient();
     const { userId } = await auth();
 
-    // RLS proves the list is mine; then prove the orgs are actually on it.
+    // RLS proves the list is mine…
     await loadListOrFail(supabase, input.listId);
+
+    // …and that the campaign is too (same RLS pattern as
+    // prioritizeTargetAccounts): the campaignId goes into a QStash payload
+    // processed under the admin client, so ownership must be proven here.
+    const { data: campaign, error: campaignError } = await supabase
+      .from("campaigns")
+      .select("id")
+      .eq("id", input.campaignId)
+      .single();
+    if (campaignError || !campaign) {
+      return {
+        error:
+          `Campaign not found (or not yours): ${campaignError?.message ?? input.campaignId}. ` +
+          "Check the campaign ID with getCampaigns.",
+      };
+    }
+
+    // Then prove the orgs are actually on the list, and grab each org's
+    // enrichment status so non-pending ones are reported, not stamped.
     const orgIds = [...new Set(input.organizationIds)];
-    const found = new Set<string>();
+    const statusByOrg = new Map<string, string>();
     for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
       const { data, error } = await supabase
         .from("target_accounts")
-        .select("organization_id")
+        .select(
+          "organization_id, organization:organizations(enrichment_status)",
+        )
         .eq("list_id", input.listId)
         .in("organization_id", ids);
       if (error) throw new Error(`Failed to verify accounts: ${error.message}`);
-      for (const row of data ?? []) found.add(row.organization_id);
+      for (const row of data ?? []) {
+        const org = row.organization as unknown as {
+          enrichment_status: string;
+        } | null;
+        statusByOrg.set(
+          row.organization_id,
+          org?.enrichment_status ?? "pending",
+        );
+      }
     }
-    const missing = orgIds.filter((id) => !found.has(id));
+    const missing = orgIds.filter((id) => !statusByOrg.has(id));
     if (missing.length > 0) {
       return {
         error:
           `${missing.length} organization(s) are not in this list: ` +
           `${missing.slice(0, 5).join(", ")}${missing.length > 5 ? ", …" : ""}. ` +
           "Check the IDs against getTargetList.",
+      };
+    }
+
+    // Only pending orgs get stamped: failed/in_progress/enriched ones would
+    // never be picked by the processor (it filters on pending), so stamping
+    // them just inflates the queue count and misleads the agent.
+    const pendingIds = orgIds.filter((id) => statusByOrg.get(id) === "pending");
+    const skippedNotPending = orgIds
+      .filter((id) => statusByOrg.get(id) !== "pending")
+      .map((organizationId) => ({
+        organizationId,
+        status: statusByOrg.get(organizationId)!,
+      }));
+    if (pendingIds.length === 0) {
+      return {
+        queued: 0,
+        skippedNotPending,
+        note:
+          "None of these accounts are pending enrichment — nothing was queued. " +
+          "Check their status with getTargetList.",
       };
     }
 
@@ -488,11 +550,17 @@ export const enrichTargetAccounts = tool({
       };
     }
 
+    // The skip flag is stamped PER ROW, not carried in the chain payload:
+    // two concurrent calls with opposite flags each mark their own rows, and
+    // the processor honors whatever each row says.
     const stampedAt = new Date().toISOString();
-    for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
+    for (const ids of chunk(pendingIds, UPSERT_CHUNK)) {
       const { error } = await supabase
         .from("target_accounts")
-        .update({ enrich_requested_at: stampedAt })
+        .update({
+          enrich_requested_at: stampedAt,
+          skip_contact_finding: input.skipContactFinding ?? false,
+        })
         .eq("list_id", input.listId)
         .in("organization_id", ids);
       if (error) throw new Error(`Failed to queue accounts: ${error.message}`);
@@ -506,12 +574,12 @@ export const enrichTargetAccounts = tool({
         listId: input.listId,
         campaignId: input.campaignId,
         userId: userId ?? "",
-        skipContactFinding: input.skipContactFinding ?? false,
       },
     });
 
     return {
-      queued: orgIds.length,
+      queued: pendingIds.length,
+      skippedNotPending,
       note: "Enrichment runs in the background (~1 min/company). Ask me for progress.",
     };
   },

--- a/src/lib/tools/target-list-tools.ts
+++ b/src/lib/tools/target-list-tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { auth } from "@clerk/nextjs/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
+import { getQStashClient, getBaseUrl } from "@/lib/services/qstash";
 import {
   scoreTargetAccounts,
   type TargetAccountToScore,
@@ -417,6 +418,101 @@ export const prioritizeTargetAccounts = tool({
         "Present the top slice and the estimated cost to the user and get explicit approval " +
         "before enriching. Accounts whose importedContacts already match the ICP titles can " +
         "be enriched with skipContactFinding to save spend.",
+    };
+  },
+});
+
+export const enrichTargetAccounts = tool({
+  description:
+    "Queue background enrichment (and contact finding) for approved target accounts. " +
+    "ONLY call this after the user has approved the cost quoted by prioritizeTargetAccounts. " +
+    "Runs as a background chain (~1 min/company) — check progress with getTargetList, " +
+    "don't poll in a loop. Set skipContactFinding for accounts whose imported contacts " +
+    "already match the ICP; split accounts across two calls if only some qualify.",
+  inputSchema: z.object({
+    listId: z.string().uuid().describe("Target account list ID"),
+    campaignId: z
+      .string()
+      .uuid()
+      .describe("Campaign providing signal config and ICP titles"),
+    organizationIds: z
+      .array(z.string().uuid())
+      .min(1)
+      .describe("Organizations from the list to enrich (the approved slice)"),
+    skipContactFinding: z
+      .boolean()
+      .default(false)
+      .describe(
+        "Skip contact discovery and only enrich the companies — use when " +
+          "imported contacts already cover the ICP titles",
+      ),
+  }),
+  execute: async (input) => {
+    const supabase = await createClient();
+    const { userId } = await auth();
+
+    // RLS proves the list is mine; then prove the orgs are actually on it.
+    await loadListOrFail(supabase, input.listId);
+    const orgIds = [...new Set(input.organizationIds)];
+    const found = new Set<string>();
+    for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
+      const { data, error } = await supabase
+        .from("target_accounts")
+        .select("organization_id")
+        .eq("list_id", input.listId)
+        .in("organization_id", ids);
+      if (error) throw new Error(`Failed to verify accounts: ${error.message}`);
+      for (const row of data ?? []) found.add(row.organization_id);
+    }
+    const missing = orgIds.filter((id) => !found.has(id));
+    if (missing.length > 0) {
+      return {
+        error:
+          `${missing.length} organization(s) are not in this list: ` +
+          `${missing.slice(0, 5).join(", ")}${missing.length > 5 ? ", …" : ""}. ` +
+          "Check the IDs against getTargetList.",
+      };
+    }
+
+    // Fail on missing QStash config BEFORE stamping rows — never fall back
+    // to inline enrichment, and never leave a stamped queue nothing drains.
+    let qstash;
+    try {
+      qstash = getQStashClient();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        error:
+          "The QStash integration isn't configured, so background enrichment can't run " +
+          `(${msg}). Set QSTASH_TOKEN (and the signing keys) in the environment, then retry.`,
+      };
+    }
+
+    const stampedAt = new Date().toISOString();
+    for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
+      const { error } = await supabase
+        .from("target_accounts")
+        .update({ enrich_requested_at: stampedAt })
+        .eq("list_id", input.listId)
+        .in("organization_id", ids);
+      if (error) throw new Error(`Failed to queue accounts: ${error.message}`);
+    }
+
+    // ONE message starts the chain; the process route re-publishes itself
+    // until the stamped work drains.
+    await qstash.publishJSON({
+      url: getBaseUrl() + "/api/target-lists/process",
+      body: {
+        listId: input.listId,
+        campaignId: input.campaignId,
+        userId: userId ?? "",
+        skipContactFinding: input.skipContactFinding ?? false,
+      },
+    });
+
+    return {
+      queued: orgIds.length,
+      note: "Enrichment runs in the background (~1 min/company). Ask me for progress.",
     };
   },
 });

--- a/src/lib/tools/target-list-tools.ts
+++ b/src/lib/tools/target-list-tools.ts
@@ -1,0 +1,422 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { auth } from "@clerk/nextjs/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import {
+  scoreTargetAccounts,
+  type TargetAccountToScore,
+} from "@/lib/services/target-account-scorer";
+import type { ICP, Offering } from "@/lib/types/campaign";
+
+/**
+ * Agent tools for target account lists (user-uploaded CSVs resolved to the
+ * shared organizations pool). Lists are a lens over that pool: scores and
+ * qualification live on campaign_organizations, so linking a list to a
+ * campaign is what makes it scoreable.
+ */
+
+/** Supabase caps reads at 1000 rows — page through big lists. */
+const PAGE_SIZE = 1000;
+/** Bulk writes go in chunks so one giant list can't blow a single request. */
+const UPSERT_CHUNK = 500;
+/** Rough all-in enrichment cost per account (Exa + scraping + Claude). */
+const ENRICH_COST_PER_ACCOUNT_USD = 0.08;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+interface ListAccountRow {
+  organization_id: string;
+  raw: Record<string, string>;
+  organization: {
+    id: string;
+    name: string;
+    domain: string | null;
+    industry: string | null;
+    location: string | null;
+  } | null;
+}
+
+/** Load every account row for a list, paged past the 1000-row read cap. */
+async function loadAllListAccounts(
+  supabase: SupabaseClient,
+  listId: string,
+): Promise<ListAccountRow[]> {
+  const rows: ListAccountRow[] = [];
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("target_accounts")
+      .select(
+        "organization_id, raw, organization:organizations(id, name, domain, industry, location)",
+      )
+      .eq("list_id", listId)
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error)
+      throw new Error(`Failed to load list accounts: ${error.message}`);
+    const page = (data ?? []) as unknown as ListAccountRow[];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+  }
+  return rows;
+}
+
+async function loadListOrFail(supabase: SupabaseClient, listId: string) {
+  const { data, error } = await supabase
+    .from("target_account_lists")
+    .select("id, name, original_filename, row_count, created_at, updated_at")
+    .eq("id", listId)
+    .single();
+  if (error || !data) {
+    throw new Error(
+      `Target list not found (or not yours): ${error?.message ?? listId}`,
+    );
+  }
+  return data;
+}
+
+export const getTargetLists = tool({
+  description:
+    "List the user's uploaded target account lists, newest first, with row counts. " +
+    "Use this when the user mentions an uploaded list and you need its ID.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("target_account_lists")
+      .select("id, name, original_filename, row_count, created_at, updated_at")
+      .order("created_at", { ascending: false });
+    if (error) throw new Error(`Failed to list target lists: ${error.message}`);
+    return { lists: data ?? [] };
+  },
+});
+
+export const getTargetList = tool({
+  description:
+    "Get one target account list: metadata, the first 25 accounts (org name, domain, " +
+    "enrichment status), and counts (total, enriched, queued for enrichment). " +
+    "Quote enrichment progress from these counts — do not poll in a loop.",
+  inputSchema: z.object({
+    listId: z.string().uuid().describe("Target account list ID"),
+  }),
+  execute: async (input) => {
+    const supabase = await createClient();
+    const list = await loadListOrFail(supabase, input.listId);
+
+    const { data: accountRows, error: accountsError } = await supabase
+      .from("target_accounts")
+      .select(
+        "organization_id, enrich_requested_at, organization:organizations(name, domain, enrichment_status)",
+      )
+      .eq("list_id", input.listId)
+      .order("created_at", { ascending: true })
+      .limit(25);
+    if (accountsError)
+      throw new Error(`Failed to load accounts: ${accountsError.message}`);
+
+    const { count: total } = await supabase
+      .from("target_accounts")
+      .select("id", { count: "exact", head: true })
+      .eq("list_id", input.listId);
+
+    const { count: enriched } = await supabase
+      .from("target_accounts")
+      .select("id, organizations!inner(enrichment_status)", {
+        count: "exact",
+        head: true,
+      })
+      .eq("list_id", input.listId)
+      .eq("organizations.enrichment_status", "enriched");
+
+    const { count: enrichQueued } = await supabase
+      .from("target_accounts")
+      .select("id", { count: "exact", head: true })
+      .eq("list_id", input.listId)
+      .not("enrich_requested_at", "is", null);
+
+    const accounts = (accountRows ?? []).map((row) => {
+      const org = row.organization as unknown as {
+        name: string;
+        domain: string | null;
+        enrichment_status: string;
+      } | null;
+      return {
+        organizationId: row.organization_id,
+        name: org?.name ?? "(unknown)",
+        domain: org?.domain ?? null,
+        enrichmentStatus: org?.enrichment_status ?? "pending",
+        enrichQueued: row.enrich_requested_at != null,
+      };
+    });
+
+    return {
+      list,
+      accounts,
+      counts: {
+        total: total ?? 0,
+        enriched: enriched ?? 0,
+        enrichQueued: enrichQueued ?? 0,
+      },
+    };
+  },
+});
+
+export const linkTargetListToCampaign = tool({
+  description:
+    "Link every account in a target list to a campaign (bulk, idempotent). Creates " +
+    "campaign_organizations memberships so the list can be prioritized and worked, and " +
+    "also links any contacts imported with the list (campaign_people, status pending). " +
+    "Run this before prioritizeTargetAccounts.",
+  inputSchema: z.object({
+    listId: z.string().uuid().describe("Target account list ID"),
+    campaignId: z.string().uuid().describe("Campaign to link the list into"),
+  }),
+  execute: async (input) => {
+    const supabase = await createClient();
+    await loadListOrFail(supabase, input.listId);
+
+    const accounts = await loadAllListAccounts(supabase, input.listId);
+    const orgIds = [...new Set(accounts.map((a) => a.organization_id))];
+    if (orgIds.length === 0) {
+      return { linked: 0, alreadyLinked: 0, peopleLinked: 0 };
+    }
+
+    // Bulk upsert memberships. ignoreDuplicates means the returned rows are
+    // exactly the ones newly inserted — that's our `linked` count.
+    let linked = 0;
+    for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
+      const { data, error } = await supabase
+        .from("campaign_organizations")
+        .upsert(
+          ids.map((organizationId) => ({
+            campaign_id: input.campaignId,
+            organization_id: organizationId,
+          })),
+          { onConflict: "campaign_id,organization_id", ignoreDuplicates: true },
+        )
+        .select("organization_id");
+      if (error)
+        throw new Error(`Failed to link organizations: ${error.message}`);
+      linked += data?.length ?? 0;
+    }
+
+    // Contacts imported with the list (contact-per-row files) ride along:
+    // link people at these orgs so outreach machinery can see them.
+    const personIds: string[] = [];
+    for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
+      const { data, error } = await supabase
+        .from("people")
+        .select("id")
+        .in("organization_id", ids);
+      if (error)
+        throw new Error(`Failed to load imported contacts: ${error.message}`);
+      personIds.push(...(data ?? []).map((p: { id: string }) => p.id));
+    }
+
+    let peopleLinked = 0;
+    for (const ids of chunk(personIds, UPSERT_CHUNK)) {
+      const { data, error } = await supabase
+        .from("campaign_people")
+        .upsert(
+          ids.map((personId) => ({
+            campaign_id: input.campaignId,
+            person_id: personId,
+            status: "pending",
+          })),
+          { onConflict: "campaign_id,person_id", ignoreDuplicates: true },
+        )
+        .select("person_id");
+      if (error) throw new Error(`Failed to link contacts: ${error.message}`);
+      peopleLinked += data?.length ?? 0;
+    }
+
+    return { linked, alreadyLinked: orgIds.length - linked, peopleLinked };
+  },
+});
+
+export const prioritizeTargetAccounts = tool({
+  description:
+    "Triage a linked target list against the campaign ICP: scores unscored accounts 1-10 " +
+    "(qualified >= 6), then returns the top slice with the estimated enrichment cost. " +
+    "Requires the campaign to have an ICP with target titles — if it doesn't, interview " +
+    "the user and saveCampaign first. Present the top slice and the quoted cost to the " +
+    "user; NEVER call enrichTargetAccounts without the user approving the quoted cost. " +
+    "Accounts with importedContacts > 0 may not need contact finding (skipContactFinding).",
+  inputSchema: z.object({
+    listId: z.string().uuid().describe("Target account list ID"),
+    campaignId: z
+      .string()
+      .uuid()
+      .describe("Campaign whose ICP to score against"),
+    topFraction: z
+      .number()
+      .min(0.01)
+      .max(1)
+      .default(0.1)
+      .describe(
+        "Fraction of the list to surface as the enrichment candidate slice (default 0.1)",
+      ),
+  }),
+  execute: async (input) => {
+    const supabase = await createClient();
+    const { userId } = await auth();
+
+    const { data: campaign, error: campaignError } = await supabase
+      .from("campaigns")
+      .select("id, name, icp, offering")
+      .eq("id", input.campaignId)
+      .single();
+    if (campaignError || !campaign) {
+      throw new Error(
+        `Campaign not found: ${campaignError?.message ?? input.campaignId}`,
+      );
+    }
+
+    // Hard gate: never spend LLM tokens scoring against an empty ICP.
+    const icp = (campaign.icp ?? {}) as ICP;
+    if (!icp.targetTitles?.length) {
+      return {
+        error:
+          "This campaign has no ICP yet. Interview the user (who do they want to reach? " +
+          "what are they selling?) and call saveCampaign with targetTitles before prioritizing.",
+      };
+    }
+
+    const accounts = await loadAllListAccounts(supabase, input.listId);
+    if (accounts.length === 0) {
+      return {
+        error:
+          "This list has no accounts (or it isn't yours). Check the list ID with getTargetLists.",
+      };
+    }
+
+    // The list must be linked — scores live on campaign_organizations.
+    const orgIds = [...new Set(accounts.map((a) => a.organization_id))];
+    const memberships: Array<{
+      organization_id: string;
+      relevance_score: number | null;
+      score_reason: string | null;
+    }> = [];
+    for (const ids of chunk(orgIds, UPSERT_CHUNK)) {
+      const { data, error } = await supabase
+        .from("campaign_organizations")
+        .select("organization_id, relevance_score, score_reason")
+        .eq("campaign_id", input.campaignId)
+        .in("organization_id", ids);
+      if (error)
+        throw new Error(`Failed to load memberships: ${error.message}`);
+      memberships.push(...(data ?? []));
+    }
+    if (memberships.length === 0) {
+      return {
+        error:
+          "This list isn't linked to the campaign yet. Call linkTargetListToCampaign first.",
+      };
+    }
+
+    // Score only unscored rows (score 0/null) so re-runs are cheap.
+    const accountByOrg = new Map(accounts.map((a) => [a.organization_id, a]));
+    const toScore: TargetAccountToScore[] = memberships
+      .filter((m) => !m.relevance_score)
+      .map((m) => {
+        const a = accountByOrg.get(m.organization_id);
+        return {
+          organizationId: m.organization_id,
+          name: a?.organization?.name ?? "(unknown)",
+          domain: a?.organization?.domain ?? null,
+          industry: a?.organization?.industry ?? null,
+          location: a?.organization?.location ?? null,
+          raw: a?.raw ?? {},
+        };
+      });
+
+    const results = toScore.length
+      ? await scoreTargetAccounts({
+          campaign: {
+            id: campaign.id,
+            name: campaign.name,
+            icp,
+            offering: (campaign.offering ?? {}) as Offering,
+          },
+          accounts: toScore,
+          userId: userId ?? "",
+        })
+      : [];
+
+    // Persist: existing scoring rubric — qualified at >= 6.
+    await Promise.all(
+      results.map((r) =>
+        supabase
+          .from("campaign_organizations")
+          .update({
+            relevance_score: r.score,
+            score_reason: r.reason,
+            status: r.score >= 6 ? "qualified" : "disqualified",
+          })
+          .eq("campaign_id", input.campaignId)
+          .eq("organization_id", r.organizationId),
+      ),
+    );
+
+    // Top slice across everything now scored (fresh + previously scored).
+    const scoreByOrg = new Map<string, { score: number; reason: string }>();
+    for (const m of memberships) {
+      if (m.relevance_score) {
+        scoreByOrg.set(m.organization_id, {
+          score: Number(m.relevance_score),
+          reason: m.score_reason ?? "",
+        });
+      }
+    }
+    for (const r of results) {
+      scoreByOrg.set(r.organizationId, { score: r.score, reason: r.reason });
+    }
+
+    const topFraction = input.topFraction ?? 0.1;
+    const sliceSize = Math.ceil(memberships.length * topFraction);
+    const ranked = [...scoreByOrg.entries()].sort(
+      (a, b) => b[1].score - a[1].score,
+    );
+    const sliceOrgIds = ranked.slice(0, sliceSize).map(([orgId]) => orgId);
+
+    // Contact coverage per slice account: imported contacts may already
+    // satisfy the ICP, letting the agent propose skipContactFinding.
+    const contactCounts = new Map<string, number>();
+    if (sliceOrgIds.length > 0) {
+      const { data: people, error: peopleError } = await supabase
+        .from("people")
+        .select("organization_id")
+        .in("organization_id", sliceOrgIds);
+      if (peopleError)
+        throw new Error(`Failed to count contacts: ${peopleError.message}`);
+      for (const p of people ?? []) {
+        contactCounts.set(
+          p.organization_id,
+          (contactCounts.get(p.organization_id) ?? 0) + 1,
+        );
+      }
+    }
+
+    const topSlice = sliceOrgIds.map((orgId) => ({
+      organizationId: orgId,
+      name: accountByOrg.get(orgId)?.organization?.name ?? "(unknown)",
+      score: scoreByOrg.get(orgId)!.score,
+      reason: scoreByOrg.get(orgId)!.reason,
+      importedContacts: contactCounts.get(orgId) ?? 0,
+    }));
+
+    return {
+      scored: results.length,
+      topSlice,
+      estimatedEnrichCostUsd:
+        Math.round(topSlice.length * ENRICH_COST_PER_ACCOUNT_USD * 100) / 100,
+      note:
+        "Present the top slice and the estimated cost to the user and get explicit approval " +
+        "before enriching. Accounts whose importedContacts already match the ICP titles can " +
+        "be enriched with skipContactFinding to save spend.",
+    };
+  },
+});

--- a/src/lib/types/target-list.ts
+++ b/src/lib/types/target-list.ts
@@ -14,6 +14,8 @@ export interface TargetAccount {
   organization_id: string;
   raw: Record<string, string>;
   enrich_requested_at: string | null;
+  /** Per-row flag stamped with enrich_requested_at; cleared when claimed. */
+  skip_contact_finding: boolean;
   created_at: string;
 }
 

--- a/src/lib/types/target-list.ts
+++ b/src/lib/types/target-list.ts
@@ -1,0 +1,37 @@
+export interface TargetAccountList {
+  id: string;
+  user_id: string;
+  name: string;
+  original_filename: string | null;
+  row_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TargetAccount {
+  id: string;
+  list_id: string;
+  organization_id: string;
+  raw: Record<string, string>;
+  enrich_requested_at: string | null;
+  created_at: string;
+}
+
+/** A parsed, column-mapped CSV row ready for import. */
+export interface TargetAccountRow {
+  name: string;
+  domain?: string | null;
+  url?: string | null;
+  industry?: string | null;
+  location?: string | null;
+  description?: string | null;
+  /** Present when the file is contact-per-row (e.g. Apollo/Clay exports). */
+  person?: {
+    name: string;
+    title?: string | null;
+    email?: string | null;
+    linkedin_url?: string | null;
+  } | null;
+  /** Everything else from the original row, preserved verbatim. */
+  extra?: Record<string, string>;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@ const isPublicRoute = createRouteMatcher([
   "/login(.*)",
   "/signup(.*)",
   "/api/outreach/process(.*)",
+  "/api/target-lists/process(.*)",
   "/api/email/track(.*)",
   "/api/email/cleanup(.*)",
   "/api/tracking/(.*)",

--- a/supabase/migrations/20260801000002_target_account_lists.sql
+++ b/supabase/migrations/20260801000002_target_account_lists.sql
@@ -1,0 +1,75 @@
+-- Target account lists: first-class, user-owned uploads of companies.
+-- A list is a lens over the global organizations pool: rows resolve to
+-- organizations at import (domain-deduped), so enrichment/contacts/outreach
+-- reuse existing machinery. Scores/qualification deliberately do NOT live
+-- here — they belong to campaign_organizations (see design doc D1/D4).
+
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '60s';
+
+create table if not exists target_account_lists (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,           -- Clerk sub; no FK by convention
+  name text not null,
+  original_filename text,
+  row_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger target_account_lists_updated_at
+  before update on target_account_lists
+  for each row execute function update_updated_at_column();
+
+create table if not exists target_accounts (
+  id uuid primary key default gen_random_uuid(),
+  list_id uuid not null references target_account_lists(id) on delete cascade,
+  organization_id uuid not null references organizations(id) on delete cascade,
+  raw jsonb not null default '{}'::jsonb,   -- original CSV row, verbatim
+  enrich_requested_at timestamptz,          -- set when a tranche is approved
+  created_at timestamptz not null default now(),
+  unique (list_id, organization_id)
+);
+
+create index if not exists idx_target_accounts_list on target_accounts(list_id);
+create index if not exists idx_target_accounts_org on target_accounts(organization_id);
+-- The QStash processor's work query:
+create index if not exists idx_target_accounts_enrich_queue
+  on target_accounts(list_id, enrich_requested_at)
+  where enrich_requested_at is not null;
+
+alter table target_account_lists enable row level security;
+create policy "target_account_lists_select" on target_account_lists
+  for select to authenticated using (user_id = requesting_user_id());
+create policy "target_account_lists_insert" on target_account_lists
+  for insert to authenticated with check (user_id = requesting_user_id());
+create policy "target_account_lists_update" on target_account_lists
+  for update to authenticated using (user_id = requesting_user_id())
+  with check (user_id = requesting_user_id());
+create policy "target_account_lists_delete" on target_account_lists
+  for delete to authenticated using (user_id = requesting_user_id());
+
+alter table target_accounts enable row level security;
+create policy "target_accounts_select" on target_accounts
+  for select to authenticated using (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+create policy "target_accounts_insert" on target_accounts
+  for insert to authenticated with check (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+create policy "target_accounts_update" on target_accounts
+  for update to authenticated using (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+create policy "target_accounts_delete" on target_accounts
+  for delete to authenticated using (
+    exists (select 1 from target_account_lists l
+            where l.id = target_accounts.list_id
+              and l.user_id = requesting_user_id()));
+
+commit;

--- a/supabase/migrations/20260801000003_target_accounts_skip_flag.sql
+++ b/supabase/migrations/20260801000003_target_accounts_skip_flag.sql
@@ -1,0 +1,14 @@
+-- Per-row contact-finding skip flag for target-list enrichment.
+-- Previously skipContactFinding rode in the QStash chain payload, so two
+-- concurrent enrichTargetAccounts calls with opposite flags cross-contaminated
+-- whichever rows the list-scoped processor happened to pick. The flag now
+-- lives on the row, stamped alongside enrich_requested_at.
+
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '60s';
+
+alter table target_accounts
+  add column if not exists skip_contact_finding boolean not null default false;
+
+commit;

--- a/supabase/migrations/20260801000004_csv_import_provenance.sql
+++ b/supabase/migrations/20260801000004_csv_import_provenance.sql
@@ -1,0 +1,58 @@
+-- CSV-import provenance: uploads are suggestions, not ground truth
+-- 2026-08-01
+--
+-- Target-list imports were recording affiliation as `user_entered` (1.0) and
+-- emails as `provider_found` (0.75). Both were lies about where the data came
+-- from, and the first one was dangerous: a CSV is routinely an AI-generated
+-- prospect list or a stale export from another tool, yet `user_entered` is the
+-- human-override rank that nothing — not even a verifier proving the person
+-- answers mail at a different company's domain — can ever displace.
+--
+-- `csv_import` names the real source so the application can rank it where it
+-- belongs: strong enough to act on (imported contacts stay draftable), weak
+-- enough that Signal's own verification (`email_domain`, a deliverable mailbox
+-- at the employer's domain) and an explicit human edit both outrank it.
+--
+-- Transaction-wrapped for the same reason as 20260801000000: each CHECK has to
+-- be dropped and recreated to admit the new value, and a failure between the
+-- two statements would leave the column unconstrained. SET LOCAL also only
+-- applies inside a transaction block.
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '60s';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. Admit csv_import to work_email_source
+-- ────────────────────────────────────────────────────────────────────────────
+alter table people
+  drop constraint if exists people_work_email_source_check;
+
+alter table people
+  add constraint people_work_email_source_check
+    check (
+      work_email_source is null
+      or work_email_source in
+        ('user_entered', 'send_confirmed', 'team_page', 'exa_search',
+         'pattern_derived', 'provider_found', 'csv_import')
+    );
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. Admit csv_import to affiliation_source
+-- ────────────────────────────────────────────────────────────────────────────
+-- Application weight 0.85: above the send threshold (0.6) so imported contacts
+-- can be drafted for immediately, below email_domain (0.95) and user_entered
+-- (1.0) so machine verification and human edits can both correct a bad upload.
+alter table people
+  drop constraint if exists people_affiliation_source_check;
+
+alter table people
+  add constraint people_affiliation_source_check
+    check (
+      affiliation_source is null
+      or affiliation_source in
+        ('user_entered', 'email_domain', 'team_page', 'linkedin_profile',
+         'llm_verified', 'search_stamp', 'csv_import')
+    );
+
+commit;


### PR DESCRIPTION
## Summary

Adds **target account lists** — the "I already have a list" entry point. Drop a CSV into chat (any messy CRM/spreadsheet export, company-only or contact-per-row) and the agent takes it end to end: import → interview (who to reach, what you're selling) → triage against the ICP → enrich the top ~10% on approval → existing contacts/outreach pipeline.

## How it works

1. **Chat upload** — CSV parsed client-side (shared parser lifted from the campaign importer, plus a Haiku fallback for unrecognized headers), rows POSTed in 500-row batches to new `target-lists` routes; the chat gets a one-line receipt with the list ID. Replaces the old paste-the-file-into-context behavior (which silently dropped uploads > 150k chars). 5 MB guard.
2. **First-class owned lists** — `target_account_lists` / `target_accounts` (owner-scoped RLS): every account has its own ID, lists are tenant-owned, the original CSV row is preserved verbatim in `raw`. Accounts resolve to the global `organizations` pool at import (domain-deduped), so all existing machinery applies.
3. **Contact-per-row files (Apollo/Clay)** import people too: LinkedIn-deduped, affiliation provenance recorded, emails stored unverified and **still Hunter-verified just-in-time at send** (the lazy-verification model holds; imports are free).
4. **Interview is enforced, not suggested** — `prioritizeTargetAccounts` hard-gates on campaign ICP (zero LLM spend before the gate). The scorer (sonnet, chunked, prompt-injection-wrapped) writes the existing `campaign_organizations.relevance_score/score_reason/status` — no parallel tier system.
5. **Triage before spend** — the agent presents the top slice with a cost quote (~$0.08/company) and must get approval; `skipContactFinding` (per-row) avoids paying to re-find contacts the user already uploaded.
6. **Background enrichment** — one QStash message self-chains through approved accounts 2 at a time via the extracted `enrichAndFindContacts` service (admin-client-safe threading through knowledge-base/contact-discovery). Atomic per-row claims, poison-row guard, 200-hop hard ceiling. Progress is DB-derived (`getTargetList`).

## Code review

Full adversarial review ran on the branch; both Criticals and all actionable Importants fixed in the final commit:
- `skipContactFinding` moved from chain payload to a per-row column + atomic claim (two concurrent tranches could previously cross-contaminate flags and double-pick rows)
- campaign-ownership check added to the one admin-client-reaching tool
- people-linking scoped to list-imported contacts (was pulling the shared pool)
- chain hardening: `mergeEnrichmentData` failures now propagate (no infinite re-enrich), attempt ceiling, accurate in-flight counts, email-shape validation, chunked score persistence, tests for the spend-starting tool

**Resolved decision — `csv_import` provenance (commit d60a893):** uploads are often AI-generated or stale exports, so imported data must be overridable by Signal's own verification. New `csv_import` source for affiliations (weight 0.85 — draftable, but email-domain proof and explicit human edits outrank it, and no cross-org override) and emails (priority 0.5 — cannot displace deliverable addresses; JIT send-time verification still applies). UI shows honest "CSV import" provenance.

## Testing

- 488 unit tests across 58 files, typecheck + lint + `next build` green.
- New suites: CSV parsing (incl. a fixed pre-existing quoted-comma bug), header mapping, list service + people import, scorer chunking/gating, all five tools, process-route claim semantics.
- Manual E2E still pending (needs dev env + QStash): real CSV through chat → interview → prioritize → approve → chain → contacts → draft.

## Ops notes

- Migrations `20260801000002` + `20260801000003`.
- QStash required for enrichment tranches; the process route **self-chains — no schedule needed**. It's added to the public matcher (signature-verified, path-bound).
- No new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
