### PR TITLE
fix(chat): stop agent turns cleanly before the platform kills them

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -23,9 +23,21 @@ import { saveChat } from "@/lib/services/chat-history";
 import { getSupabaseAndUser } from "@/lib/supabase/server";
 
 // Full-pipeline agent runs (enrich → score → find contacts) regularly exceed
-// two minutes; at 120 the platform killed the function mid-stream and the UI
-// looked stuck. Vercel fluid compute allows up to 300s on all current plans.
-export const maxDuration = 300;
+// two minutes; at 120 and again at 300 the platform killed the function
+// mid-stream, silently — no error event reaches the stream, onFinish never
+// runs, and the whole turn (and its chat history) is lost. 800 is the Vercel
+// Pro/Enterprise ceiling (GA). Hobby caps at 300 and fails the build above
+// it — self-hosters on Hobby should drop this to 300; the turn time budget
+// below keeps things working either way, just with more continuation turns.
+export const maxDuration = 800;
+
+// Stop the agent loop well before maxDuration so the turn ends CLEANLY:
+// the model's progress streams out, onFinish runs, and the chat is saved.
+// The gap covers the longest single step still in flight when the budget
+// trips (a 150s enrichment chunk plus model latency). When a turn is cut
+// short, the client sees a `data-turn-paused` part and auto-continues in a
+// fresh request, so long pipelines span windows instead of dying silently.
+const TURN_TIME_BUDGET_MS = 600_000;
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -118,6 +130,8 @@ export async function POST(request: Request) {
     };
   }
 
+  const deadlineAt = Date.now() + TURN_TIME_BUDGET_MS;
+
   const profile = await getProfileForPrompt(campaignId);
   const signals = campaignId ? await getActiveSignals(campaignId) : null;
   const systemPrompt = buildSystemPrompt({
@@ -153,7 +167,9 @@ export async function POST(request: Request) {
         // Full-pipeline agent runs (enrich → score → find contacts → draft)
         // routinely take 20+ steps; at 15 the loop halted silently mid-batch
         // and the UI just looked stuck. 40 covers the longest observed runs.
-        stopWhen: stepCountIs(40),
+        // The time condition ends the turn before the platform would kill
+        // the function; the client auto-continues (see data-turn-paused).
+        stopWhen: [stepCountIs(40), () => Date.now() >= deadlineAt],
         // Without this, Stop / closing the tab leaves the server running the
         // whole remaining pipeline (and paying for it) invisibly.
         abortSignal: request.signal,
@@ -168,8 +184,25 @@ export async function POST(request: Request) {
           writer,
           userId: user.id,
           campaignId: campaignId ?? null,
+          // Batch tools (enrichCompanies/enrichContacts) check this before
+          // starting a chunk they can't finish inside the turn budget.
+          deadlineAt,
         },
-        onFinish({ usage }) {
+        onFinish({ usage, finishReason }) {
+          // "tool-calls" as the FINAL finish reason means the model still
+          // wanted to work but stopWhen ended the loop — tell the client so
+          // it can continue the pipeline in a fresh request. Transient: the
+          // part reaches onData but is never persisted into the message.
+          if (finishReason === "tool-calls") {
+            writer.write({
+              type: "data-turn-paused",
+              data: {
+                reason:
+                  Date.now() >= deadlineAt ? "time-budget" : "step-limit",
+              },
+              transient: true,
+            });
+          }
           trackUsage({
             service: "claude",
             operation: "chat",

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -20,6 +20,11 @@ const MIN_WIDTH = 360;
 const MAX_WIDTH_RATIO = 0.6;
 const DEFAULT_WIDTH = 480;
 
+// When the server ends a turn early (turn time budget / step limit), the
+// client resumes the pipeline automatically. Bounded so a pathological loop
+// can't burn tokens forever; a manual message resets the counter.
+const MAX_AUTO_CONTINUES = 3;
+
 function getSuggestions(pathname: string, campaignId: string | null): string[] {
   if (campaignId && pathname.startsWith("/campaigns/")) {
     return [
@@ -151,10 +156,19 @@ function AgentPanelInner({
 
   const transport = useMemo(() => createChatTransport(), []);
 
+  // Set when the server cut the turn short (see data-turn-paused in the chat
+  // route); consumed in onFinish to fire an automatic continuation.
+  const turnPausedRef = useRef(false);
+  const autoContinuesRef = useRef(0);
+  const [continueTick, setContinueTick] = useState(0);
+
   const { messages, sendMessage, status, stop, error, regenerate } = useChat({
     id: campaignId ? `campaign-${campaignId}` : `global-${chatId}`,
     messages: initialMessages,
     transport,
+    onData(part) {
+      if (part.type === "data-turn-paused") turnPausedRef.current = true;
+    },
     onFinish({ messages: allMessages }) {
       if (userId) {
         saveChat(
@@ -164,6 +178,13 @@ function AgentPanelInner({
           allMessages,
           campaignId ?? undefined,
         );
+      }
+      if (turnPausedRef.current) {
+        turnPausedRef.current = false;
+        if (autoContinuesRef.current < MAX_AUTO_CONTINUES) {
+          autoContinuesRef.current += 1;
+          setContinueTick((tick) => tick + 1);
+        }
       }
     },
   });
@@ -184,6 +205,17 @@ function AgentPanelInner({
     return { body };
   }, [campaignId, chatId, pathname]);
 
+  // Resume a turn the server paused for time/steps. Runs via effect (not
+  // inline in onFinish) so sendMessage/buildRequestOptions are initialized.
+  useEffect(() => {
+    if (continueTick === 0) return;
+    sendMessage(
+      { text: "Continue exactly where you left off." },
+      buildRequestOptions(),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [continueTick]);
+
   // Auto-send any prompt that was queued via openAgentWith()
   useEffect(() => {
     if (didAutoSend.current) return;
@@ -196,11 +228,13 @@ function AgentPanelInner({
   }, []);
 
   const handleSuggestionClick = (text: string) => {
+    autoContinuesRef.current = 0;
     sendMessage({ text }, buildRequestOptions());
   };
 
   const onSubmit = () => {
     if (!input.trim()) return;
+    autoContinuesRef.current = 0;
     sendMessage({ text: input }, buildRequestOptions());
     setInput("");
   };

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -36,8 +36,8 @@ function warnIfKeyless() {
 // Clerk's server-side getToken() with no options does NOT mint anything: it
 // returns the JWT that arrived on the request, verbatim, forever (see
 // createGetToken in @clerk/backend). Those tokens live ~60s, but our routes
-// run much longer — maxDuration is 120s on /api/chat and 300s on
-// /api/find-email/bulk, and one chat turn can take 15 tool steps. So any
+// run much longer — maxDuration is 300s on /api/chat and on
+// /api/find-email/bulk, and one chat turn can take dozens of tool steps. So any
 // Supabase call made past the ~60s mark used to fail with "JWT expired", and
 // stayed broken for the rest of the request, retries included.
 //
@@ -45,7 +45,11 @@ function warnIfKeyless() {
 // token through the Backend API. We only do that once the request's own token
 // is spent, so short requests behave exactly as before, with no extra calls.
 
-/** Comfortably longer than the longest route maxDuration (300s). */
+/**
+ * Doesn't need to outlive the longest route: the provider re-mints whenever
+ * the cached token is within REFRESH_SKEW_MS of expiry, so a request longer
+ * than the TTL just mints again mid-flight.
+ */
 const MINTED_TOKEN_TTL_SECONDS = 600;
 /**
  * Minting goes over the network to api.clerk.com, and every concurrent query

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -27,6 +27,20 @@ import { withTimeout } from "@/lib/utils/timeout";
 /** Ceiling for one company's full enrichment chain. */
 const PER_COMPANY_TIMEOUT_MS = 150_000;
 
+/** Rough worst case for one contact-enrichment chunk (Exa + socials). */
+const PER_CONTACT_CHUNK_ESTIMATE_MS = 120_000;
+
+/**
+ * The chat route puts its turn time budget on experimental_context so batch
+ * tools never start a chunk they can't finish before the turn is stopped.
+ * Absent outside chat (dedicated API routes, tests) — then no deadline.
+ */
+function deadlineFrom(experimental_context: unknown): number | null {
+  const deadlineAt = (experimental_context as { deadlineAt?: number } | null)
+    ?.deadlineAt;
+  return typeof deadlineAt === "number" ? deadlineAt : null;
+}
+
 export const searchPeople = tool({
   description:
     "Search for people at companies using Exa semantic search with LinkedIn-focused queries. Stores results in the shared knowledge base. When campaignId is provided, links results to the campaign and deduplicates against existing campaign contacts. When the search targets a known company, ALWAYS pass companyName (and companyDomain if known) so results are linked to that organization for the org chart and per-company views.",
@@ -666,18 +680,28 @@ export const enrichContacts = tool({
       .max(10)
       .describe("Array of person IDs to enrich (max 10)"),
   }),
-  execute: async (input) => {
+  execute: async (input, { experimental_context }) => {
+    const deadlineAt = deadlineFrom(experimental_context);
     const succeeded: Array<{
       contactId: string;
       status: string;
       skipped?: boolean;
     }> = [];
     const failed: Array<{ contactId: string; error: string }> = [];
+    let deferred: string[] = [];
 
     // Process in chunks of 3 to stay under Exa's 10 QPS limit
     // (each contact makes 3-4 Exa searches)
     const CHUNK_SIZE = 3;
     for (let i = 0; i < input.contactIds.length; i += CHUNK_SIZE) {
+      // Same turn-budget guard as enrichCompanies (see deadlineFrom).
+      if (
+        deadlineAt &&
+        deadlineAt - Date.now() < PER_CONTACT_CHUNK_ESTIMATE_MS
+      ) {
+        deferred = input.contactIds.slice(i);
+        break;
+      }
       const chunk = input.contactIds.slice(i, i + CHUNK_SIZE);
       const results = await Promise.allSettled(
         chunk.map((id) => enrichContactById(id)),
@@ -708,6 +732,11 @@ export const enrichContacts = tool({
       failed: failed.length,
       results: succeeded,
       errors: failed.length > 0 ? failed : undefined,
+      deferred: deferred.length > 0 ? deferred : undefined,
+      note:
+        deferred.length > 0
+          ? "Turn time budget ran out before these contacts were enriched. They were NOT processed. Call enrichContacts again with the `deferred` IDs to finish."
+          : undefined,
     };
   },
 });
@@ -1282,7 +1311,8 @@ export const enrichCompanies = tool({
       .optional()
       .describe("Campaign ID to load ICP context for scoring."),
   }),
-  execute: async (input) => {
+  execute: async (input, { experimental_context }) => {
+    const deadlineAt = deadlineFrom(experimental_context);
     const succeeded: Array<{
       companyId: string;
       companyName: string;
@@ -1290,11 +1320,18 @@ export const enrichCompanies = tool({
       skipped?: boolean;
     }> = [];
     const failed: Array<{ companyId: string; error: string }> = [];
+    let deferred: string[] = [];
 
     // Process in chunks of 3 to stay under Exa's 10 QPS limit
     // (each company makes 3-4 Exa searches)
     const CHUNK_SIZE = 3;
     for (let i = 0; i < input.companyIds.length; i += CHUNK_SIZE) {
+      // Don't start a chunk the turn budget can't absorb: a full batch can
+      // legally run CHUNKS × 150s, longer than the whole chat turn.
+      if (deadlineAt && deadlineAt - Date.now() < PER_COMPANY_TIMEOUT_MS) {
+        deferred = input.companyIds.slice(i);
+        break;
+      }
       const chunk = input.companyIds.slice(i, i + CHUNK_SIZE);
       // Bound each company. Every downstream call has its own timeout, but
       // one company chains enough of them (fetch → Browserbase fetch →
@@ -1337,6 +1374,11 @@ export const enrichCompanies = tool({
       failed: failed.length,
       results: succeeded,
       errors: failed.length > 0 ? failed : undefined,
+      deferred: deferred.length > 0 ? deferred : undefined,
+      note:
+        deferred.length > 0
+          ? "Turn time budget ran out before these companies were enriched. They were NOT processed. Call enrichCompanies again with the `deferred` IDs to finish."
+          : undefined,
     };
   },
 });


### PR DESCRIPTION
## Problem

The chat agent regularly "just dies" mid-pipeline. Root cause: full pipeline turns (search, enrich, score, find contacts) exceed the function's maxDuration and Vercel kills the function mid-stream. No error event reaches the client, and because chat persistence only ran in `onFinish`, the entire turn was also lost from history, so the next message acted like a fresh session.

A single `enrichCompanies` call could legally run 450s+ (3 chunks x 150s per-company timeout), longer than the whole 300s window on its own.

## Fix

- **`/api/chat` maxDuration -> 800** (Vercel Pro ceiling). Hobby self-hosters should drop this back to 300; the rest of the fix keeps things working there too, just with more continuation turns.
- **600s turn time budget** added as a `stopWhen` condition: the loop always ends cleanly inside the window, so progress streams out and the chat is saved. 200s headroom covers the longest single step still in flight.
- **Client auto-continue**: when a turn is cut short, the server emits a transient `data-turn-paused` part and the panel resumes the pipeline in a fresh request (capped at 3 auto-continues per user message; manual messages reset the cap).
- **Deadline-aware batch tools**: `enrichCompanies` / `enrichContacts` read the turn deadline from `experimental_context` and defer chunks they cannot finish, returning the deferred IDs to the model with instructions to call again.
- Supabase token-mint comments updated; no behavior change needed there (it already re-mints mid-request).

## Notes

- **Deploy order matters**: upgrade the Vercel team to Pro before merging/deploying, otherwise the build fails with "maxDuration must be between 1 and 300" (previous deployment stays live).
- Verified: eslint clean, `tsc --noEmit` clean, 413/416 tests pass (the 3 failures are in an uncommitted local test file unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)