### PR TITLE
feat(enrich): dated, sourced, reconciled claims; careers-page-first hiring

### DIFF
--- a/docs/plans/2026-08-01-enrichment-claims-verification.md
+++ b/docs/plans/2026-08-01-enrichment-claims-verification.md
@@ -1,0 +1,777 @@
+# Enrichment Claims + Verification Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Company enrichment produces dated, sourced, reconciled claims; hiring facts come only from the live careers page; scores cite claims that survived reconciliation.
+
+**Architecture:** A pure-function reconciler (`claim-reconciler.ts`) and a Haiku extraction service (`claim-extractor.ts`) slot into `enrichCompanyById` after the existing raw pulls. The Browserbase careers scraper (`scrapeHiringData`, already built) becomes a standard parallel pull. Claims live in `organizations.enrichment_data.claims` (jsonb, no migration), mirroring the contact affiliation-provenance pattern. Both enrichment paths (agent tool + `/api/enrich-company`) share the same core.
+
+**Tech Stack:** Next.js App Router, AI SDK v6 (`generateObject`), Anthropic Haiku (`MODELS.LIGHT`), Stagehand/Browserbase, Supabase jsonb, Vitest.
+
+**Design doc:** `/Users/jay/.claude/plans/2026-08-01-enrichment-claims-verification-design.md`
+
+**Branch:** create `feat/enrichment-claims` off `origin/main` before Task 1. The user works on other branches concurrently; never commit unrelated working-tree files.
+
+**House rules that will bite you:**
+- No em dashes in any string/copy — eslint blocks them (`no-restricted-syntax`).
+- All LLM calls follow the `src/lib/services/relevance-filter.ts` pattern exactly: `generateObject` + `llmTimeout()` abort signal + `trackUsage` + `UNTRUSTED_NOTICE`/`wrapUntrusted`/`stringify` from `@/lib/prompt-safety` + fail-open catch.
+- Run `pnpm exec eslint <files>` and `pnpm typecheck` before every commit. (If typecheck fails on `.next/types` referencing deleted routes, `rm -rf .next/types` first — stale cache.)
+- Test runner is Vitest: `pnpm vitest run <file>`.
+
+---
+
+### Task 1: Claim types + pure reconciler (TDD)
+
+**Files:**
+- Create: `src/lib/types/claims.ts`
+- Create: `src/lib/services/claim-reconciler.ts`
+- Test: `src/__tests__/claim-reconciler.test.ts`
+
+**Step 1: Create the types file**
+
+```ts
+// src/lib/types/claims.ts
+export const CLAIM_TYPES = [
+  "funding_round",
+  "headcount",
+  "hiring_role",
+  "exec_change",
+  "product",
+  "location",
+] as const;
+
+export type ClaimType = (typeof CLAIM_TYPES)[number];
+
+export type ClaimStatus =
+  | "verified"
+  | "unverified"
+  | "stale"
+  | "contradicted"
+  | "superseded";
+
+export interface CompanyClaim {
+  type: ClaimType;
+  /** One factual sentence, e.g. "Raised a $30M Series B led by Madrona". */
+  statement: string;
+  sourceUrl: string;
+  /** ISO date of the source when known; null when the source is undated. */
+  publishedDate: string | null;
+  /** 0-1, extractor's confidence the statement is about this company. */
+  confidence: number;
+  extractedAt: string;
+  status: ClaimStatus;
+}
+
+export interface CareersScrape {
+  careersUrl: string | null;
+  jobs: Array<{ title: string; department?: string; location?: string }>;
+  scrapedAt: string;
+}
+```
+
+**Step 2: Write the failing tests.** The fixture is the real Fyxer failure.
+
+```ts
+// src/__tests__/claim-reconciler.test.ts
+import { describe, expect, it } from "vitest";
+import { reconcileClaims } from "@/lib/services/claim-reconciler";
+import type { CompanyClaim, CareersScrape } from "@/lib/types/claims";
+
+const NOW = new Date("2026-08-01T12:00:00Z");
+
+function claim(partial: Partial<CompanyClaim>): CompanyClaim {
+  return {
+    type: "product",
+    statement: "x",
+    sourceUrl: "https://example.com",
+    publishedDate: null,
+    confidence: 0.8,
+    extractedAt: NOW.toISOString(),
+    status: "unverified",
+    ...partial,
+  };
+}
+
+const fyxerCareers: CareersScrape = {
+  careersUrl: "https://fyxer.com/careers",
+  jobs: [{ title: "Senior Customer Support Specialist", location: "Austin" }],
+  scrapedAt: NOW.toISOString(),
+};
+
+describe("reconcileClaims", () => {
+  it("supersedes older funding claims with the newest dated one", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "funding_round",
+          statement: "Raised a $10M Series A",
+          publishedDate: "2024-11-01",
+        }),
+        claim({
+          type: "funding_round",
+          statement: "Raised a $30M Series B led by Madrona",
+          publishedDate: "2026-02-11",
+        }),
+        claim({
+          type: "funding_round",
+          statement: "Raised $500K",
+          publishedDate: null,
+        }),
+      ],
+      { now: NOW, careers: null },
+    );
+    expect(out.find((c) => c.statement.includes("Series B"))?.status).toBe(
+      "verified",
+    );
+    expect(out.find((c) => c.statement.includes("Series A"))?.status).toBe(
+      "superseded",
+    );
+    expect(out.find((c) => c.statement.includes("$500K"))?.status).toBe(
+      "superseded",
+    );
+  });
+
+  it("contradicts hiring claims not backed by the careers scrape", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Hiring a Growth Director",
+          sourceUrl: "https://news-aggregator.example.com/fyxer",
+        }),
+      ],
+      { now: NOW, careers: fyxerCareers },
+    );
+    expect(out[0].status).toBe("contradicted");
+  });
+
+  it("verifies hiring claims that match a scraped job title", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Hiring: Senior Customer Support Specialist",
+        }),
+      ],
+      { now: NOW, careers: fyxerCareers },
+    );
+    expect(out[0].status).toBe("verified");
+  });
+
+  it("marks hiring claims stale without a scrape when older than 90 days", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Hiring a Growth Director",
+          publishedDate: "2026-01-01",
+        }),
+      ],
+      { now: NOW, careers: null },
+    );
+    expect(out[0].status).toBe("stale");
+  });
+
+  it("marks lone funding claims older than 12 months stale, not superseded", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "funding_round",
+          statement: "Raised a $10M Series A",
+          publishedDate: "2024-11-01",
+        }),
+      ],
+      { now: NOW, careers: null },
+    );
+    expect(out[0].status).toBe("stale");
+  });
+
+  it("leaves fresh, unconflicted claims unverified and untouched", () => {
+    const out = reconcileClaims(
+      [claim({ type: "product", statement: "AI email assistant" })],
+      { now: NOW, careers: null },
+    );
+    expect(out[0].status).toBe("unverified");
+  });
+});
+```
+
+**Step 3: Run to verify failure.**
+Run: `pnpm vitest run src/__tests__/claim-reconciler.test.ts`
+Expected: FAIL, cannot resolve `@/lib/services/claim-reconciler`.
+
+**Step 4: Implement the reconciler.**
+
+```ts
+// src/lib/services/claim-reconciler.ts
+import type { CareersScrape, CompanyClaim } from "@/lib/types/claims";
+
+const FUNDING_STALE_MS = 365 * 24 * 60 * 60 * 1000;
+const HIRING_STALE_MS = 90 * 24 * 60 * 60 * 1000;
+
+function ageMs(claim: CompanyClaim, now: Date): number | null {
+  if (!claim.publishedDate) return null;
+  const t = Date.parse(claim.publishedDate);
+  return Number.isNaN(t) ? null : now.getTime() - t;
+}
+
+/** Case-insensitive containment either way, so "Hiring: Growth Director" matches "Growth Director (Remote)". */
+function matchesScrapedJob(statement: string, careers: CareersScrape): boolean {
+  const s = statement.toLowerCase();
+  return careers.jobs.some((j) => {
+    const t = j.title.toLowerCase();
+    return s.includes(t) || t.includes(s);
+  });
+}
+
+/**
+ * Deterministic verification pass over extracted claims. Pure function so
+ * the rules are unit-testable; no LLM, no IO. Rules, in order:
+ *
+ * 1. hiring_role with a careers scrape available: verified when a scraped
+ *    job title matches, contradicted when none does. The live careers page
+ *    is ground truth; news and aggregator text never outranks it.
+ * 2. Same-type conflicts (funding_round, headcount): the newest dated claim
+ *    wins (verified); every other claim of that type is superseded.
+ * 3. Staleness: a surviving dated claim past its shelf life (12 months for
+ *    funding, 90 days for hiring) is marked stale rather than asserted.
+ */
+export function reconcileClaims(
+  claims: CompanyClaim[],
+  opts: { now: Date; careers: CareersScrape | null },
+): CompanyClaim[] {
+  const out = claims.map((c) => ({ ...c }));
+
+  for (const c of out) {
+    if (c.type !== "hiring_role") continue;
+    if (opts.careers) {
+      c.status = matchesScrapedJob(c.statement, opts.careers)
+        ? "verified"
+        : "contradicted";
+    } else {
+      const age = ageMs(c, opts.now);
+      if (age !== null && age > HIRING_STALE_MS) c.status = "stale";
+    }
+  }
+
+  for (const type of ["funding_round", "headcount"] as const) {
+    const group = out.filter((c) => c.type === type);
+    if (group.length > 1) {
+      const dated = group
+        .filter((c) => ageMs(c, opts.now) !== null)
+        .sort((a, b) => ageMs(a, opts.now)! - ageMs(b, opts.now)!);
+      if (dated.length > 0) {
+        const winner = dated[0];
+        for (const c of group) {
+          c.status = c === winner ? "verified" : "superseded";
+        }
+      }
+    }
+    for (const c of group) {
+      if (c.status === "superseded" || c.status === "contradicted") continue;
+      const age = ageMs(c, opts.now);
+      if (type === "funding_round" && age !== null && age > FUNDING_STALE_MS) {
+        c.status = "stale";
+      }
+    }
+  }
+
+  return out;
+}
+```
+
+**Step 5: Run to verify pass.**
+Run: `pnpm vitest run src/__tests__/claim-reconciler.test.ts`
+Expected: 6 passed.
+
+**Step 6: Lint, typecheck, commit.**
+
+```bash
+pnpm exec eslint src/lib/types/claims.ts src/lib/services/claim-reconciler.ts src/__tests__/claim-reconciler.test.ts
+pnpm typecheck
+git add src/lib/types/claims.ts src/lib/services/claim-reconciler.ts src/__tests__/claim-reconciler.test.ts
+git commit -m "feat(claims): typed company claims and deterministic reconciler"
+```
+
+Note: the design mentions a Haiku judge for date-less conflicting claims. Deliberately NOT built now (YAGNI): rule 2 already handles the observed failure, and the judge only matters if the eval harness later shows date-less conflicts are common.
+
+---
+
+### Task 2: Claim extractor service (TDD, mocked LLM)
+
+**Files:**
+- Create: `src/lib/services/claim-extractor.ts`
+- Test: `src/__tests__/claim-extractor.test.ts`
+
+Mirror `src/lib/services/relevance-filter.ts` exactly (imports, timeout, trackUsage, prompt-safety wrappers, fail-open catch). Read that file first.
+
+**Step 1: Write the failing test.**
+
+```ts
+// src/__tests__/claim-extractor.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const generateObjectMock = vi.fn();
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  generateObject: (...args: unknown[]) => generateObjectMock(...args),
+}));
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: vi.fn(),
+  estimateClaudeCostFromUsage: () => 0,
+}));
+
+import { extractClaims } from "@/lib/services/claim-extractor";
+
+const searches = [
+  {
+    category: "funding",
+    query: '"Fyxer" fyxer.com funding news announcement',
+    results: [
+      {
+        title: "Fyxer raises $30M Series B",
+        url: "https://news.example.com/fyxer-series-b",
+        publishedDate: "2026-02-11",
+        text: "Fyxer AI closed a $30 million Series B led by Madrona...",
+      },
+    ],
+  },
+];
+
+describe("extractClaims", () => {
+  beforeEach(() => generateObjectMock.mockReset());
+
+  it("returns typed claims from the LLM with provenance attached", async () => {
+    generateObjectMock.mockResolvedValue({
+      object: {
+        claims: [
+          {
+            type: "funding_round",
+            statement: "Raised a $30M Series B led by Madrona",
+            sourceIndex: 0,
+            publishedDate: "2026-02-11",
+            confidence: 0.9,
+          },
+        ],
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    const out = await extractClaims({
+      companyName: "Fyxer",
+      companyDomain: "fyxer.com",
+      websiteContent: null,
+      searches,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("funding_round");
+    expect(out[0].sourceUrl).toBe("https://news.example.com/fyxer-series-b");
+    expect(out[0].status).toBe("unverified");
+    expect(out[0].extractedAt).toBeTruthy();
+  });
+
+  it("fails open to an empty list when the LLM call throws", async () => {
+    generateObjectMock.mockRejectedValue(new Error("overloaded"));
+    const out = await extractClaims({
+      companyName: "Fyxer",
+      companyDomain: "fyxer.com",
+      websiteContent: null,
+      searches,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("drops claims whose sourceIndex is out of range", async () => {
+    generateObjectMock.mockResolvedValue({
+      object: {
+        claims: [
+          {
+            type: "product",
+            statement: "hallucinated",
+            sourceIndex: 99,
+            publishedDate: null,
+            confidence: 0.9,
+          },
+        ],
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    const out = await extractClaims({
+      companyName: "Fyxer",
+      companyDomain: "fyxer.com",
+      websiteContent: null,
+      searches,
+    });
+    expect(out).toEqual([]);
+  });
+});
+```
+
+**Step 2: Run to verify failure.** `pnpm vitest run src/__tests__/claim-extractor.test.ts` → FAIL (module missing).
+
+**Step 3: Implement.**
+
+```ts
+// src/lib/services/claim-extractor.ts
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { llmTimeout } from "@/lib/utils/timeout";
+import { MODELS } from "@/lib/ai/models";
+import {
+  estimateClaudeCostFromUsage,
+  trackUsage,
+} from "@/lib/services/cost-tracker";
+import {
+  UNTRUSTED_NOTICE,
+  stringify,
+  wrapUntrusted,
+} from "@/lib/prompt-safety";
+import { CLAIM_TYPES, type CompanyClaim } from "@/lib/types/claims";
+
+interface EnrichmentSearch {
+  category: string;
+  query: string;
+  results: Array<{
+    title: string;
+    url: string;
+    publishedDate: string | null;
+    text: string | null;
+  }>;
+}
+
+interface ExtractInput {
+  companyName: string;
+  companyDomain: string | null;
+  websiteContent: string | null;
+  searches: EnrichmentSearch[];
+}
+
+/**
+ * One Haiku pass over the raw enrichment pulls that emits typed, sourced
+ * claims. The model references sources by index; the code resolves the
+ * index back to the URL so a claim can never cite a URL the pull did not
+ * contain. Fails open to [] so enrichment still stores raw data when the
+ * extractor is down.
+ */
+export async function extractClaims(
+  input: ExtractInput,
+): Promise<CompanyClaim[]> {
+  const sources: Array<{ url: string; publishedDate: string | null }> = [];
+  const sourceBlocks: string[] = [];
+
+  if (input.websiteContent && input.companyDomain) {
+    sources.push({
+      url: `https://${input.companyDomain}`,
+      publishedDate: null,
+    });
+    sourceBlocks.push(
+      `[0] Company website (${input.companyDomain}):\n${input.websiteContent.slice(0, 1500)}`,
+    );
+  }
+  for (const search of input.searches) {
+    for (const r of search.results) {
+      const i = sources.length;
+      sources.push({ url: r.url, publishedDate: r.publishedDate });
+      sourceBlocks.push(
+        `[${i}] (${search.category}) "${r.title}" ${r.url}${r.publishedDate ? ` published ${r.publishedDate}` : " (undated)"}\n${r.text?.slice(0, 1200) ?? ""}`,
+      );
+    }
+  }
+  if (sources.length === 0) return [];
+
+  try {
+    const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
+      model: anthropic(MODELS.LIGHT),
+      schema: z.object({
+        claims: z.array(
+          z.object({
+            type: z.enum(CLAIM_TYPES),
+            statement: z
+              .string()
+              .describe("One factual sentence about the company"),
+            sourceIndex: z
+              .number()
+              .int()
+              .describe("Index of the source block the claim comes from"),
+            publishedDate: z
+              .string()
+              .nullable()
+              .describe("Date of the underlying fact if the source states one"),
+            confidence: z.number().min(0).max(1),
+          }),
+        ),
+      }),
+      prompt: `You extract factual claims about a company from research sources.
+
+${UNTRUSTED_NOTICE}
+
+Target company: ${stringify(input.companyName)}${input.companyDomain ? ` (${stringify(input.companyDomain)})` : ""}
+
+Extract every distinct factual claim about THIS company from the sources below. Claims must be things a salesperson would act on: funding rounds, headcount, roles being hired, executive changes, product facts, locations. Rules:
+- One claim per fact. Do not merge facts from different sources into one claim.
+- If two sources disagree (e.g. Series A vs Series B), emit BOTH claims, each citing its own source. Reconciliation happens downstream.
+- Never invent a date. Use the source's published date only when the source states when the fact happened.
+- Skip claims about other companies, even similarly named ones.
+
+Sources:
+${wrapUntrusted(sourceBlocks.join("\n\n"))}`,
+    });
+
+    trackUsage({
+      service: "claude",
+      operation: "claim-extractor",
+      tokens_input: usage.inputTokens ?? 0,
+      tokens_output: usage.outputTokens ?? 0,
+      estimated_cost_usd: estimateClaudeCostFromUsage("haiku", usage),
+      metadata: {
+        model: "claude-haiku-4-5",
+        companyName: input.companyName,
+        sourceCount: sources.length,
+        claimCount: object.claims.length,
+      },
+    });
+
+    const extractedAt = new Date().toISOString();
+    return object.claims
+      .filter((c) => c.sourceIndex >= 0 && c.sourceIndex < sources.length)
+      .map((c) => ({
+        type: c.type,
+        statement: c.statement,
+        sourceUrl: sources[c.sourceIndex].url,
+        publishedDate:
+          c.publishedDate ?? sources[c.sourceIndex].publishedDate,
+        confidence: c.confidence,
+        extractedAt,
+        status: "unverified" as const,
+      }));
+  } catch (err) {
+    console.error("[claim-extractor] failed, storing raw data only:", err);
+    return [];
+  }
+}
+```
+
+**Step 4: Run to verify pass.** `pnpm vitest run src/__tests__/claim-extractor.test.ts` → 3 passed.
+
+**Step 5: Lint, typecheck, commit.**
+
+```bash
+pnpm exec eslint src/lib/services/claim-extractor.ts src/__tests__/claim-extractor.test.ts && pnpm typecheck
+git add src/lib/services/claim-extractor.ts src/__tests__/claim-extractor.test.ts
+git commit -m "feat(claims): Haiku claim extractor with source-index provenance"
+```
+
+---
+
+### Task 3: Careers scrape + claims inside `enrichCompanyById`
+
+**Files:**
+- Modify: `src/lib/tools/enrichment-tools.ts` (function `enrichCompanyById`, currently ~line 1100; Promise.allSettled at ~1172; search storage loop at ~1234)
+- Modify: `src/lib/services/hiring-scraper.ts` (export a non-throwing wrapper)
+
+Read both files first; line numbers drift.
+
+**Step 1: Add a fail-open wrapper to `hiring-scraper.ts`** (the raw `scrapeHiringData` throws on missing env vars; enrichment must not).
+
+```ts
+/**
+ * Fail-open variant for use inside enrichment: a scrape failure returns
+ * null (raw enrichment proceeds without hiring data) instead of failing
+ * the whole company. The raw scrapeHiringData stays throwing for the
+ * agent tools, which surface errors to the model.
+ */
+export async function tryScrapeHiringData(
+  organizationId: string,
+  domain: string,
+): Promise<HiringScrapeResult | null> {
+  try {
+    return await scrapeHiringData(organizationId, domain);
+  } catch (err) {
+    console.error(`[hiring-scraper] scrape failed for ${domain}:`, err);
+    return null;
+  }
+}
+```
+
+**Step 2: In `enrichCompanyById`, extend the parallel pulls.** The existing destructure is:
+
+```ts
+const [websiteResult, productResult, fundingResult, teamResult] =
+  await Promise.allSettled([...]);
+```
+
+Add a fifth entry. Also hoist the three query strings into consts (`productQuery`, `fundingQuery`, `teamQuery`) so Step 3 can store the real ones:
+
+```ts
+const [websiteResult, productResult, fundingResult, teamResult, hiringResult] =
+  await Promise.allSettled([
+    /* existing four unchanged, but using the hoisted query consts */
+    org.domain
+      ? tryScrapeHiringData(organizationId, org.domain as string)
+      : Promise.resolve(null),
+  ]);
+```
+
+(`scrapeHiringData` already writes `enrichment_data.hiring` itself via `mergeEnrichmentData`; the returned value here is only for claim building.)
+
+**Step 3: Store the real executed query.** In the search storage loop, the entries become `["product", productResult, productQuery]` etc., and `query: `${org.name} ${label}`` becomes `query` from the tuple.
+
+**Step 4: Extract + reconcile claims after the loop**, before `enrichmentData.searches = searches`:
+
+```ts
+// Typed claims: extract from raw pulls, then reconcile against the careers
+// scrape (ground truth for hiring) and recency rules. Fail-open at every
+// stage; a claims failure never blocks storing the raw enrichment.
+const careers =
+  hiringResult.status === "fulfilled" && hiringResult.value
+    ? {
+        careersUrl: hiringResult.value.careersUrl,
+        jobs: hiringResult.value.jobs,
+        scrapedAt: new Date().toISOString(),
+      }
+    : null;
+
+const extracted = await extractClaims({
+  companyName: org.name as string,
+  companyDomain,
+  websiteContent:
+    websiteResult.status === "fulfilled" && websiteResult.value?.success
+      ? websiteResult.value.data.content
+      : null,
+  searches,
+});
+
+// Scraped jobs become verified hiring claims directly; no LLM needed.
+const hiringClaims: CompanyClaim[] =
+  careers?.careersUrl
+    ? careers.jobs.map((j) => ({
+        type: "hiring_role" as const,
+        statement: `Hiring: ${j.title}${j.location ? ` (${j.location})` : ""}`,
+        sourceUrl: careers.careersUrl as string,
+        publishedDate: careers.scrapedAt,
+        confidence: 1,
+        extractedAt: careers.scrapedAt,
+        status: "verified" as const,
+      }))
+    : [];
+
+enrichmentData.claims = [
+  ...reconcileClaims(extracted, { now: new Date(), careers }),
+  ...hiringClaims,
+];
+```
+
+Imports to add at the top of `enrichment-tools.ts`: `extractClaims` from `@/lib/services/claim-extractor`, `reconcileClaims` from `@/lib/services/claim-reconciler`, `tryScrapeHiringData` from `@/lib/services/hiring-scraper`, and `type CompanyClaim` from `@/lib/types/claims`.
+
+**Step 5: Update `summarizeCompanyEnrichment`** (~line 1077) to include `claims: (data.claims as unknown[])?.length ?? 0` and `hiringScraped: Boolean(data.hiring)` so the thin tool summary tells the model what it got.
+
+**Step 6: Verify.**
+Run: `pnpm exec eslint src/lib/tools/enrichment-tools.ts src/lib/services/hiring-scraper.ts && pnpm typecheck && pnpm vitest run`
+Expected: clean, full suite passes (3 pre-existing failures in `companies-list-default-view.test.tsx` are known if that file exists on this branch).
+
+**Step 7: Commit.**
+
+```bash
+git add src/lib/tools/enrichment-tools.ts src/lib/services/hiring-scraper.ts
+git commit -m "feat(enrich): careers scrape and reconciled claims in company enrichment"
+```
+
+---
+
+### Task 4: Unify `/api/enrich-company` onto the same claims path
+
+**Files:**
+- Modify: `src/app/api/enrich-company/route.ts` (~lines 199-430)
+
+Full extraction of a shared `enrichCompanyCore` was considered and cut (YAGNI for now): the route has signal-gated searches, Google Reviews, and summarization the tool path deliberately lacks, and merging those is a refactor with its own risk. Instead, give the route the same claims tail:
+
+**Step 1: Read the route.** Locate where it assembles its `enrichmentData` (searches array with optional `.summary` fields, `website`, `googleReviews`) and where it calls `mergeEnrichmentData`.
+
+**Step 2: Before its `mergeEnrichmentData` call**, insert the same block as Task 3 Step 4 (extract → hiring claims → reconcile → `enrichmentData.claims`). The route does not currently scrape careers: add the same `tryScrapeHiringData` parallel pull, gated on the org having a domain, alongside its existing `Promise.allSettled` batch. Map its `executive` category results into the `searches` argument for `extractClaims` unchanged (the extractor treats categories as labels only).
+
+**Step 3: Verify + commit.**
+
+```bash
+pnpm exec eslint src/app/api/enrich-company/route.ts && pnpm typecheck && pnpm vitest run
+git add src/app/api/enrich-company/route.ts
+git commit -m "feat(enrich): claims and careers scrape on the UI enrichment path"
+```
+
+---
+
+### Task 5: System prompt: hiring hard rule + claims-based scoring
+
+**Files:**
+- Modify: `src/lib/system-prompt.ts` (~lines 88, 97-104, 205-215, 226)
+
+**Step 1:** In the Full Pipeline list (~line 88), delete step 2 ("Scrape hiring data with `scrapeJobListingsBatch`...") and renumber: the scrape now runs inside `enrichCompany`. Keep `scrapeJobListings` mentioned as a refresh tool only.
+
+**Step 2:** In Company Enrichment Details (~line 97), replace the "Hiring research" bullet with:
+
+```
+- **Hiring facts come only from the live careers page.** \`enrichCompany\` scrapes it automatically (Browserbase) and stores the result in \`enrichment_data.hiring\` plus verified \`hiring_role\` claims. An Exa result or news article saying a company "is hiring X" is a lead, never a fact: if the careers scrape contradicts it, the scrape wins. If there is no scrape (no domain, scrape failed), say hiring is unknown rather than guessing. Use \`scrapeJobListings\` to refresh a stale scrape.
+```
+
+**Step 3:** In the Priority Scoring Framework (~line 205), after the Company Priority bullet list, add:
+
+```
+**Score from reconciled claims, not raw search text.** \`getCompanyDetail\` returns \`enrichment_data.claims\`, each with a status. Build the score and reason only from \`verified\` and \`unverified\` claims, and state the claim's date in the reason ("$30M Series B, Feb 2026"). Never cite a \`contradicted\`, \`superseded\`, or \`stale\` claim as a timing signal; if the only signals available are stale, say so and score accordingly.
+```
+
+**Step 4:** Add a grounding rule. Motivating failure: the agent described Browserbase as "a YC-backed startup" when no data said so and the contact's own enrichment listed Notable Capital, CRV, and Kleiner Perkins as the backers. This is not a data-quality bug; it is the model asserting an association it never read, so it must be blocked at the prompt level. Add to the Company Enrichment Details section (near the hiring rule from Step 2):
+
+```
+- **Never assert a company fact you did not read.** Investors, accelerator membership (YC etc.), funding stage, headcount, customers, and similar facts may only be stated when they appear in enrichment data, claims, or something the user said. If you are inferring or pattern-matching ("startups like this are usually..."), say it is a guess in the same sentence. When enrichment contradicts something you were about to say, the enrichment wins.
+```
+
+**Step 5:** Add a voice rule: domain language, not implementation language. Motivating exchange: asked how an email was verified, the agent answered "the findEmail tool with revalidate: true runs a two-step process... that flips the status from unchecked to deliverable". Owner decision: transparency about method and evidence stays (it builds trust and catches errors), but the register must be the domain, never the code. Find the system prompt's communication/voice section (or add one near the top-level behavior rules) and add:
+
+```
+- **Explain in domain language, never implementation language.** Always be willing to explain how you reached a conclusion, but describe evidence and actions, not machinery: say "I asked the company's mail server whether that mailbox exists" rather than naming tools, parameters, flags, or status values (findEmail, revalidate, unchecked, deliverable). Never mention internal step lists, credits, or which steps are paid unless the user asks about cost directly. Keep process narration to one short line; prefer doing the work over describing that you are about to do it.
+```
+
+**Step 6:** Check `getCompanyDetail` (in `src/lib/tools/enrichment-tools.ts` or `search-tools.ts`) returns the full `enrichment_data` including `claims`. It returns the stored blob today, so claims flow through automatically; verify, don't assume.
+
+**Step 7: Verify + commit.** Watch the em-dash rule; the blocks above use colons deliberately.
+
+```bash
+pnpm exec eslint src/lib/system-prompt.ts && pnpm typecheck
+git add src/lib/system-prompt.ts
+git commit -m "feat(prompt): hiring hard rule, claims-based scoring, grounding and voice rules"
+```
+
+---
+
+### Task 6: UI: claims with status badges, dates on search results
+
+**Files:**
+- Modify: `src/components/campaign/company-detail.tsx` (sections at ~lines 95-260, `SearchSection` at ~295)
+- Modify or create the enrichment types it casts to (`CompanyEnrichmentData`, wherever defined; likely `src/lib/types/enrichment.ts`) to add `claims?: CompanyClaim[]`
+
+**Step 1: Read `company-detail.tsx` fully.** Match its existing section/card idiom exactly; do not invent new styling primitives.
+
+**Step 2: Add a Claims section** rendered above the search sections when `enrichment_data.claims` is non-empty. Per claim: statement, a small status badge, `publishedDate` when present, and the source hostname as an external link. Badge treatment: `verified` green, `unverified` neutral, `stale` amber, `contradicted`/`superseded` red-struck or muted, following whatever badge component `provenance-badge.tsx` uses so the visual language matches the contact provenance work.
+
+**Step 3: Render `publishedDate` in `SearchSection`.** The prop already exists in its type and is unused; display it next to the result title (e.g. `Feb 2026`) when non-null.
+
+**Step 4: Verify in the running app** (`pnpm dev`), against a company with claims after re-enriching one, plus lint/typecheck.
+
+**Step 5: Commit.**
+
+```bash
+git add src/components/campaign/company-detail.tsx <types file>
+git commit -m "feat(ui): claim status badges and source dates on company detail"
+```
+
+---
+
+### Task 7: Full verification + PR
+
+**Step 1:** `pnpm exec eslint . && pnpm typecheck && pnpm vitest run` — all clean (minus known pre-existing failures, list them in the PR if still present).
+
+**Step 2:** Manual smoke: in the app, enrich one known company (Fyxer is the canonical case) and confirm: `hiring` populated from the careers page, `claims` present with the Series B claim `verified` and any aggregator hiring claim `contradicted`, score reason cites dated claims. Then ask the chat agent "who are this company's investors?" for a company whose enrichment does not mention investors; it should say the data does not say, not improvise (grounding rule from Task 5). The deferred eval harness should include hallucination probes like this as graded cases.
+
+**Step 3:** Push branch, open PR to `main` titled `feat(enrich): dated, sourced, reconciled claims; careers-page-first hiring`. Body: link the Fyxer failure as motivation, note the +1 Haiku call and +1 Browserbase session per company enrichment cost, note the deferred eval harness as the follow-up that measures this.

--- a/docs/plans/2026-08-01-enrichment-claims-verification.md
+++ b/docs/plans/2026-08-01-enrichment-claims-verification.md
@@ -13,6 +13,7 @@
 **Branch:** create `feat/enrichment-claims` off `origin/main` before Task 1. The user works on other branches concurrently; never commit unrelated working-tree files.
 
 **House rules that will bite you:**
+
 - No em dashes in any string/copy — eslint blocks them (`no-restricted-syntax`).
 - All LLM calls follow the `src/lib/services/relevance-filter.ts` pattern exactly: `generateObject` + `llmTimeout()` abort signal + `trackUsage` + `UNTRUSTED_NOTICE`/`wrapUntrusted`/`stringify` from `@/lib/prompt-safety` + fail-open catch.
 - Run `pnpm exec eslint <files>` and `pnpm typecheck` before every commit. (If typecheck fails on `.next/types` referencing deleted routes, `rm -rf .next/types` first — stale cache.)
@@ -23,6 +24,7 @@
 ### Task 1: Claim types + pure reconciler (TDD)
 
 **Files:**
+
 - Create: `src/lib/types/claims.ts`
 - Create: `src/lib/services/claim-reconciler.ts`
 - Test: `src/__tests__/claim-reconciler.test.ts`
@@ -300,6 +302,7 @@ Note: the design mentions a Haiku judge for date-less conflicting claims. Delibe
 ### Task 2: Claim extractor service (TDD, mocked LLM)
 
 **Files:**
+
 - Create: `src/lib/services/claim-extractor.ts`
 - Test: `src/__tests__/claim-extractor.test.ts`
 
@@ -541,8 +544,7 @@ ${wrapUntrusted(sourceBlocks.join("\n\n"))}`,
         type: c.type,
         statement: c.statement,
         sourceUrl: sources[c.sourceIndex].url,
-        publishedDate:
-          c.publishedDate ?? sources[c.sourceIndex].publishedDate,
+        publishedDate: c.publishedDate ?? sources[c.sourceIndex].publishedDate,
         confidence: c.confidence,
         extractedAt,
         status: "unverified" as const,
@@ -569,6 +571,7 @@ git commit -m "feat(claims): Haiku claim extractor with source-index provenance"
 ### Task 3: Careers scrape + claims inside `enrichCompanyById`
 
 **Files:**
+
 - Modify: `src/lib/tools/enrichment-tools.ts` (function `enrichCompanyById`, currently ~line 1100; Promise.allSettled at ~1172; search storage loop at ~1234)
 - Modify: `src/lib/services/hiring-scraper.ts` (export a non-throwing wrapper)
 
@@ -617,7 +620,7 @@ const [websiteResult, productResult, fundingResult, teamResult, hiringResult] =
 
 (`scrapeHiringData` already writes `enrichment_data.hiring` itself via `mergeEnrichmentData`; the returned value here is only for claim building.)
 
-**Step 3: Store the real executed query.** In the search storage loop, the entries become `["product", productResult, productQuery]` etc., and `query: `${org.name} ${label}`` becomes `query` from the tuple.
+**Step 3: Store the real executed query.** In the search storage loop, the entries become `["product", productResult, productQuery]` etc., and `query: `${org.name} ${label}``becomes`query` from the tuple.
 
 **Step 4: Extract + reconcile claims after the loop**, before `enrichmentData.searches = searches`:
 
@@ -645,18 +648,17 @@ const extracted = await extractClaims({
 });
 
 // Scraped jobs become verified hiring claims directly; no LLM needed.
-const hiringClaims: CompanyClaim[] =
-  careers?.careersUrl
-    ? careers.jobs.map((j) => ({
-        type: "hiring_role" as const,
-        statement: `Hiring: ${j.title}${j.location ? ` (${j.location})` : ""}`,
-        sourceUrl: careers.careersUrl as string,
-        publishedDate: careers.scrapedAt,
-        confidence: 1,
-        extractedAt: careers.scrapedAt,
-        status: "verified" as const,
-      }))
-    : [];
+const hiringClaims: CompanyClaim[] = careers?.careersUrl
+  ? careers.jobs.map((j) => ({
+      type: "hiring_role" as const,
+      statement: `Hiring: ${j.title}${j.location ? ` (${j.location})` : ""}`,
+      sourceUrl: careers.careersUrl as string,
+      publishedDate: careers.scrapedAt,
+      confidence: 1,
+      extractedAt: careers.scrapedAt,
+      status: "verified" as const,
+    }))
+  : [];
 
 enrichmentData.claims = [
   ...reconcileClaims(extracted, { now: new Date(), careers }),
@@ -684,6 +686,7 @@ git commit -m "feat(enrich): careers scrape and reconciled claims in company enr
 ### Task 4: Unify `/api/enrich-company` onto the same claims path
 
 **Files:**
+
 - Modify: `src/app/api/enrich-company/route.ts` (~lines 199-430)
 
 Full extraction of a shared `enrichCompanyCore` was considered and cut (YAGNI for now): the route has signal-gated searches, Google Reviews, and summarization the tool path deliberately lacks, and merging those is a refactor with its own risk. Instead, give the route the same claims tail:
@@ -705,6 +708,7 @@ git commit -m "feat(enrich): claims and careers scrape on the UI enrichment path
 ### Task 5: System prompt: hiring hard rule + claims-based scoring
 
 **Files:**
+
 - Modify: `src/lib/system-prompt.ts` (~lines 88, 97-104, 205-215, 226)
 
 **Step 1:** In the Full Pipeline list (~line 88), delete step 2 ("Scrape hiring data with `scrapeJobListingsBatch`...") and renumber: the scrape now runs inside `enrichCompany`. Keep `scrapeJobListings` mentioned as a refresh tool only.
@@ -748,6 +752,7 @@ git commit -m "feat(prompt): hiring hard rule, claims-based scoring, grounding a
 ### Task 6: UI: claims with status badges, dates on search results
 
 **Files:**
+
 - Modify: `src/components/campaign/company-detail.tsx` (sections at ~lines 95-260, `SearchSection` at ~295)
 - Modify or create the enrichment types it casts to (`CompanyEnrichmentData`, wherever defined; likely `src/lib/types/enrichment.ts`) to add `claims?: CompanyClaim[]`
 
@@ -768,7 +773,33 @@ git commit -m "feat(ui): claim status badges and source dates on company detail"
 
 ---
 
-### Task 7: Full verification + PR
+### Task 7: Cheap-first careers scrape (owner request, added mid-execution)
+
+**Files:**
+
+- Modify: `src/lib/services/hiring-scraper.ts`
+- Test: `src/__tests__/hiring-scraper-cheap.test.ts`
+
+Today `scrapeHiringData` goes straight to the most expensive tier: a full Stagehand browser session (60s init plus un-timed LLM observe/act/extract) for every company. Rebuild its internals cheap-first; the exported signature, `HiringScrapeResult` shape, `tryScrapeHiringData`, `HIRING_SCRAPE_TIMEOUT_MS`, and the `mergeEnrichmentData` write must not change, so every caller (both enrichment paths, the agent tools, the tracking executor) is untouched.
+
+**Tier order:**
+
+1. **Find the careers URL without a browser.** Probe the existing common-paths list with `fetchWithTimeout` (see `src/lib/fetch-with-timeout.ts`) and accept the first 2xx. If none hit, fetch the homepage and look for careers/jobs links in the HTML. Optionally one Exa search scoped to the domain as the last resort.
+2. **ATS shortcut, zero LLM.** If the careers page (or homepage) links to a hosted board, hit the board's public JSON API for structured listings: Greenhouse (`https://boards-api.greenhouse.io/v1/boards/{slug}/jobs`), Lever (`https://api.lever.co/v0/postings/{slug}?mode=json`), Ashby (`https://api.ashbyhq.com/posting-api/job-board/{slug}`), Workable (`https://apply.workable.com/api/v1/widget/accounts/{slug}`). Extract the slug from the link URL. Verify each URL pattern against the provider's current docs during implementation; do not trust this list blindly. Map into the existing `jobs` shape.
+3. **Fetched-HTML extraction.** Otherwise run `WebExtractionService.extract(careersUrl)` (its internal tiers: free fetch, then Browserbase Fetch) and one Haiku `generateObject` pass (relevance-filter house pattern) to pull `{title, department?, location?, url?}` from the text.
+4. **Stagehand only as last resort.** Keep the current implementation as a private fallback, invoked only when tiers 1-3 produce no careers URL or thin content (< ~200 chars of job-relevant text).
+
+**TDD:** mock `fetch`/`fetchWithTimeout` and test: ATS link detection + slug extraction per provider, JSON mapping into `jobs`, tier fall-through order (ATS hit never calls WebExtraction; thin content falls through to the Stagehand fallback, which in tests is a stub). Follow the repo's existing mock style in `src/__tests__/`.
+
+**Verify:** eslint, typecheck, full vitest run. Commit:
+
+```bash
+git commit -m "perf(hiring): cheap-first careers scrape with ATS shortcut, browser as last resort"
+```
+
+---
+
+### Task 8: Full verification + PR
 
 **Step 1:** `pnpm exec eslint . && pnpm typecheck && pnpm vitest run` — all clean (minus known pre-existing failures, list them in the PR if still present).
 

--- a/src/__tests__/claim-extractor.test.ts
+++ b/src/__tests__/claim-extractor.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const generateObjectMock = vi.fn();
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  generateObject: (...args: unknown[]) => generateObjectMock(...args),
+}));
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: vi.fn(),
+  estimateClaudeCostFromUsage: () => 0,
+}));
+
+import { extractClaims } from "@/lib/services/claim-extractor";
+
+const searches = [
+  {
+    category: "funding",
+    query: '"Fyxer" fyxer.com funding news announcement',
+    results: [
+      {
+        title: "Fyxer raises $30M Series B",
+        url: "https://news.example.com/fyxer-series-b",
+        publishedDate: "2026-02-11",
+        text: "Fyxer AI closed a $30 million Series B led by Madrona...",
+      },
+    ],
+  },
+];
+
+describe("extractClaims", () => {
+  // Braces matter: mockReset() returns the mock (a function), and a function
+  // returned from beforeEach is treated by Vitest as a teardown callback. That
+  // teardown call would re-invoke the rejecting mock and leak an unhandled
+  // rejection into the fail-open test.
+  beforeEach(() => {
+    generateObjectMock.mockReset();
+  });
+
+  it("returns typed claims from the LLM with provenance attached", async () => {
+    generateObjectMock.mockResolvedValue({
+      object: {
+        claims: [
+          {
+            type: "funding_round",
+            statement: "Raised a $30M Series B led by Madrona",
+            sourceIndex: 0,
+            publishedDate: "2026-02-11",
+            confidence: 0.9,
+          },
+        ],
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    const out = await extractClaims({
+      companyName: "Fyxer",
+      companyDomain: "fyxer.com",
+      websiteContent: null,
+      searches,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("funding_round");
+    expect(out[0].sourceUrl).toBe("https://news.example.com/fyxer-series-b");
+    expect(out[0].status).toBe("unverified");
+    expect(out[0].extractedAt).toBeTruthy();
+  });
+
+  it("fails open to an empty list when the LLM call throws", async () => {
+    generateObjectMock.mockRejectedValue(new Error("overloaded"));
+    const out = await extractClaims({
+      companyName: "Fyxer",
+      companyDomain: "fyxer.com",
+      websiteContent: null,
+      searches,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("drops claims whose sourceIndex is out of range", async () => {
+    generateObjectMock.mockResolvedValue({
+      object: {
+        claims: [
+          {
+            type: "product",
+            statement: "hallucinated",
+            sourceIndex: 99,
+            publishedDate: null,
+            confidence: 0.9,
+          },
+        ],
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    const out = await extractClaims({
+      companyName: "Fyxer",
+      companyDomain: "fyxer.com",
+      websiteContent: null,
+      searches,
+    });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/__tests__/claim-reconciler.test.ts
+++ b/src/__tests__/claim-reconciler.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { reconcileClaims } from "@/lib/services/claim-reconciler";
+import type { CompanyClaim, CareersScrape } from "@/lib/types/claims";
+
+const NOW = new Date("2026-08-01T12:00:00Z");
+
+function claim(partial: Partial<CompanyClaim>): CompanyClaim {
+  return {
+    type: "product",
+    statement: "x",
+    sourceUrl: "https://example.com",
+    publishedDate: null,
+    confidence: 0.8,
+    extractedAt: NOW.toISOString(),
+    status: "unverified",
+    ...partial,
+  };
+}
+
+const fyxerCareers: CareersScrape = {
+  careersUrl: "https://fyxer.com/careers",
+  jobs: [{ title: "Senior Customer Support Specialist", location: "Austin" }],
+  scrapedAt: NOW.toISOString(),
+};
+
+describe("reconcileClaims", () => {
+  it("supersedes older funding claims with the newest dated one", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "funding_round",
+          statement: "Raised a $10M Series A",
+          publishedDate: "2024-11-01",
+        }),
+        claim({
+          type: "funding_round",
+          statement: "Raised a $30M Series B led by Madrona",
+          publishedDate: "2026-02-11",
+        }),
+        claim({
+          type: "funding_round",
+          statement: "Raised $500K",
+          publishedDate: null,
+        }),
+      ],
+      { now: NOW, careers: null },
+    );
+    expect(out.find((c) => c.statement.includes("Series B"))?.status).toBe(
+      "verified",
+    );
+    expect(out.find((c) => c.statement.includes("Series A"))?.status).toBe(
+      "superseded",
+    );
+    expect(out.find((c) => c.statement.includes("$500K"))?.status).toBe(
+      "superseded",
+    );
+  });
+
+  it("contradicts hiring claims not backed by the careers scrape", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Hiring a Growth Director",
+          sourceUrl: "https://news-aggregator.example.com/fyxer",
+        }),
+      ],
+      { now: NOW, careers: fyxerCareers },
+    );
+    expect(out[0].status).toBe("contradicted");
+  });
+
+  it("verifies hiring claims that match a scraped job title", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Hiring: Senior Customer Support Specialist",
+        }),
+      ],
+      { now: NOW, careers: fyxerCareers },
+    );
+    expect(out[0].status).toBe("verified");
+  });
+
+  it("marks hiring claims stale without a scrape when older than 90 days", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Hiring a Growth Director",
+          publishedDate: "2026-01-01",
+        }),
+      ],
+      { now: NOW, careers: null },
+    );
+    expect(out[0].status).toBe("stale");
+  });
+
+  it("marks lone funding claims older than 12 months stale, not superseded", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "funding_round",
+          statement: "Raised a $10M Series A",
+          publishedDate: "2024-11-01",
+        }),
+      ],
+      { now: NOW, careers: null },
+    );
+    expect(out[0].status).toBe("stale");
+  });
+
+  it("leaves fresh, unconflicted claims unverified and untouched", () => {
+    const out = reconcileClaims(
+      [claim({ type: "product", statement: "AI email assistant" })],
+      { now: NOW, careers: null },
+    );
+    expect(out[0].status).toBe("unverified");
+  });
+});

--- a/src/__tests__/company-detail-claims.test.tsx
+++ b/src/__tests__/company-detail-claims.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CompanyDetail } from "@/components/campaign/company-detail";
+import type {
+  CampaignCompany,
+  CompanyEnrichmentData,
+} from "@/lib/types/campaign";
+import type { CompanyClaim } from "@/lib/types/claims";
+
+function claim(partial: Partial<CompanyClaim>): CompanyClaim {
+  return {
+    type: "product",
+    statement: "x",
+    sourceUrl: "https://example.com/article",
+    publishedDate: null,
+    confidence: 0.8,
+    extractedAt: "2026-08-01T00:00:00Z",
+    status: "unverified",
+    ...partial,
+  };
+}
+
+function company(enrichment: CompanyEnrichmentData): CampaignCompany {
+  return {
+    id: "c1",
+    organization_id: "o1",
+    campaign_id: "cam1",
+    name: "Fyxer",
+    domain: "fyxer.com",
+    url: null,
+    industry: null,
+    location: null,
+    description: null,
+    relevance_score: null,
+    score_reason: null,
+    status: "discovered",
+    readiness_tag: null,
+    enrichment_data: enrichment,
+    source: null,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+  };
+}
+
+describe("<CompanyDetail> claims section", () => {
+  afterEach(cleanup);
+
+  it("renders claims with status badges, dates, and source hosts", () => {
+    render(
+      <CompanyDetail
+        company={company({
+          enrichedAt: "2026-08-01T00:00:00Z",
+          claims: [
+            claim({
+              type: "funding_round",
+              statement: "Raised a $30M Series B led by Madrona",
+              sourceUrl: "https://www.news.example.com/fyxer-series-b",
+              publishedDate: "2026-02-11",
+              status: "verified",
+            }),
+            claim({
+              type: "funding_round",
+              statement: "Raised a $10M Series A",
+              publishedDate: "2024-11-01",
+              status: "superseded",
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Claims (2)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Raised a $30M Series B led by Madrona"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("verified")).toBeInTheDocument();
+    expect(screen.getByText("Feb 2026")).toBeInTheDocument();
+    expect(screen.getByText("news.example.com")).toBeInTheDocument();
+
+    // Superseded claims stay visible but struck through.
+    expect(screen.getByText("Raised a $10M Series A")).toHaveClass(
+      "line-through",
+    );
+    expect(screen.getByText("superseded")).toBeInTheDocument();
+  });
+
+  it("omits the claims section when there are no claims", () => {
+    render(
+      <CompanyDetail
+        company={company({ enrichedAt: "2026-08-01T00:00:00Z" })}
+      />,
+    );
+    expect(screen.queryByText(/^Claims \(/)).not.toBeInTheDocument();
+  });
+
+  it("shows a compact published date on search results", () => {
+    render(
+      <CompanyDetail
+        company={company({
+          enrichedAt: "2026-08-01T00:00:00Z",
+          searches: [
+            {
+              category: "funding",
+              query: "Fyxer funding",
+              results: [
+                {
+                  title: "Fyxer raises $30M Series B",
+                  url: "https://news.example.com/fyxer-series-b",
+                  publishedDate: "2026-02-11",
+                  text: "Fyxer AI closed a $30 million Series B.",
+                },
+              ],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Fyxer raises $30M Series B")).toBeInTheDocument();
+    expect(screen.getByText("Feb 2026")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/hiring-scraper-cheap.test.ts
+++ b/src/__tests__/hiring-scraper-cheap.test.ts
@@ -1,0 +1,407 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithTimeoutMock = vi.fn();
+vi.mock("@/lib/fetch-with-timeout", () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
+}));
+
+const mergeEnrichmentDataMock = vi.fn();
+vi.mock("@/lib/services/knowledge-base", () => ({
+  mergeEnrichmentData: (...args: unknown[]) => mergeEnrichmentDataMock(...args),
+}));
+
+const webExtractMock = vi.fn();
+vi.mock("@/lib/services/web-extraction-service", () => ({
+  WebExtractionService: class {
+    extract = (...args: unknown[]) => webExtractMock(...args);
+  },
+}));
+
+const generateObjectMock = vi.fn();
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  generateObject: (...args: unknown[]) => generateObjectMock(...args),
+}));
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: vi.fn(),
+  estimateClaudeCostFromUsage: () => 0,
+}));
+
+// Stagehand stub: the last-resort browser tier. Tests assert on these mocks
+// to prove (or disprove) that a scrape fell all the way through.
+const stagehandInitMock = vi.fn();
+const stagehandObserveMock = vi.fn();
+const stagehandActMock = vi.fn();
+const stagehandExtractMock = vi.fn();
+const stagehandPage = {
+  goto: vi.fn(async () => ({ ok: () => true })),
+  waitForTimeout: vi.fn(async () => {}),
+  url: () => "https://acme.com/careers",
+};
+vi.mock("@browserbasehq/stagehand", () => ({
+  Stagehand: class {
+    init = stagehandInitMock;
+    context = { pages: () => [stagehandPage] };
+    observe = stagehandObserveMock;
+    act = stagehandActMock;
+    extract = stagehandExtractMock;
+    close = vi.fn(async () => {});
+  },
+}));
+
+import { scrapeHiringData } from "@/lib/services/hiring-scraper";
+
+interface FakeResponseInit {
+  ok?: boolean;
+  status?: number;
+  url?: string;
+}
+
+function res(body: string | object, init: FakeResponseInit = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? (init.ok === false ? 404 : 200),
+    statusText: "",
+    url: init.url ?? "",
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    json: async () => (typeof body === "string" ? JSON.parse(body) : body),
+  };
+}
+
+const notFound = () => res("", { ok: false, status: 404 });
+
+/** Routes fetchWithTimeout calls by exact URL; everything else 404s. */
+function routeFetches(routes: Record<string, ReturnType<typeof res>>) {
+  fetchWithTimeoutMock.mockImplementation(async (url: unknown) => {
+    const u = String(url);
+    return routes[u] ?? notFound();
+  });
+}
+
+function calledUrls(): string[] {
+  return fetchWithTimeoutMock.mock.calls.map((c) => String(c[0]));
+}
+
+describe("scrapeHiringData cheap-first tiers", () => {
+  beforeEach(() => {
+    fetchWithTimeoutMock.mockReset();
+    mergeEnrichmentDataMock.mockReset();
+    mergeEnrichmentDataMock.mockResolvedValue(undefined);
+    webExtractMock.mockReset();
+    generateObjectMock.mockReset();
+    stagehandInitMock.mockReset();
+    stagehandInitMock.mockResolvedValue(undefined);
+    stagehandObserveMock.mockReset();
+    stagehandActMock.mockReset();
+    stagehandExtractMock.mockReset();
+    vi.stubEnv("BROWSERBASE_API_KEY", "bb-key");
+    vi.stubEnv("BROWSERBASE_PROJECT_ID", "bb-project");
+    vi.stubEnv("ANTHROPIC_API_KEY", "ant-key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("ATS shortcut (tier 2, zero LLM)", () => {
+    it("detects a Greenhouse board on the careers page and maps its jobs", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          '<html><a href="https://boards.greenhouse.io/acme">See openings</a></html>',
+          { url: "https://acme.com/careers" },
+        ),
+        "https://boards-api.greenhouse.io/v1/boards/acme/jobs?content=true":
+          res({
+            jobs: [
+              {
+                title: "Platform Engineer",
+                absolute_url: "https://boards.greenhouse.io/acme/jobs/123",
+                location: { name: "Remote" },
+                departments: [{ name: "Engineering" }],
+              },
+            ],
+          }),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+
+      expect(out.careersUrl).toBe("https://acme.com/careers");
+      expect(out.totalJobs).toBe(1);
+      expect(out.jobs).toEqual([
+        {
+          title: "Platform Engineer",
+          department: "Engineering",
+          location: "Remote",
+          url: "https://boards.greenhouse.io/acme/jobs/123",
+        },
+      ]);
+      expect(mergeEnrichmentDataMock).toHaveBeenCalledWith(
+        "organizations",
+        "org-1",
+        expect.objectContaining({
+          hiring: expect.objectContaining({
+            careersUrl: "https://acme.com/careers",
+            jobs: out.jobs,
+          }),
+        }),
+      );
+      // ATS hit must never reach the heavier tiers.
+      expect(webExtractMock).not.toHaveBeenCalled();
+      expect(generateObjectMock).not.toHaveBeenCalled();
+      expect(stagehandInitMock).not.toHaveBeenCalled();
+    });
+
+    it("extracts the Greenhouse slug from an embed job_board URL", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          '<script src="https://boards.greenhouse.io/embed/job_board?for=acme"></script>',
+          { url: "https://acme.com/careers" },
+        ),
+        "https://boards-api.greenhouse.io/v1/boards/acme/jobs?content=true":
+          res({ jobs: [{ title: "SDR", absolute_url: "https://x.example" }] }),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+      expect(out.jobs.map((j) => j.title)).toEqual(["SDR"]);
+    });
+
+    it("detects a Lever board and maps text/categories into the jobs shape", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          '<a href="https://jobs.lever.co/acme">Jobs</a>',
+          { url: "https://acme.com/careers" },
+        ),
+        "https://api.lever.co/v0/postings/acme?mode=json": res([
+          {
+            text: "Sales Lead",
+            categories: { team: "Sales", location: "New York" },
+            hostedUrl: "https://jobs.lever.co/acme/abc",
+          },
+        ]),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+      expect(out.jobs).toEqual([
+        {
+          title: "Sales Lead",
+          department: "Sales",
+          location: "New York",
+          url: "https://jobs.lever.co/acme/abc",
+        },
+      ]);
+      expect(webExtractMock).not.toHaveBeenCalled();
+    });
+
+    it("detects an Ashby board and skips unlisted postings", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          '<a href="https://jobs.ashbyhq.com/acme">Open roles</a>',
+          { url: "https://acme.com/careers" },
+        ),
+        "https://api.ashbyhq.com/posting-api/job-board/acme": res({
+          jobs: [
+            {
+              title: "Product Designer",
+              department: "Design",
+              location: "San Francisco",
+              jobUrl: "https://jobs.ashbyhq.com/acme/xyz",
+              isListed: true,
+            },
+            {
+              title: "Ghost Role",
+              department: "Design",
+              location: "SF",
+              jobUrl: "https://jobs.ashbyhq.com/acme/ghost",
+              isListed: false,
+            },
+          ],
+        }),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+      expect(out.jobs).toEqual([
+        {
+          title: "Product Designer",
+          department: "Design",
+          location: "San Francisco",
+          url: "https://jobs.ashbyhq.com/acme/xyz",
+        },
+      ]);
+    });
+
+    it("detects a Workable board and joins city and country into location", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          '<a href="https://apply.workable.com/acme/">Apply</a>',
+          { url: "https://acme.com/careers" },
+        ),
+        "https://apply.workable.com/api/v1/widget/accounts/acme": res({
+          name: "Acme",
+          jobs: [
+            {
+              title: "Support Rep",
+              department: "CX",
+              city: "Athens",
+              country: "Greece",
+              url: "https://apply.workable.com/j/ABC123",
+            },
+          ],
+        }),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+      expect(out.jobs).toEqual([
+        {
+          title: "Support Rep",
+          department: "CX",
+          location: "Athens, Greece",
+          url: "https://apply.workable.com/j/ABC123",
+        },
+      ]);
+    });
+
+    it("caps jobs at maxJobs while reporting the full totalJobs", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          '<a href="https://jobs.lever.co/acme">Jobs</a>',
+          { url: "https://acme.com/careers" },
+        ),
+        "https://api.lever.co/v0/postings/acme?mode=json": res([
+          { text: "Role A", hostedUrl: "https://x.example/a" },
+          { text: "Role B", hostedUrl: "https://x.example/b" },
+          { text: "Role C", hostedUrl: "https://x.example/c" },
+        ]),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com", 2);
+      expect(out.jobs).toHaveLength(2);
+      expect(out.totalJobs).toBe(3);
+    });
+
+    it("finds the careers link on the homepage when no common path responds", async () => {
+      routeFetches({
+        "https://acme.com": res('<nav><a href="/join-us">Join us</a></nav>', {
+          url: "https://acme.com",
+        }),
+        "https://acme.com/join-us": res(
+          '<a href="https://jobs.ashbyhq.com/acme">Roles</a>',
+          { url: "https://acme.com/join-us" },
+        ),
+        "https://api.ashbyhq.com/posting-api/job-board/acme": res({
+          jobs: [
+            {
+              title: "Founding Engineer",
+              location: "Remote",
+              jobUrl: "https://jobs.ashbyhq.com/acme/1",
+            },
+          ],
+        }),
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+      expect(out.careersUrl).toBe("https://acme.com/join-us");
+      expect(out.jobs.map((j) => j.title)).toEqual(["Founding Engineer"]);
+    });
+  });
+
+  describe("fetched-HTML extraction (tier 3)", () => {
+    it("runs WebExtraction plus one Haiku pass when no ATS board is linked", async () => {
+      routeFetches({
+        "https://acme.com/careers": res(
+          "<html><h1>Careers</h1><p>We hire in-house, no job board here.</p></html>",
+          { url: "https://acme.com/careers" },
+        ),
+      });
+      webExtractMock.mockResolvedValue({
+        success: true,
+        url: "https://acme.com/careers",
+        source: "fetch",
+        data: {
+          title: "Careers",
+          description: "",
+          content:
+            "Open positions at Acme. Operations Manager, Berlin, full time. " +
+            "Head of Sales, London. Apply by emailing jobs@acme.com. " +
+            "We are a growing team looking for people who love logistics " +
+            "and want to build the future of freight with us in Europe.",
+        },
+        extractionTime: 5,
+      });
+      generateObjectMock.mockResolvedValue({
+        object: {
+          jobs: [
+            { title: "Operations Manager", location: "Berlin" },
+            { title: "Head of Sales", location: "London" },
+          ],
+        },
+        usage: { inputTokens: 1, outputTokens: 1 },
+      });
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+
+      expect(webExtractMock).toHaveBeenCalledWith(
+        "https://acme.com/careers",
+        expect.anything(),
+      );
+      expect(out.careersUrl).toBe("https://acme.com/careers");
+      expect(out.jobs).toEqual([
+        { title: "Operations Manager", location: "Berlin" },
+        { title: "Head of Sales", location: "London" },
+      ]);
+      expect(out.totalJobs).toBe(2);
+      expect(stagehandInitMock).not.toHaveBeenCalled();
+      // No ATS API was ever called.
+      expect(
+        calledUrls().filter(
+          (u) =>
+            u.includes("greenhouse.io") ||
+            u.includes("lever.co") ||
+            u.includes("ashbyhq.com") ||
+            u.includes("workable.com"),
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("Stagehand last resort (tier 4)", () => {
+    it("falls through to the browser when extracted content is thin", async () => {
+      routeFetches({
+        "https://acme.com/careers": res("<html>Loading...</html>", {
+          url: "https://acme.com/careers",
+        }),
+      });
+      webExtractMock.mockResolvedValue({
+        success: true,
+        url: "https://acme.com/careers",
+        source: "fetch",
+        data: { title: "", description: "", content: "Loading..." },
+        extractionTime: 5,
+      });
+      stagehandObserveMock.mockResolvedValue([{ selector: "a" }]);
+      stagehandExtractMock.mockResolvedValue([
+        { title: "Browser-Only Role", location: "Remote" },
+      ]);
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+
+      expect(stagehandInitMock).toHaveBeenCalled();
+      expect(out.jobs.map((j) => j.title)).toEqual(["Browser-Only Role"]);
+    });
+
+    it("falls through to the browser when no careers URL is found at all", async () => {
+      routeFetches({
+        "https://acme.com": res('<html><a href="/pricing">Pricing</a></html>', {
+          url: "https://acme.com",
+        }),
+      });
+      stagehandObserveMock.mockResolvedValue([{ selector: "a" }]);
+      stagehandExtractMock.mockResolvedValue([{ title: "Hidden Role" }]);
+
+      const out = await scrapeHiringData("org-1", "acme.com");
+
+      expect(stagehandInitMock).toHaveBeenCalled();
+      expect(out.jobs.map((j) => j.title)).toEqual(["Hidden Role"]);
+      expect(out.careersUrl).toBe("https://acme.com/careers");
+    });
+  });
+});

--- a/src/app/api/enrich-company/route.ts
+++ b/src/app/api/enrich-company/route.ts
@@ -13,6 +13,14 @@ import {
 } from "@/lib/services/knowledge-base";
 import { findContactsForOrganization } from "@/lib/services/contact-discovery";
 import { type CompanyContext } from "@/lib/services/contact-filter";
+import { extractClaims } from "@/lib/services/claim-extractor";
+import { reconcileClaims } from "@/lib/services/claim-reconciler";
+import {
+  HIRING_SCRAPE_TIMEOUT_MS,
+  tryScrapeHiringData,
+} from "@/lib/services/hiring-scraper";
+import type { CompanyClaim } from "@/lib/types/claims";
+import { withTimeout } from "@/lib/utils/timeout";
 
 export const maxDuration = 120;
 
@@ -301,6 +309,18 @@ async function enrichOrganization(
             );
           })()
         : Promise.resolve(null),
+      // Bounded: Stagehand's observe/act/extract steps have no timeouts of
+      // their own, and an unbounded scrape would blow past the route's
+      // maxDuration. On timeout allSettled records a rejection, careers
+      // stays null, and hiring is reported unknown, which is the designed
+      // fail-open behavior.
+      org.domain
+        ? withTimeout(
+            tryScrapeHiringData(orgId, org.domain as string),
+            HIRING_SCRAPE_TIMEOUT_MS,
+            `Careers scrape ${org.domain}`,
+          )
+        : Promise.resolve(null),
     ]);
 
     const [
@@ -309,6 +329,7 @@ async function enrichOrganization(
       fundingResult,
       executiveResult,
       googleReviewsResult,
+      hiringResult,
     ] = operations;
 
     const enrichmentData: Record<string, unknown> = {
@@ -411,6 +432,48 @@ async function enrichOrganization(
         `Google Reviews: ${googleReviewsResult.reason?.message || "Failed"}`,
       );
     }
+
+    // Typed claims: extract from raw pulls, then reconcile against the
+    // careers scrape (ground truth for hiring) and recency rules. Runs
+    // regardless of which signal-gated searches ran; extractClaims handles
+    // empty or partial input. Fail-open at every stage; a claims failure
+    // never blocks storing the raw enrichment.
+    const careers =
+      hiringResult.status === "fulfilled" && hiringResult.value
+        ? {
+            careersUrl: hiringResult.value.careersUrl,
+            jobs: hiringResult.value.jobs,
+            scrapedAt: new Date().toISOString(),
+          }
+        : null;
+
+    const extracted = await extractClaims({
+      companyName: org.name as string,
+      companyDomain,
+      websiteContent:
+        websiteResult.status === "fulfilled" && websiteResult.value?.success
+          ? websiteResult.value.data.content
+          : null,
+      searches,
+    });
+
+    // Scraped jobs become verified hiring claims directly; no LLM needed.
+    const hiringClaims: CompanyClaim[] = careers?.careersUrl
+      ? careers.jobs.map((j) => ({
+          type: "hiring_role" as const,
+          statement: `Hiring: ${j.title}${j.location ? ` (${j.location})` : ""}`,
+          sourceUrl: careers.careersUrl as string,
+          publishedDate: careers.scrapedAt,
+          confidence: 1,
+          extractedAt: careers.scrapedAt,
+          status: "verified" as const,
+        }))
+      : [];
+
+    enrichmentData.claims = [
+      ...reconcileClaims(extracted, { now: new Date(), careers }),
+      ...hiringClaims,
+    ];
 
     if (errors.length > 0) enrichmentData.errors = errors;
 

--- a/src/components/campaign/company-detail.tsx
+++ b/src/components/campaign/company-detail.tsx
@@ -10,6 +10,7 @@ import type {
   CampaignCompany,
   CompanyEnrichmentData,
 } from "@/lib/types/campaign";
+import type { ClaimStatus, CompanyClaim } from "@/lib/types/claims";
 
 const LINK_FOCUS =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded";
@@ -49,6 +50,21 @@ function formatDate(iso: string) {
   });
 }
 
+/** Compact source date, e.g. "Feb 2026". Null when the string does not parse. */
+function formatMonthYear(iso: string): string | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+function hostname(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
 interface CompanyDetailProps {
   company: CampaignCompany;
   onRefresh?: (companyId: string) => void;
@@ -79,6 +95,7 @@ export function CompanyDetail({
   const teamSearch = searches.find(
     (s) => s.category === "team" || s.category === "executive",
   );
+  const claims = data.claims ?? [];
   const hiring = data.hiring;
   const jobsToShow = hiring
     ? showAllJobs
@@ -182,6 +199,19 @@ export function CompanyDetail({
               </ul>
             </div>
           )}
+        </section>
+      )}
+
+      {claims.length > 0 && (
+        <section className="space-y-1">
+          <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Claims ({claims.length})
+          </h4>
+          <ul className="divide-border divide-y">
+            {claims.map((claim, i) => (
+              <ClaimRow key={i} claim={claim} />
+            ))}
+          </ul>
         </section>
       )}
 
@@ -292,6 +322,82 @@ export function CompanyDetail({
   );
 }
 
+// Same tone tokens as provenance-badge.tsx (success/destructive/muted) plus
+// the warn token status-pill.tsx already uses, so claim states read exactly
+// like the contact provenance pills elsewhere in the app.
+const CLAIM_STATUS_STYLE: Record<ClaimStatus, string> = {
+  verified: "bg-success/10 text-success",
+  unverified: "bg-muted text-muted-foreground",
+  stale: "bg-warn/15 text-warn",
+  contradicted: "bg-muted text-muted-foreground",
+  superseded: "bg-muted text-muted-foreground",
+};
+
+const CLAIM_STATUS_TITLE: Record<ClaimStatus, string> = {
+  verified: "Confirmed by the newest dated source or the live careers page.",
+  unverified: "Extracted from a source but not yet confirmed.",
+  stale: "The source is old enough that this may no longer be true.",
+  contradicted: "The live careers page says otherwise.",
+  superseded: "A newer claim of the same type replaced this one.",
+};
+
+function ClaimRow({ claim }: { claim: CompanyClaim }) {
+  const dismissed =
+    claim.status === "contradicted" || claim.status === "superseded";
+  const published = claim.publishedDate
+    ? formatMonthYear(claim.publishedDate)
+    : null;
+  const host = hostname(claim.sourceUrl);
+
+  return (
+    <li className="py-2 first:pt-1">
+      <div className="flex items-start gap-2">
+        <p
+          className={cn(
+            "flex-1 text-xs",
+            dismissed
+              ? "text-muted-foreground line-through"
+              : "text-foreground font-medium",
+          )}
+        >
+          {claim.statement}
+        </p>
+        <span
+          title={CLAIM_STATUS_TITLE[claim.status]}
+          className={cn(
+            "inline-block shrink-0 rounded-full px-1.5 py-0.5 text-xs font-medium",
+            CLAIM_STATUS_STYLE[claim.status],
+          )}
+        >
+          {claim.status}
+        </span>
+      </div>
+      {(published || host) && (
+        <div className="text-muted-foreground mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+          {published && <span className="tabular-nums">{published}</span>}
+          {published && host && (
+            <span className="text-muted-foreground/40">·</span>
+          )}
+          {host && (
+            <a
+              href={claim.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                "hover:text-foreground inline-flex items-center gap-1 transition-colors",
+                LINK_FOCUS,
+              )}
+            >
+              {host}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
 function SearchSection({
   title,
   items,
@@ -313,12 +419,20 @@ function SearchSection({
       <ul className="divide-border divide-y">
         {items.map((r, i) => {
           const body = r.summary ?? r.text ?? "";
+          const published = r.publishedDate
+            ? formatMonthYear(r.publishedDate)
+            : null;
           return (
             <li key={i} className="py-2 first:pt-1">
               <div className="flex items-start gap-1.5">
                 <p className="line-clamp-1 flex-1 text-xs font-medium">
                   {r.title}
                 </p>
+                {published && (
+                  <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                    {published}
+                  </span>
+                )}
                 <a
                   href={r.url}
                   target="_blank"

--- a/src/lib/services/claim-extractor.ts
+++ b/src/lib/services/claim-extractor.ts
@@ -1,0 +1,137 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { llmTimeout } from "@/lib/utils/timeout";
+import { MODELS } from "@/lib/ai/models";
+import {
+  estimateClaudeCostFromUsage,
+  trackUsage,
+} from "@/lib/services/cost-tracker";
+import {
+  UNTRUSTED_NOTICE,
+  stringify,
+  wrapUntrusted,
+} from "@/lib/prompt-safety";
+import { CLAIM_TYPES, type CompanyClaim } from "@/lib/types/claims";
+
+interface EnrichmentSearch {
+  category: string;
+  query: string;
+  results: Array<{
+    title: string;
+    url: string;
+    publishedDate: string | null;
+    text: string | null;
+  }>;
+}
+
+interface ExtractInput {
+  companyName: string;
+  companyDomain: string | null;
+  websiteContent: string | null;
+  searches: EnrichmentSearch[];
+}
+
+/**
+ * One Haiku pass over the raw enrichment pulls that emits typed, sourced
+ * claims. The model references sources by index; the code resolves the
+ * index back to the URL so a claim can never cite a URL the pull did not
+ * contain. Fails open to [] so enrichment still stores raw data when the
+ * extractor is down.
+ */
+export async function extractClaims(
+  input: ExtractInput,
+): Promise<CompanyClaim[]> {
+  const sources: Array<{ url: string; publishedDate: string | null }> = [];
+  const sourceBlocks: string[] = [];
+
+  if (input.websiteContent && input.companyDomain) {
+    sources.push({
+      url: `https://${input.companyDomain}`,
+      publishedDate: null,
+    });
+    sourceBlocks.push(
+      `[0] Company website (${input.companyDomain}):\n${input.websiteContent.slice(0, 1500)}`,
+    );
+  }
+  for (const search of input.searches) {
+    for (const r of search.results) {
+      const i = sources.length;
+      sources.push({ url: r.url, publishedDate: r.publishedDate });
+      sourceBlocks.push(
+        `[${i}] (${search.category}) "${r.title}" ${r.url}${r.publishedDate ? ` published ${r.publishedDate}` : " (undated)"}\n${r.text?.slice(0, 1200) ?? ""}`,
+      );
+    }
+  }
+  if (sources.length === 0) return [];
+
+  try {
+    const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
+      model: anthropic(MODELS.LIGHT),
+      schema: z.object({
+        claims: z.array(
+          z.object({
+            type: z.enum(CLAIM_TYPES),
+            statement: z
+              .string()
+              .describe("One factual sentence about the company"),
+            sourceIndex: z
+              .number()
+              .int()
+              .describe("Index of the source block the claim comes from"),
+            publishedDate: z
+              .string()
+              .nullable()
+              .describe("Date of the underlying fact if the source states one"),
+            confidence: z.number().min(0).max(1),
+          }),
+        ),
+      }),
+      prompt: `You extract factual claims about a company from research sources.
+
+${UNTRUSTED_NOTICE}
+
+Target company: ${stringify(input.companyName)}${input.companyDomain ? ` (${stringify(input.companyDomain)})` : ""}
+
+Extract every distinct factual claim about THIS company from the sources below. Claims must be things a salesperson would act on: funding rounds, headcount, roles being hired, executive changes, product facts, locations. Rules:
+- One claim per fact. Do not merge facts from different sources into one claim.
+- If two sources disagree (e.g. Series A vs Series B), emit BOTH claims, each citing its own source. Reconciliation happens downstream.
+- Never invent a date. Use the source's published date only when the source states when the fact happened.
+- Skip claims about other companies, even similarly named ones.
+
+Sources:
+${wrapUntrusted(sourceBlocks.join("\n\n"))}`,
+    });
+
+    trackUsage({
+      service: "claude",
+      operation: "claim-extractor",
+      tokens_input: usage.inputTokens ?? 0,
+      tokens_output: usage.outputTokens ?? 0,
+      estimated_cost_usd: estimateClaudeCostFromUsage("haiku", usage),
+      metadata: {
+        model: "claude-haiku-4-5",
+        companyName: input.companyName,
+        sourceCount: sources.length,
+        claimCount: object.claims.length,
+      },
+    });
+
+    const extractedAt = new Date().toISOString();
+    return object.claims
+      .filter((c) => c.sourceIndex >= 0 && c.sourceIndex < sources.length)
+      .map((c) => ({
+        type: c.type,
+        statement: c.statement,
+        sourceUrl: sources[c.sourceIndex].url,
+        publishedDate: c.publishedDate ?? sources[c.sourceIndex].publishedDate,
+        confidence: c.confidence,
+        extractedAt,
+        status: "unverified" as const,
+      }));
+  } catch (err) {
+    console.error("[claim-extractor] failed, storing raw data only:", err);
+    return [];
+  }
+}

--- a/src/lib/services/claim-reconciler.ts
+++ b/src/lib/services/claim-reconciler.ts
@@ -1,0 +1,74 @@
+import type { CareersScrape, CompanyClaim } from "@/lib/types/claims";
+
+const FUNDING_STALE_MS = 365 * 24 * 60 * 60 * 1000;
+const HIRING_STALE_MS = 90 * 24 * 60 * 60 * 1000;
+
+function ageMs(claim: CompanyClaim, now: Date): number | null {
+  if (!claim.publishedDate) return null;
+  const t = Date.parse(claim.publishedDate);
+  return Number.isNaN(t) ? null : now.getTime() - t;
+}
+
+/** Case-insensitive containment either way, so "Hiring: Growth Director" matches "Growth Director (Remote)". */
+function matchesScrapedJob(statement: string, careers: CareersScrape): boolean {
+  const s = statement.toLowerCase();
+  return careers.jobs.some((j) => {
+    const t = j.title.toLowerCase();
+    return s.includes(t) || t.includes(s);
+  });
+}
+
+/**
+ * Deterministic verification pass over extracted claims. Pure function so
+ * the rules are unit-testable; no LLM, no IO. Rules, in order:
+ *
+ * 1. hiring_role with a careers scrape available: verified when a scraped
+ *    job title matches, contradicted when none does. The live careers page
+ *    is ground truth; news and aggregator text never outranks it.
+ * 2. Same-type conflicts (funding_round, headcount): the newest dated claim
+ *    wins (verified); every other claim of that type is superseded.
+ * 3. Staleness: a surviving dated claim past its shelf life (12 months for
+ *    funding, 90 days for hiring) is marked stale rather than asserted.
+ */
+export function reconcileClaims(
+  claims: CompanyClaim[],
+  opts: { now: Date; careers: CareersScrape | null },
+): CompanyClaim[] {
+  const out = claims.map((c) => ({ ...c }));
+
+  for (const c of out) {
+    if (c.type !== "hiring_role") continue;
+    if (opts.careers) {
+      c.status = matchesScrapedJob(c.statement, opts.careers)
+        ? "verified"
+        : "contradicted";
+    } else {
+      const age = ageMs(c, opts.now);
+      if (age !== null && age > HIRING_STALE_MS) c.status = "stale";
+    }
+  }
+
+  for (const type of ["funding_round", "headcount"] as const) {
+    const group = out.filter((c) => c.type === type);
+    if (group.length > 1) {
+      const dated = group
+        .filter((c) => ageMs(c, opts.now) !== null)
+        .sort((a, b) => ageMs(a, opts.now)! - ageMs(b, opts.now)!);
+      if (dated.length > 0) {
+        const winner = dated[0];
+        for (const c of group) {
+          c.status = c === winner ? "verified" : "superseded";
+        }
+      }
+    }
+    for (const c of group) {
+      if (c.status === "superseded" || c.status === "contradicted") continue;
+      const age = ageMs(c, opts.now);
+      if (type === "funding_round" && age !== null && age > FUNDING_STALE_MS) {
+        c.status = "stale";
+      }
+    }
+  }
+
+  return out;
+}

--- a/src/lib/services/hiring-scraper.ts
+++ b/src/lib/services/hiring-scraper.ts
@@ -1,9 +1,46 @@
+import * as cheerio from "cheerio";
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateObject } from "ai";
 import { z } from "zod";
 import { MODELS } from "@/lib/ai/models";
+import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
+import {
+  UNTRUSTED_NOTICE,
+  stringify,
+  wrapUntrusted,
+} from "@/lib/prompt-safety";
+import {
+  estimateClaudeCostFromUsage,
+  trackUsage,
+} from "@/lib/services/cost-tracker";
 import { mergeEnrichmentData } from "@/lib/services/knowledge-base";
-import { withTimeout } from "@/lib/utils/timeout";
+import { WebExtractionService } from "@/lib/services/web-extraction-service";
+import { llmTimeout, withTimeout } from "@/lib/utils/timeout";
 
 const STAGEHAND_INIT_TIMEOUT_MS = 60_000;
+const PROBE_TIMEOUT_MS = 10_000;
+const PAGE_FETCH_TIMEOUT_MS = 15_000;
+const ATS_API_TIMEOUT_MS = 15_000;
+
+/** Below this many chars of extracted text, assume the page is JS-rendered. */
+const THIN_CONTENT_CHARS = 200;
+
+const BROWSER_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.9",
+};
+
+const COMMON_CAREERS_PATHS = [
+  "/careers",
+  "/jobs",
+  "/hiring",
+  "/work-with-us",
+  "/join-us",
+  "/about/careers",
+  "/company/careers",
+];
 
 /**
  * Ceiling for the careers-page scrape when it runs inside an enrichment's
@@ -25,17 +62,472 @@ export interface HiringScrapeResult {
   totalJobs: number;
 }
 
+type Job = HiringScrapeResult["jobs"][number];
+
 /**
- * Scrape a company's careers page using Stagehand (Browserbase + GPT-4o).
- * Finds the careers page automatically, extracts structured job listings,
- * and saves the hiring data to the organization's enrichment_data.
+ * Scrape a company's careers page, cheapest method first:
  *
- * Used by both the `scrapeJobListings` agent tool and the tracking run route.
+ * 1. Find the careers URL with plain fetch: probe common paths, then scan
+ *    homepage links. No browser, no LLM.
+ * 2. ATS shortcut: if the careers page (or homepage) links to a hosted
+ *    board (Greenhouse, Lever, Ashby, Workable), hit the board's public
+ *    JSON API for structured listings. Zero LLM tokens.
+ * 3. Fetched-HTML extraction: WebExtractionService on the careers URL plus
+ *    one Haiku pass to pull job titles out of the text.
+ * 4. Full Stagehand browser session (Browserbase) only as the last resort,
+ *    when no careers URL was found or the fetched content is too thin.
+ *
+ * Saves the hiring data to the organization's enrichment_data. Used by both
+ * the `scrapeJobListings` agent tool and the tracking run route.
  */
 export async function scrapeHiringData(
   organizationId: string,
   domain: string,
   maxJobs: number = 20,
+): Promise<HiringScrapeResult> {
+  const cleanDomain = domain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+
+  // Tier 1: locate the careers page without a browser.
+  const { careersUrl, careersHtml, homepageHtml } =
+    await findCareersPage(cleanDomain);
+
+  // Tier 2: hosted ATS board JSON API, zero LLM.
+  const board =
+    detectAtsBoard(careersUrl ?? "") ??
+    detectAtsBoard(careersHtml ?? "") ??
+    detectAtsBoard(homepageHtml ?? "");
+  if (board) {
+    const atsJobs = await fetchAtsJobs(board);
+    if (atsJobs !== null) {
+      const url = careersUrl ?? board.boardUrl;
+      const trimmed = atsJobs.slice(0, maxJobs);
+      await saveHiring(organizationId, url, trimmed);
+      return { careersUrl: url, jobs: trimmed, totalJobs: atsJobs.length };
+    }
+  }
+
+  // Tier 3: fetch the careers page and run one Haiku extraction pass.
+  if (careersUrl) {
+    const extraction = await new WebExtractionService()
+      .extract(careersUrl, { includeMetadata: false })
+      .catch(() => null);
+    const content = extraction?.success ? extraction.data.content : "";
+    if (content.length >= THIN_CONTENT_CHARS) {
+      const jobs = await extractJobsFromText(careersUrl, content, maxJobs);
+      if (jobs !== null) {
+        const trimmed = jobs.slice(0, maxJobs);
+        await saveHiring(organizationId, careersUrl, trimmed);
+        return { careersUrl, jobs: trimmed, totalJobs: jobs.length };
+      }
+    }
+  }
+
+  // Tier 4: full browser session, the old path, now the exception.
+  return scrapeHiringDataWithBrowser(organizationId, cleanDomain, maxJobs);
+}
+
+/**
+ * Fail-open variant for use inside enrichment: a scrape failure returns
+ * null (raw enrichment proceeds without hiring data) instead of failing
+ * the whole company. The raw scrapeHiringData stays throwing for the
+ * agent tools, which surface errors to the model.
+ */
+export async function tryScrapeHiringData(
+  organizationId: string,
+  domain: string,
+): Promise<HiringScrapeResult | null> {
+  try {
+    return await scrapeHiringData(organizationId, domain);
+  } catch (err) {
+    console.error(`[hiring-scraper] scrape failed for ${domain}:`, err);
+    return null;
+  }
+}
+
+async function saveHiring(
+  organizationId: string,
+  careersUrl: string | null,
+  jobs: Job[],
+): Promise<void> {
+  await mergeEnrichmentData("organizations", organizationId, {
+    hiring: { careersUrl, jobs, scrapedAt: new Date().toISOString() },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1: careers URL discovery via plain fetch
+// ---------------------------------------------------------------------------
+
+async function findCareersPage(cleanDomain: string): Promise<{
+  careersUrl: string | null;
+  careersHtml: string | null;
+  homepageHtml: string | null;
+}> {
+  // Probe the common paths and accept the first 2xx.
+  for (const path of COMMON_CAREERS_PATHS) {
+    const probeUrl = `https://${cleanDomain}${path}`;
+    try {
+      const res = await fetchWithTimeout(
+        probeUrl,
+        { headers: BROWSER_HEADERS },
+        PROBE_TIMEOUT_MS,
+      );
+      if (res.ok) {
+        return {
+          careersUrl: res.url || probeUrl,
+          careersHtml: await res.text().catch(() => null),
+          homepageHtml: null,
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  // No path hit: fetch the homepage and look for a careers link.
+  let homepageHtml: string | null = null;
+  try {
+    const res = await fetchWithTimeout(
+      `https://${cleanDomain}`,
+      { headers: BROWSER_HEADERS },
+      PAGE_FETCH_TIMEOUT_MS,
+    );
+    if (res.ok) homepageHtml = await res.text();
+  } catch {
+    homepageHtml = null;
+  }
+
+  if (homepageHtml) {
+    const link = findCareersLink(homepageHtml, `https://${cleanDomain}`);
+    if (link) {
+      try {
+        const res = await fetchWithTimeout(
+          link,
+          { headers: BROWSER_HEADERS },
+          PAGE_FETCH_TIMEOUT_MS,
+        );
+        if (res.ok) {
+          return {
+            careersUrl: res.url || link,
+            careersHtml: await res.text().catch(() => null),
+            homepageHtml,
+          };
+        }
+      } catch {
+        // fall through with the link itself; ATS detection may still match it
+      }
+      return { careersUrl: link, careersHtml: null, homepageHtml };
+    }
+  }
+
+  return { careersUrl: null, careersHtml: null, homepageHtml };
+}
+
+const CAREERS_HREF_PATTERN =
+  /(^|\/)(careers?|jobs|hiring|join-?us|work-?with-?us|open-?(positions|roles))(\/|$|\?|#)/i;
+const CAREERS_TEXT_PATTERN =
+  /^(careers?|jobs|we'?re hiring|hiring|join (us|the team)|work with us|open (positions|roles))$/i;
+
+function findCareersLink(html: string, baseUrl: string): string | null {
+  const $ = cheerio.load(html);
+  let found: string | null = null;
+  $("a[href]").each((_, el) => {
+    if (found) return;
+    const href = $(el).attr("href") ?? "";
+    const text = $(el).text().trim();
+    if (!CAREERS_HREF_PATTERN.test(href) && !CAREERS_TEXT_PATTERN.test(text)) {
+      return;
+    }
+    try {
+      const resolved = new URL(href, baseUrl);
+      if (resolved.protocol === "http:" || resolved.protocol === "https:") {
+        found = resolved.toString();
+      }
+    } catch {
+      // ignore unresolvable hrefs
+    }
+  });
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: hosted ATS board JSON APIs (no LLM)
+// ---------------------------------------------------------------------------
+
+type AtsProvider = "greenhouse" | "lever" | "ashby" | "workable";
+
+interface AtsBoard {
+  provider: AtsProvider;
+  slug: string;
+  boardUrl: string;
+}
+
+/**
+ * Detect a hosted-board link anywhere in the given text (a URL or raw HTML)
+ * and pull out the account slug. Regex over the raw string on purpose: it
+ * catches board URLs inside embed scripts and JSON blobs, not just anchors.
+ * EU-hosted Greenhouse/Lever boards use different API hosts that are not
+ * verified here, so they intentionally do not match and fall to tier 3.
+ */
+function detectAtsBoard(text: string): AtsBoard | null {
+  if (!text) return null;
+
+  const greenhouseEmbed = text.match(
+    /boards\.greenhouse\.io\/embed\/job_board\?for=([A-Za-z0-9_-]+)/i,
+  );
+  if (greenhouseEmbed) {
+    return {
+      provider: "greenhouse",
+      slug: greenhouseEmbed[1],
+      boardUrl: `https://boards.greenhouse.io/${greenhouseEmbed[1]}`,
+    };
+  }
+  const greenhouse = text.match(
+    /(?:job-boards|boards)\.greenhouse\.io\/([A-Za-z0-9_-]+)/i,
+  );
+  if (greenhouse && greenhouse[1].toLowerCase() !== "embed") {
+    return {
+      provider: "greenhouse",
+      slug: greenhouse[1],
+      boardUrl: `https://boards.greenhouse.io/${greenhouse[1]}`,
+    };
+  }
+
+  const lever = text.match(/jobs\.lever\.co\/([A-Za-z0-9_-]+)/i);
+  if (lever) {
+    return {
+      provider: "lever",
+      slug: lever[1],
+      boardUrl: `https://jobs.lever.co/${lever[1]}`,
+    };
+  }
+
+  const ashby = text.match(/jobs\.ashbyhq\.com\/([A-Za-z0-9_.-]+)/i);
+  if (ashby) {
+    return {
+      provider: "ashby",
+      slug: ashby[1],
+      boardUrl: `https://jobs.ashbyhq.com/${ashby[1]}`,
+    };
+  }
+
+  const workable = text.match(/apply\.workable\.com\/([A-Za-z0-9_-]+)/i);
+  if (workable && !["api", "j"].includes(workable[1].toLowerCase())) {
+    return {
+      provider: "workable",
+      slug: workable[1],
+      boardUrl: `https://apply.workable.com/${workable[1]}/`,
+    };
+  }
+  const workableSubdomain = text.match(
+    /https?:\/\/([A-Za-z0-9-]+)\.workable\.com/i,
+  );
+  if (
+    workableSubdomain &&
+    !["apply", "www", "help", "resources"].includes(
+      workableSubdomain[1].toLowerCase(),
+    )
+  ) {
+    return {
+      provider: "workable",
+      slug: workableSubdomain[1],
+      boardUrl: `https://apply.workable.com/${workableSubdomain[1]}/`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Fetch structured listings from the board's public JSON API. All four URL
+ * patterns verified against live boards on 2026-08-01 (Greenhouse: stripe,
+ * Lever: palantir, Ashby: openai, Workable: blueground). Returns null on
+ * any failure so the caller falls through to the next tier.
+ */
+async function fetchAtsJobs(board: AtsBoard): Promise<Job[] | null> {
+  try {
+    switch (board.provider) {
+      case "greenhouse": {
+        const data = await fetchJson<{
+          jobs?: Array<{
+            title?: string;
+            absolute_url?: string;
+            location?: { name?: string };
+            departments?: Array<{ name?: string }>;
+          }>;
+        }>(
+          `https://boards-api.greenhouse.io/v1/boards/${board.slug}/jobs?content=true`,
+        );
+        return (data.jobs ?? [])
+          .filter((j) => j.title)
+          .map((j) =>
+            job(
+              j.title!,
+              j.departments?.[0]?.name,
+              j.location?.name,
+              j.absolute_url,
+            ),
+          );
+      }
+      case "lever": {
+        const data = await fetchJson<
+          Array<{
+            text?: string;
+            categories?: { team?: string; location?: string };
+            hostedUrl?: string;
+          }>
+        >(`https://api.lever.co/v0/postings/${board.slug}?mode=json`);
+        if (!Array.isArray(data)) return null;
+        return data
+          .filter((j) => j.text)
+          .map((j) =>
+            job(
+              j.text!,
+              j.categories?.team,
+              j.categories?.location,
+              j.hostedUrl,
+            ),
+          );
+      }
+      case "ashby": {
+        const data = await fetchJson<{
+          jobs?: Array<{
+            title?: string;
+            department?: string;
+            location?: string;
+            jobUrl?: string;
+            isListed?: boolean;
+          }>;
+        }>(`https://api.ashbyhq.com/posting-api/job-board/${board.slug}`);
+        return (data.jobs ?? [])
+          .filter((j) => j.title && j.isListed !== false)
+          .map((j) => job(j.title!, j.department, j.location, j.jobUrl));
+      }
+      case "workable": {
+        const data = await fetchJson<{
+          jobs?: Array<{
+            title?: string;
+            department?: string;
+            city?: string;
+            country?: string;
+            url?: string;
+          }>;
+        }>(`https://apply.workable.com/api/v1/widget/accounts/${board.slug}`);
+        return (data.jobs ?? [])
+          .filter((j) => j.title)
+          .map((j) =>
+            job(
+              j.title!,
+              j.department,
+              [j.city, j.country].filter(Boolean).join(", ") || undefined,
+              j.url,
+            ),
+          );
+      }
+    }
+  } catch (err) {
+    console.error(
+      `[hiring-scraper] ${board.provider} API failed for slug "${board.slug}":`,
+      err,
+    );
+    return null;
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetchWithTimeout(url, {}, ATS_API_TIMEOUT_MS);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+function job(
+  title: string,
+  department?: string,
+  location?: string,
+  url?: string,
+): Job {
+  const j: Job = { title };
+  if (department) j.department = department;
+  if (location) j.location = location;
+  if (url) j.url = url;
+  return j;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3: one Haiku pass over fetched careers-page text
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull structured job listings out of careers-page text with one cheap LLM
+ * call. Returns null on failure so the caller falls through to the browser
+ * tier instead of silently storing an empty scrape.
+ */
+async function extractJobsFromText(
+  careersUrl: string,
+  content: string,
+  maxJobs: number,
+): Promise<Job[] | null> {
+  try {
+    const { object, usage } = await generateObject({
+      abortSignal: llmTimeout(),
+      model: anthropic(MODELS.LIGHT),
+      schema: z.object({
+        jobs: z.array(
+          z.object({
+            title: z.string().describe("Job title"),
+            department: z
+              .string()
+              .optional()
+              .describe("Department or category"),
+            location: z.string().optional().describe("Job location"),
+          }),
+        ),
+      }),
+      prompt: `You extract open job listings from the text of a company careers page.
+
+${UNTRUSTED_NOTICE}
+
+Careers page URL: ${stringify(careersUrl)}
+
+List every open role stated on the page, up to ${maxJobs}. Only include roles the page presents as currently open. Do not invent roles, departments, or locations that the text does not state. If the page lists no open roles, return an empty list.
+
+Page text:
+${wrapUntrusted(content.slice(0, 12_000))}`,
+    });
+
+    trackUsage({
+      service: "claude",
+      operation: "hiring-scraper-extract",
+      tokens_input: usage.inputTokens ?? 0,
+      tokens_output: usage.outputTokens ?? 0,
+      estimated_cost_usd: estimateClaudeCostFromUsage("haiku", usage),
+      metadata: {
+        model: "claude-haiku-4-5",
+        careersUrl,
+        jobCount: object.jobs.length,
+      },
+    });
+
+    return object.jobs.map((j) => job(j.title, j.department, j.location));
+  } catch (err) {
+    console.error("[hiring-scraper] Haiku extraction failed:", err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier 4: full Stagehand browser session (the previous implementation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Last-resort scrape using Stagehand (Browserbase + LLM browsing). This is
+ * the previous implementation of scrapeHiringData, kept verbatim; it only
+ * runs when the fetch-based tiers found nothing usable.
+ */
+async function scrapeHiringDataWithBrowser(
+  organizationId: string,
+  cleanDomain: string,
+  maxJobs: number,
 ): Promise<HiringScrapeResult> {
   const apiKey = process.env.BROWSERBASE_API_KEY;
   const projectId = process.env.BROWSERBASE_PROJECT_ID;
@@ -70,7 +562,6 @@ export async function scrapeHiringData(
     );
 
     const page = stagehand.context.pages()[0];
-    const cleanDomain = domain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
 
     // Step 1: Navigate to the company's website
     await page.goto(`https://${cleanDomain}`, {
@@ -93,17 +584,7 @@ export async function scrapeHiringData(
       await page.waitForTimeout(3000);
       careersUrl = page.url();
     } else {
-      const commonPaths = [
-        "/careers",
-        "/jobs",
-        "/hiring",
-        "/work-with-us",
-        "/join-us",
-        "/about/careers",
-        "/company/careers",
-      ];
-
-      for (const path of commonPaths) {
+      for (const path of COMMON_CAREERS_PATHS) {
         try {
           const response = await page.goto(`https://${cleanDomain}${path}`, {
             waitUntil: "domcontentloaded",
@@ -162,23 +643,5 @@ export async function scrapeHiringData(
     } catch {
       // ignore close errors
     }
-  }
-}
-
-/**
- * Fail-open variant for use inside enrichment: a scrape failure returns
- * null (raw enrichment proceeds without hiring data) instead of failing
- * the whole company. The raw scrapeHiringData stays throwing for the
- * agent tools, which surface errors to the model.
- */
-export async function tryScrapeHiringData(
-  organizationId: string,
-  domain: string,
-): Promise<HiringScrapeResult | null> {
-  try {
-    return await scrapeHiringData(organizationId, domain);
-  } catch (err) {
-    console.error(`[hiring-scraper] scrape failed for ${domain}:`, err);
-    return null;
   }
 }

--- a/src/lib/services/hiring-scraper.ts
+++ b/src/lib/services/hiring-scraper.ts
@@ -155,3 +155,21 @@ export async function scrapeHiringData(
     }
   }
 }
+
+/**
+ * Fail-open variant for use inside enrichment: a scrape failure returns
+ * null (raw enrichment proceeds without hiring data) instead of failing
+ * the whole company. The raw scrapeHiringData stays throwing for the
+ * agent tools, which surface errors to the model.
+ */
+export async function tryScrapeHiringData(
+  organizationId: string,
+  domain: string,
+): Promise<HiringScrapeResult | null> {
+  try {
+    return await scrapeHiringData(organizationId, domain);
+  } catch (err) {
+    console.error(`[hiring-scraper] scrape failed for ${domain}:`, err);
+    return null;
+  }
+}

--- a/src/lib/services/hiring-scraper.ts
+++ b/src/lib/services/hiring-scraper.ts
@@ -5,6 +5,15 @@ import { withTimeout } from "@/lib/utils/timeout";
 
 const STAGEHAND_INIT_TIMEOUT_MS = 60_000;
 
+/**
+ * Ceiling for the careers-page scrape when it runs inside an enrichment's
+ * parallel pull batch alongside website extraction (~120s worst case), so
+ * the whole parallel phase stays bounded. withTimeout does not cancel the
+ * underlying scrape; a slow scrape may still finish and merge hiring data
+ * into the DB later, it just misses that enrichment's claims.
+ */
+export const HIRING_SCRAPE_TIMEOUT_MS = 90_000;
+
 export interface HiringScrapeResult {
   careersUrl: string | null;
   jobs: Array<{

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -84,19 +84,19 @@ After initial research and qualification, suggest tracking for companies the use
 When the user kicks off research on a batch of companies, run the full pipeline automatically for each qualified company. Don't stop between phases to ask permission -- keep going until the batch is fully researched.
 
 **For each company in the batch:**
-1. **Enrich the company** with \`enrichCompany\` (always pass campaignId for ICP context)
-2. **Scrape hiring data** with \`scrapeJobListingsBatch\` for multiple companies at once -- it runs them in parallel. Use the single \`scrapeJobListings\` only for one company.
-3. **Evaluate ICP fit** from the enrichment data + hiring signals -- score 1-10, qualify (>= 6) or disqualify (< 6)
-4. **Score the company** with \`scoreCompany\` to persist the score and reason
-5. **If qualified, discover contacts** -- use \`fetchSitemap\` to find About/Team pages and scrape them with \`extractWebContent\`, then use \`findContacts\` for LinkedIn-based discovery
-6. **Enrich each contact** with \`enrichContact\` to pull LinkedIn/Twitter/web data
-7. **Score each contact** with \`scoreContact\` to persist their priority and reason
+1. **Enrich the company** with \`enrichCompany\` (always pass campaignId for ICP context). This also scrapes the live careers page for hiring data automatically.
+2. **Evaluate ICP fit** from the enrichment data + hiring signals -- score 1-10, qualify (>= 6) or disqualify (< 6)
+3. **Score the company** with \`scoreCompany\` to persist the score and reason
+4. **If qualified, discover contacts** -- use \`fetchSitemap\` to find About/Team pages and scrape them with \`extractWebContent\`, then use \`findContacts\` for LinkedIn-based discovery
+5. **Enrich each contact** with \`enrichContact\` to pull LinkedIn/Twitter/web data
+6. **Score each contact** with \`scoreContact\` to persist their priority and reason
 
 After the batch is complete, present a single summary table showing companies, their scores, the contacts found, and each contact's priority score. This gives the user the full picture in one view instead of drip-feeding partial results.
 
 ### Company Enrichment Details
 - \`enrichCompany\` fetches the company website and runs 3 targeted Exa searches (product/features, funding/news, team/size)
-- **Hiring research**: After enriching a company, call \`scrapeJobListings\` with the company's domain. This uses Stagehand (AI browser automation via Browserbase) to navigate the company's website, find their careers/jobs page automatically, and extract structured job listings. Hiring data is a key signal -- companies actively hiring for roles related to the user's offering are prime targets.
+- **Hiring facts come only from the live careers page.** \`enrichCompany\` scrapes it automatically (Browserbase) and stores the result in \`enrichment_data.hiring\` plus verified \`hiring_role\` claims. An Exa result or news article saying a company "is hiring X" is a lead, never a fact: if the careers scrape contradicts it, the scrape wins. If there is no scrape (no domain, scrape failed), say hiring is unknown rather than guessing. Use \`scrapeJobListings\` to refresh a stale scrape.
+- **Never assert a company fact you did not read.** Investors, accelerator membership (YC etc.), funding stage, headcount, customers, and similar facts may only be stated when they appear in enrichment data, claims, or something the user said. If you are inferring or pattern-matching ("startups like this are usually..."), say it is a guess in the same sentence. When enrichment contradicts something you were about to say, the enrichment wins.
 - Review the raw enrichment data and evaluate ICP fit:
   - Score relevance 1-10 based on industry match, company size, pain point alignment, and overall ICP fit
   - Factor in hiring signals: are they hiring for roles that suggest they need the user's product/service?
@@ -209,6 +209,8 @@ When scoring companies and contacts, evaluate these dimensions using your judgme
 - **Offering Alignment** -- How well the user's offering solves this company's likely problems
 - **Growth Trajectory** -- Company momentum, market activity, stage
 
+**Score from reconciled claims, not raw search text.** \`getCompanyDetail\` returns \`enrichment_data.claims\`, each with a status. Build the score and reason only from \`verified\` and \`unverified\` claims, and state the claim's date in the reason ("$30M Series B, Feb 2026"). Never cite a \`contradicted\`, \`superseded\`, or \`stale\` claim as a timing signal; if the only signals available are stale, say so and score accordingly.
+
 8-10: Strong ICP match AND active timing signals. Reach out now.
 5-7: Good fit but no urgent timing, or moderate fit with signals.
 1-4: Weak fit or no relevant signals.
@@ -247,6 +249,7 @@ Deleting a company or contact from a campaign only unlinks it from that campaign
 - For companies: use a table with columns like Company, Size, Key Info, Priority
 - Use structured summaries for enriched contacts (role, key points, signals)
 - Be concise — lead with insights, not process narration
+- **Explain in domain language, never implementation language.** Always be willing to explain how you reached a conclusion, but describe evidence and actions, not machinery: say "I asked the company's mail server whether that mailbox exists" rather than naming tools, parameters, flags, or status values (findEmail, revalidate, unchecked, deliverable). Never mention internal step lists, credits, or which steps are paid unless the user asks about cost directly. Keep process narration to one short line; prefer doing the work over describing that you are about to do it.
 - Use markdown for readability
 
 ## Ad-hoc Research Mode (No Campaign)

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -31,6 +31,15 @@ import { withTimeout } from "@/lib/utils/timeout";
 /** Ceiling for one company's full enrichment chain. */
 const PER_COMPANY_TIMEOUT_MS = 150_000;
 
+/**
+ * Ceiling for the careers-page scrape inside enrichment. Runs in parallel
+ * with website extraction (~120s worst case), so this keeps the whole
+ * parallel phase inside PER_COMPANY_TIMEOUT_MS. withTimeout does not cancel
+ * the underlying scrape; a slow scrape may still finish and merge hiring
+ * data into the DB later, it just misses this enrichment's claims.
+ */
+const HIRING_SCRAPE_TIMEOUT_MS = 90_000;
+
 /** Rough worst case for one contact-enrichment chunk (Exa + socials). */
 const PER_CONTACT_CHUNK_ESTIMATE_MS = 120_000;
 
@@ -1205,8 +1214,17 @@ async function enrichCompanyById(
       numResults: 5,
       includeText: true,
     }),
+    // Bounded: Stagehand's observe/act/extract steps have no timeouts of
+    // their own, and an unbounded scrape would pierce PER_COMPANY_TIMEOUT_MS
+    // and fail the whole company. On timeout allSettled records a rejection,
+    // careers stays null, and hiring is reported unknown, which is the
+    // designed fail-open behavior.
     org.domain
-      ? tryScrapeHiringData(organizationId, org.domain as string)
+      ? withTimeout(
+          tryScrapeHiringData(organizationId, org.domain as string),
+          HIRING_SCRAPE_TIMEOUT_MS,
+          `Careers scrape ${org.domain}`,
+        )
       : Promise.resolve(null),
   ]);
 

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -22,6 +22,10 @@ import { filterContactsByCompany } from "@/lib/services/contact-filter";
 import { recordAffiliation } from "@/lib/services/affiliation";
 import { runDataQualityAudit } from "@/lib/services/data-quality";
 import { summarizePerson } from "@/lib/services/enrichment-summarizer";
+import { extractClaims } from "@/lib/services/claim-extractor";
+import { reconcileClaims } from "@/lib/services/claim-reconciler";
+import { tryScrapeHiringData } from "@/lib/services/hiring-scraper";
+import type { CompanyClaim } from "@/lib/types/claims";
 import { withTimeout } from "@/lib/utils/timeout";
 
 /** Ceiling for one company's full enrichment chain. */
@@ -1094,6 +1098,8 @@ export function summarizeCompanyEnrichment(
       if (cat) s[`${cat}Results`] = n;
     }
   }
+  s.claims = (data.claims as unknown[] | undefined)?.length ?? 0;
+  s.hiringScraped = Boolean(data.hiring);
   return s;
 }
 
@@ -1169,31 +1175,40 @@ async function enrichCompanyById(
   const companyDomain =
     org.domain || (companyUrl ? new URL(companyUrl).hostname : null);
 
-  const [websiteResult, productResult, fundingResult, teamResult] =
-    await Promise.allSettled([
-      companyUrl
-        ? extractor.extract(companyUrl, { includeLinks: false })
-        : Promise.resolve(null),
-      exa.search(
-        companyDomain
-          ? `${org.name} products services`
-          : `${specificName} product services offering`,
-        {
-          numResults: 5,
-          includeText: true,
-          ...(companyDomain ? { includeDomains: [companyDomain] } : {}),
-        },
-      ),
-      exa.search(`${specificName} funding news announcement`, {
-        numResults: 5,
-        includeText: true,
-        category: "news",
-      }),
-      exa.search(`${specificName} team employees company size`, {
-        numResults: 5,
-        includeText: true,
-      }),
-    ]);
+  const productQuery = companyDomain
+    ? `${org.name} products services`
+    : `${specificName} product services offering`;
+  const fundingQuery = `${specificName} funding news announcement`;
+  const teamQuery = `${specificName} team employees company size`;
+
+  const [
+    websiteResult,
+    productResult,
+    fundingResult,
+    teamResult,
+    hiringResult,
+  ] = await Promise.allSettled([
+    companyUrl
+      ? extractor.extract(companyUrl, { includeLinks: false })
+      : Promise.resolve(null),
+    exa.search(productQuery, {
+      numResults: 5,
+      includeText: true,
+      ...(companyDomain ? { includeDomains: [companyDomain] } : {}),
+    }),
+    exa.search(fundingQuery, {
+      numResults: 5,
+      includeText: true,
+      category: "news",
+    }),
+    exa.search(teamQuery, {
+      numResults: 5,
+      includeText: true,
+    }),
+    org.domain
+      ? tryScrapeHiringData(organizationId, org.domain as string)
+      : Promise.resolve(null),
+  ]);
 
   const enrichmentData: Record<string, unknown> = {
     enrichedAt: new Date().toISOString(),
@@ -1226,12 +1241,12 @@ async function enrichCompanyById(
   }> = [];
 
   const searchEntries = [
-    ["product", productResult],
-    ["funding", fundingResult],
-    ["team", teamResult],
+    ["product", productResult, productQuery],
+    ["funding", fundingResult, fundingQuery],
+    ["team", teamResult, teamQuery],
   ] as const;
 
-  for (const [label, result] of searchEntries) {
+  for (const [label, result, query] of searchEntries) {
     if (result.status === "fulfilled") {
       const mapped = result.value.results.map(
         (r: {
@@ -1253,13 +1268,53 @@ async function enrichCompanyById(
       );
       searches.push({
         category: label,
-        query: `${org.name} ${label}`,
+        query,
         results: filtered.slice(0, 3),
       });
     } else {
       errors.push(`Search (${label}): ${result.reason?.message || "Failed"}`);
     }
   }
+
+  // Typed claims: extract from raw pulls, then reconcile against the careers
+  // scrape (ground truth for hiring) and recency rules. Fail-open at every
+  // stage; a claims failure never blocks storing the raw enrichment.
+  const careers =
+    hiringResult.status === "fulfilled" && hiringResult.value
+      ? {
+          careersUrl: hiringResult.value.careersUrl,
+          jobs: hiringResult.value.jobs,
+          scrapedAt: new Date().toISOString(),
+        }
+      : null;
+
+  const extracted = await extractClaims({
+    companyName: org.name as string,
+    companyDomain,
+    websiteContent:
+      websiteResult.status === "fulfilled" && websiteResult.value?.success
+        ? websiteResult.value.data.content
+        : null,
+    searches,
+  });
+
+  // Scraped jobs become verified hiring claims directly; no LLM needed.
+  const hiringClaims: CompanyClaim[] = careers?.careersUrl
+    ? careers.jobs.map((j) => ({
+        type: "hiring_role" as const,
+        statement: `Hiring: ${j.title}${j.location ? ` (${j.location})` : ""}`,
+        sourceUrl: careers.careersUrl as string,
+        publishedDate: careers.scrapedAt,
+        confidence: 1,
+        extractedAt: careers.scrapedAt,
+        status: "verified" as const,
+      }))
+    : [];
+
+  enrichmentData.claims = [
+    ...reconcileClaims(extracted, { now: new Date(), careers }),
+    ...hiringClaims,
+  ];
 
   enrichmentData.searches = searches;
   if (errors.length > 0) enrichmentData.errors = errors;
@@ -1270,7 +1325,11 @@ async function enrichCompanyById(
     companyId: organizationId,
     companyName: org.name as string,
     domain: org.domain as string | null,
-    summary: summarizeCompanyEnrichment(enrichmentData),
+    // The scraper persists enrichment_data.hiring itself, so overlay the
+    // scrape result here so the thin summary reflects what this run got.
+    summary: summarizeCompanyEnrichment(
+      careers ? { ...enrichmentData, hiring: careers } : enrichmentData,
+    ),
     icp: icp || undefined,
     errors: errors.length > 0 ? errors : undefined,
   };

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -24,21 +24,15 @@ import { runDataQualityAudit } from "@/lib/services/data-quality";
 import { summarizePerson } from "@/lib/services/enrichment-summarizer";
 import { extractClaims } from "@/lib/services/claim-extractor";
 import { reconcileClaims } from "@/lib/services/claim-reconciler";
-import { tryScrapeHiringData } from "@/lib/services/hiring-scraper";
+import {
+  HIRING_SCRAPE_TIMEOUT_MS,
+  tryScrapeHiringData,
+} from "@/lib/services/hiring-scraper";
 import type { CompanyClaim } from "@/lib/types/claims";
 import { withTimeout } from "@/lib/utils/timeout";
 
 /** Ceiling for one company's full enrichment chain. */
 const PER_COMPANY_TIMEOUT_MS = 150_000;
-
-/**
- * Ceiling for the careers-page scrape inside enrichment. Runs in parallel
- * with website extraction (~120s worst case), so this keeps the whole
- * parallel phase inside PER_COMPANY_TIMEOUT_MS. withTimeout does not cancel
- * the underlying scrape; a slow scrape may still finish and merge hiring
- * data into the DB later, it just misses this enrichment's claims.
- */
-const HIRING_SCRAPE_TIMEOUT_MS = 90_000;
 
 /** Rough worst case for one contact-enrichment chunk (Exa + socials). */
 const PER_CONTACT_CHUNK_ESTIMATE_MS = 120_000;

--- a/src/lib/types/campaign.ts
+++ b/src/lib/types/campaign.ts
@@ -1,3 +1,5 @@
+import type { CompanyClaim } from "@/lib/types/claims";
+
 export interface ICP {
   industry?: string;
   companySize?: string;
@@ -138,6 +140,7 @@ export interface CompanyEnrichmentData {
     isHiring: boolean;
     scrapedAt: string;
   };
+  claims?: CompanyClaim[];
   enrichedAt?: string;
   errors?: string[];
 }

--- a/src/lib/types/claims.ts
+++ b/src/lib/types/claims.ts
@@ -1,0 +1,36 @@
+export const CLAIM_TYPES = [
+  "funding_round",
+  "headcount",
+  "hiring_role",
+  "exec_change",
+  "product",
+  "location",
+] as const;
+
+export type ClaimType = (typeof CLAIM_TYPES)[number];
+
+export type ClaimStatus =
+  | "verified"
+  | "unverified"
+  | "stale"
+  | "contradicted"
+  | "superseded";
+
+export interface CompanyClaim {
+  type: ClaimType;
+  /** One factual sentence, e.g. "Raised a $30M Series B led by Madrona". */
+  statement: string;
+  sourceUrl: string;
+  /** ISO date of the source when known; null when the source is undated. */
+  publishedDate: string | null;
+  /** 0-1, extractor's confidence the statement is about this company. */
+  confidence: number;
+  extractedAt: string;
+  status: ClaimStatus;
+}
+
+export interface CareersScrape {
+  careersUrl: string | null;
+  jobs: Array<{ title: string; department?: string; location?: string }>;
+  scrapedAt: string;
+}


### PR DESCRIPTION
## Problem

Enrichment presented stale third-party text as fact. Canonical failure: Fyxer scored 8/10 with the pitch "actively hiring a Growth Director" while the live careers page showed one customer support opening; the same record simultaneously claimed Series A ($10M), a $30M Series B, and $500K raised in 2024, with no arbitration. Separately, the chat agent asserted facts it never read (called Browserbase "YC-backed"; the data said Notable Capital, CRV, Kleiner Perkins) and explained itself in implementation jargon (`revalidate: true`, status enums).

## What this does

**Typed claims with provenance** (mirroring the contact affiliation quartet):
- `claim-extractor.ts`: one Haiku pass turns website + Exa pulls into `enrichment_data.claims`: `{type, statement, sourceUrl, publishedDate, confidence, status}`. Source-index mapping means a claim cannot cite a URL the pull did not contain. Fail-open.
- `claim-reconciler.ts` (pure functions, unit-tested on the real Fyxer fixture): newest dated funding claim wins, older ones `superseded`; hiring claims contradicted by the careers scrape are `contradicted`; old claims become `stale` instead of being asserted.

**Careers page is ground truth for hiring:**
- Both enrichment paths (agent tool + UI Enrich button) scrape the careers page automatically, bounded by a 90s fail-open timeout so the 150s per-company ceiling and the chat turn budget still hold.
- Scraped jobs become directly `verified` hiring claims with no LLM involved.

**Cheap-first scraping** (was: full Stagehand browser session for every company):
1. Probe common careers paths with plain fetches, scan homepage anchors
2. ATS shortcut: Greenhouse / Lever / Ashby / Workable public JSON APIs, all four verified against live boards on 2026-08-01. Structured jobs, zero LLM, zero browser
3. `WebExtractionService` + one Haiku extraction pass
4. Full Stagehand session only as last resort (kept verbatim as a private fallback)

**System prompt:**
- Hiring facts only from the careers scrape; news saying "is hiring X" is a lead, never a fact; no scrape means "hiring unknown"
- Scores built only from surviving claims, citing dates
- Grounding: never assert a company fact you did not read; label inferences as guesses
- Voice: explain with evidence and actions in domain language, never tool names, flags, or status values

**UI:** claims section with status badges (existing theme tokens, matching provenance-badge conventions) on company detail; Exa `publishedDate` is finally rendered instead of discarded. Also fixes `searches[].query` storing a fabricated label instead of the executed query.

## Verification

- 466 tests passing (13 new: reconciler rules on the Fyxer fixture, extractor with mocked LLM, claims UI rendering, 10 for the cheap scraper tiers), eslint and typecheck clean
- Manual smoke pending: re-enrich a company (note the 7-day recency skip) and confirm claims render with correct statuses
- Cost: +1 Haiku call per enrichment; the browser session moves from every-company to rare fallback, so typical enrichment gets cheaper and much faster

Follow-up (deliberately out of scope): eval harness measuring enrichment accuracy on a hand-verified golden set, plus a contradiction/staleness audit over existing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)