### PR TITLE
feat(outreach): see what was sent and what came back

### DIFF
--- a/src/__tests__/email-feedback-loop.test.ts
+++ b/src/__tests__/email-feedback-loop.test.ts
@@ -314,6 +314,7 @@ describe("bounce feedback", () => {
     sent_at: new Date().toISOString(),
     person_id: "per_1",
     to_email: "dead@acme.com",
+    campaign_id: "camp_1",
     ...over,
   });
 

--- a/src/__tests__/email-feedback-loop.test.ts
+++ b/src/__tests__/email-feedback-loop.test.ts
@@ -298,6 +298,142 @@ describe("send_confirmed", () => {
   });
 });
 
+// ─── why a send did not happen ────────────────────────────────────────────
+
+/**
+ * The seven refusal sites in claimAndSendDraft each return a sentence written
+ * for a person to read, and until now every one of them was thrown away to a
+ * console.error. An approved draft that could not send just sat there with no
+ * explanation anywhere in the product.
+ *
+ * The classification is the part worth protecting. `deferred` (daily cap) is
+ * the most common non-send by far and is completely normal; letting it read as
+ * a failure would bury the two kinds that genuinely need attention.
+ */
+describe("send failure recording", () => {
+  // sendResponses() calls encryptSecret, which needs the key. The block above
+  // sets it in its own beforeEach, which does not reach here.
+  let key: string | undefined;
+  beforeEach(() => {
+    key = process.env.EMAIL_CREDENTIALS_KEY;
+    process.env.EMAIL_CREDENTIALS_KEY = Buffer.alloc(32, 7).toString("base64");
+    sendGmailMock
+      .mockReset()
+      .mockResolvedValue({ messageId: "<m1@sahnan.co>" });
+    recordVerifiedMock.mockClear();
+  });
+  afterEach(() => {
+    process.env.EMAIL_CREDENTIALS_KEY = key;
+  });
+
+  /** Like fakeSupabase, but keeps every update payload for assertions. */
+  function observingSupabase(responses: FakeResponse[]) {
+    const updates: Array<Record<string, unknown>> = [];
+    let i = 0;
+    const from = () => {
+      const builder: Record<string, unknown> = {};
+      for (const name of [
+        "select",
+        "eq",
+        "in",
+        "gte",
+        "insert",
+        "single",
+        "maybeSingle",
+        "order",
+        "limit",
+      ]) {
+        builder[name] = () => builder;
+      }
+      builder.update = (payload: Record<string, unknown>) => {
+        updates.push(payload);
+        return builder;
+      };
+      builder.then = (
+        resolve: (v: unknown) => unknown,
+        reject: (e: unknown) => unknown,
+      ) =>
+        Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+          resolve,
+          reject,
+        );
+      return builder;
+    };
+    return { client: { from } as never, updates };
+  }
+
+  const errorWrites = (updates: Array<Record<string, unknown>>) =>
+    updates.filter((u) => "last_error_kind" in u);
+
+  it("classifies the daily cap as deferred, not failed", async () => {
+    const responses = sendResponses("per_1");
+    responses[5] = { count: 999 }; // over the cap
+
+    const { client, updates } = observingSupabase(responses);
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result.ok).toBe(false);
+    const written = errorWrites(updates);
+    expect(written).toHaveLength(1);
+    // Not "failed". Hitting the cap is routine, and a failed list full of it
+    // is a list nobody reads.
+    expect(written[0].last_error_kind).toBe("deferred");
+    expect(written[0].last_error).toMatch(/daily send limit/i);
+    expect(sendGmailMock).not.toHaveBeenCalled();
+  });
+
+  it("classifies a stale address as blocked, with the reason kept verbatim", async () => {
+    const responses = sendResponses("per_1");
+    responses[3] = {
+      data: {
+        work_email: "corrected@example.com",
+        work_email_source: "user_entered",
+        work_email_verification: null,
+        affiliation_confidence: 0.9,
+        affiliation_source: "team_page",
+        organization_id: "org_1",
+      },
+    };
+
+    const { client, updates } = observingSupabase(responses);
+    await sendApprovedDraft(client, enrollment);
+
+    const written = errorWrites(updates);
+    expect(written).toHaveLength(1);
+    expect(written[0].last_error_kind).toBe("blocked");
+    // The stored sentence is the one the user reads, so it has to survive
+    // intact rather than being paraphrased at read time.
+    expect(written[0].last_error).toMatch(/regenerate the draft/i);
+  });
+
+  it("classifies an SMTP throw as failed", async () => {
+    sendGmailMock.mockRejectedValueOnce(new Error("535 auth failed"));
+
+    const { client, updates } = observingSupabase(sendResponses("per_1"));
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result.ok).toBe(false);
+    const written = errorWrites(updates);
+    expect(written).toHaveLength(1);
+    expect(written[0].last_error_kind).toBe("failed");
+    expect(written[0].last_error).toMatch(/535 auth failed/);
+  });
+
+  it("clears a previous error once the draft sends", async () => {
+    const { client, updates } = observingSupabase(sendResponses("per_1"));
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result.ok).toBe(true);
+    // A draft blocked on Monday that sends on Tuesday must not still show
+    // Monday's reason next to a delivered email.
+    const cleared = updates.find((u) => u.status === "sent");
+    expect(cleared).toBeDefined();
+    expect(cleared?.last_error).toBeNull();
+    expect(cleared?.last_error_kind).toBeNull();
+    expect(cleared?.last_error_at).toBeNull();
+  });
+});
+
 // ─── recordBounce from the tracking cron ──────────────────────────────────
 
 describe("bounce feedback", () => {

--- a/src/__tests__/email-test.test.ts
+++ b/src/__tests__/email-test.test.ts
@@ -64,6 +64,7 @@ describe("matchTestReply", () => {
   const MSG_ID = "<test-1@sahnan.co>";
   const base = {
     inReplyTo: null,
+    messageId: null,
     references: [],
     bodyText: "",
     subject: "",
@@ -77,6 +78,7 @@ describe("matchTestReply", () => {
         ...base,
         fromAddress: "jaysahnan31@gmail.com",
         inReplyTo: MSG_ID,
+        messageId: null,
         subject: "Re: Signal test",
         date: new Date("2026-07-30T14:32:00Z"),
         uid: null,

--- a/src/__tests__/gmail-imap.test.ts
+++ b/src/__tests__/gmail-imap.test.ts
@@ -30,6 +30,7 @@ vi.mock("imapflow", () => {
         envelope: {
           from: [{ address: "mailer-daemon@googlemail.com" }],
           inReplyTo: "",
+          messageId: null,
           subject: "Delivery Status Notification (Failure)",
           date: new Date("2026-07-30T14:30:00Z"),
         },
@@ -40,6 +41,7 @@ vi.mock("imapflow", () => {
         envelope: {
           from: [{ address: "prospect@example.com" }],
           inReplyTo: "<sent-1@sahnan.co>",
+          messageId: null,
           subject: "Re: Signal test",
           date: new Date("2026-07-30T14:32:00Z"),
         },

--- a/src/__tests__/gmail-service.test.ts
+++ b/src/__tests__/gmail-service.test.ts
@@ -17,6 +17,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "prospect@example.com",
           inReplyTo: "<sent-1@sahnan.co>",
+          messageId: null,
           references: [],
           bodyText: "",
           subject: "Re: Signal test",
@@ -35,6 +36,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "prospect@example.com",
           inReplyTo: null,
+          messageId: null,
           references: ["<other@x>", "<sent-2@sahnan.co>"],
           bodyText: "",
           subject: "Re: Signal test",
@@ -53,6 +55,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "mailer-daemon@googlemail.com",
           inReplyTo: "<sent-1@sahnan.co>",
+          messageId: null,
           references: [],
           bodyText: "Address not found",
           subject: "Delivery Status Notification (Failure)",
@@ -71,6 +74,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
           inReplyTo: null,
+          messageId: null,
           references: [],
           bodyText: "The response was: 550 ... Message-ID: <sent-2@sahnan.co>",
           subject: "Delivery Status Notification (Failure)",
@@ -89,6 +93,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "jay@sahnan.co",
           inReplyTo: "<sent-1@sahnan.co>",
+          messageId: null,
           references: [],
           bodyText: "",
           subject: "Re: Signal test",
@@ -104,6 +109,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "newsletter@stuff.com",
           inReplyTo: null,
+          messageId: null,
           references: [],
           bodyText: "hello",
           subject: "Weekly digest",
@@ -122,6 +128,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "ajay@sahnan.co",
           inReplyTo: "<sent-1@sahnan.co>",
+          messageId: null,
           references: [],
           bodyText: "",
           subject: "Re: Signal test",
@@ -140,6 +147,7 @@ describe("classifyInboundMessage", () => {
         {
           fromAddress: "JAY@SAHNAN.CO",
           inReplyTo: "<sent-1@sahnan.co>",
+          messageId: null,
           references: [],
           bodyText: "",
           subject: "Re: Signal test",

--- a/src/__tests__/outreach-activity-panel.test.tsx
+++ b/src/__tests__/outreach-activity-panel.test.tsx
@@ -1,0 +1,179 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ActivityItem } from "@/lib/outreach/activity";
+
+// The detail pane fetches on expand; this file is about the list.
+vi.mock("@/components/outreach/activity-detail", () => ({
+  ActivityDetail: ({ id }: { id: string }) => (
+    <div data-testid="detail">{id}</div>
+  ),
+}));
+
+import { OutreachActivityPanel } from "@/components/outreach/outreach-activity-panel";
+
+// vitest runs without `globals`, so Testing Library's automatic teardown never
+// registers and renders would stack up across tests.
+afterEach(cleanup);
+
+function item(over: Partial<ActivityItem> = {}): ActivityItem {
+  return {
+    id: "se_1",
+    source: "sent",
+    state: "replied",
+    person_name: "Dana Whitfield",
+    person_title: "VP Engineering",
+    company_name: "Fernpath",
+    to_email: "dana@fernpath.test",
+    subject: "Metering to invoice",
+    at: "2026-08-03T10:00:00Z",
+    sent_at: "2026-08-02T09:00:00Z",
+    next_send_at: null,
+    reply_count: 1,
+    reply_snippet: "How does it handle proration?",
+    reply_captured: true,
+    error: null,
+    gmail_url: "https://mail.google.com/mail/u/#search/x",
+    ...over,
+  };
+}
+
+function renderPanel(items: ActivityItem[], filter = "all") {
+  const onFilterChange = vi.fn();
+  render(
+    <OutreachActivityPanel
+      items={items}
+      filter={filter as "all"}
+      onFilterChange={onFilterChange}
+    />,
+  );
+  return { onFilterChange };
+}
+
+describe("<OutreachActivityPanel>", () => {
+  it("shows the reply without needing to expand or filter", () => {
+    // Replies being findable at a glance is the entire point of this surface.
+    renderPanel([item()]);
+
+    expect(screen.getByText("Dana Whitfield")).toBeInTheDocument();
+    expect(screen.getByText("Fernpath")).toBeInTheDocument();
+    expect(
+      screen.getByText("How does it handle proration?"),
+    ).toBeInTheDocument();
+  });
+
+  it("says so when a reply arrived but its words were not captured", () => {
+    // Distinct from an empty reply. Rendering nothing here would read as "they
+    // replied with silence", and this is the permanent state for anything that
+    // replied before capture existed.
+    renderPanel([item({ reply_snippet: null, reply_captured: false })]);
+
+    expect(
+      screen.getByText("Replied, content not captured"),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a blocked reason on the collapsed row", () => {
+    renderPanel([
+      item({
+        id: "draft:1",
+        source: "pending",
+        state: "blocked",
+        reply_snippet: null,
+        reply_count: 0,
+        error: {
+          kind: "blocked",
+          message: "Not sending to dana@fernpath.test: address is unverified.",
+          at: "2026-08-03T10:00:00Z",
+        },
+      }),
+    ]);
+
+    expect(screen.getByText(/address is unverified/)).toBeInTheDocument();
+  });
+
+  it("keeps a deferred draft quiet", () => {
+    // Hitting the daily cap resolves itself tomorrow. Shouting about it on the
+    // row would train the user to ignore the rows that do need them.
+    renderPanel([
+      item({
+        id: "draft:2",
+        source: "pending",
+        state: "deferred",
+        reply_snippet: null,
+        error: {
+          kind: "deferred",
+          message: "Daily send limit reached (5/day), draft left for tomorrow",
+          at: "2026-08-03T10:00:00Z",
+        },
+      }),
+    ]);
+
+    expect(screen.getByText("Deferred")).toBeInTheDocument();
+    expect(screen.queryByText(/Daily send limit/)).not.toBeInTheDocument();
+  });
+
+  it("narrows to the selected filter", () => {
+    const items = [
+      item({ id: "a", state: "replied" }),
+      item({ id: "b", state: "sent", reply_snippet: null, reply_count: 0 }),
+      item({
+        id: "draft:c",
+        source: "pending",
+        state: "blocked",
+        reply_snippet: null,
+        reply_count: 0,
+      }),
+    ];
+
+    renderPanel(items, "failed");
+
+    // "Needs attention" covers blocked as well as failed: both wait on a human.
+    // The replied and sent rows must not leak through.
+    expect(document.querySelectorAll("tbody tr[role=button]")).toHaveLength(1);
+    // Scoped to the table: "Replied" and "Sent" are also filter chip labels.
+    const table = within(document.querySelector("tbody") as HTMLElement);
+    expect(table.getByText("Blocked")).toBeInTheDocument();
+    expect(table.queryByText("Replied")).not.toBeInTheDocument();
+    expect(table.queryByText("Sent")).not.toBeInTheDocument();
+  });
+
+  it("expands a row to its detail, and collapses it again", () => {
+    renderPanel([item()]);
+    const row = document.querySelector("tbody tr[role=button]")!;
+
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByTestId("detail")).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(screen.getByTestId("detail")).toHaveTextContent("se_1");
+    expect(
+      document
+        .querySelector("tbody tr[role=button]")!
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+
+    fireEvent.click(document.querySelector("tbody tr[role=button]")!);
+    expect(screen.queryByTestId("detail")).not.toBeInTheDocument();
+  });
+
+  it("opens on Enter as well as click", () => {
+    // Rows are divs-as-buttons, so keyboard parity is not free.
+    renderPanel([item()]);
+    const row = document.querySelector("tbody tr[role=button]")!;
+
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(screen.getByTestId("detail")).toBeInTheDocument();
+  });
+
+  it("offers an empty state rather than a bare table", () => {
+    renderPanel([]);
+    expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/outreach-activity.test.ts
+++ b/src/__tests__/outreach-activity.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyPending,
+  classifySent,
+  gmailSearchUrl,
+  replySnippet,
+} from "@/lib/outreach/activity";
+import { htmlToDisplayText, htmlToPlain } from "@/lib/email/html-to-plain";
+
+describe("gmailSearchUrl", () => {
+  it("builds an rfc822msgid search for the sending mailbox", () => {
+    const url = gmailSearchUrl("<abc123@mail.gmail.com>", "jay@sahnan.co");
+    expect(url).toBe(
+      "https://mail.google.com/mail/u/?authuser=jay%40sahnan.co#search/rfc822msgid%3Aabc123%40mail.gmail.com",
+    );
+  });
+
+  it("strips the angle brackets Gmail handles inconsistently", () => {
+    expect(gmailSearchUrl("<a@b>", null)).toContain("rfc822msgid%3Aa%40b");
+    expect(gmailSearchUrl("<a@b>", null)).not.toContain("%3C");
+  });
+
+  it("encodes characters nodemailer can put in an id", () => {
+    // A raw + or # in a URL fragment would truncate or mis-route the search.
+    const url = gmailSearchUrl("<a+b#c@d>", null)!;
+    expect(url).toContain("%2B");
+    expect(url).toContain("%23");
+  });
+
+  it("returns null without a Message-ID rather than guessing", () => {
+    // A subject search on a cold email is a shotgun. Opening the wrong thread
+    // is worse than opening nothing.
+    expect(gmailSearchUrl(null, "jay@sahnan.co")).toBeNull();
+    expect(gmailSearchUrl("  ", "jay@sahnan.co")).toBeNull();
+  });
+
+  it("omits authuser when the sending address is unknown", () => {
+    expect(gmailSearchUrl("<a@b>", null)).toBe(
+      "https://mail.google.com/mail/u/#search/rfc822msgid%3Aa%40b",
+    );
+  });
+});
+
+describe("classifySent", () => {
+  it("maps the three statuses that are actually written", () => {
+    expect(classifySent("replied")).toBe("replied");
+    expect(classifySent("bounced")).toBe("bounced");
+    expect(classifySent("sent")).toBe("sent");
+  });
+
+  it("treats legacy values as plain sent", () => {
+    // 'opened' and 'delivered' are in the CHECK constraint but nothing has
+    // ever written them: Signal sends no tracking pixel.
+    expect(classifySent("opened")).toBe("sent");
+    expect(classifySent("delivered")).toBe("sent");
+  });
+});
+
+describe("classifyPending", () => {
+  const base = { status: "draft", last_error_kind: null, next_send_at: null };
+
+  it("keeps deferred separate from failed", () => {
+    // Hitting the daily cap is routine and by far the most common non-send.
+    // Showing it as a failure would bury the kinds that need attention.
+    expect(classifyPending({ ...base, last_error_kind: "deferred" })).toBe(
+      "deferred",
+    );
+    expect(classifyPending({ ...base, last_error_kind: "failed" })).toBe(
+      "failed",
+    );
+    expect(classifyPending({ ...base, last_error_kind: "blocked" })).toBe(
+      "blocked",
+    );
+  });
+
+  it("prefers the error over the waiting state", () => {
+    // "Why it did not send" beats "it is waiting" when both are true.
+    expect(
+      classifyPending({
+        status: "queued",
+        last_error_kind: "blocked",
+        next_send_at: "2026-08-04T09:00:00Z",
+      }),
+    ).toBe("blocked");
+  });
+
+  it("distinguishes scheduled from queued", () => {
+    expect(
+      classifyPending({ ...base, next_send_at: "2026-08-04T09:00:00Z" }),
+    ).toBe("scheduled");
+    expect(classifyPending({ ...base, status: "queued" })).toBe("queued");
+    expect(classifyPending(base)).toBe("queued");
+  });
+});
+
+describe("replySnippet", () => {
+  it("collapses whitespace onto one line", () => {
+    expect(replySnippet("Sounds good.\n\nNext week works.")).toBe(
+      "Sounds good. Next week works.",
+    );
+  });
+
+  it("distinguishes no body from an empty one", () => {
+    expect(replySnippet(null)).toBeNull();
+    expect(replySnippet("   ")).toBeNull();
+  });
+
+  it("truncates long replies", () => {
+    const snippet = replySnippet("x".repeat(500))!;
+    expect(snippet.endsWith("…")).toBe(true);
+    expect(snippet.length).toBeLessThan(200);
+  });
+});
+
+describe("html to text", () => {
+  const body =
+    '<p>Hi Dana,</p><p>Worth a look: <a href="https://arbor.dev/demo">book a time</a></p>';
+
+  it("keeps the URL on read-only surfaces", () => {
+    // The composer is allowed to emit anchors, so stripping tags blindly loses
+    // where the link pointed and the reader cannot tell what was sent.
+    expect(htmlToDisplayText(body)).toBe(
+      "Hi Dana,\n\nWorth a look: book a time (https://arbor.dev/demo)",
+    );
+  });
+
+  it("still drops the URL in the editor's lossy variant", () => {
+    // This one feeds a textarea that plainToHtml re-serialises on save, so
+    // preserving the URL inline would write it back as literal text and
+    // destroy the anchor.
+    expect(htmlToPlain(body)).toBe("Hi Dana,\n\nWorth a look: book a time");
+  });
+
+  it("does not double up a bare link", () => {
+    expect(
+      htmlToDisplayText('<p><a href="https://a.co">https://a.co</a></p>'),
+    ).toBe("https://a.co");
+  });
+
+  it("falls back to the URL when the anchor has no text", () => {
+    expect(htmlToDisplayText('<p><a href="https://a.co"></a></p>')).toBe(
+      "https://a.co",
+    );
+  });
+
+  it("decodes entities in both variants", () => {
+    expect(htmlToDisplayText("<p>Tom &amp; Jerry</p>")).toBe("Tom & Jerry");
+    expect(htmlToPlain("<p>Tom &amp; Jerry</p>")).toBe("Tom & Jerry");
+  });
+
+  it("turns paragraph and break structure into newlines", () => {
+    expect(htmlToDisplayText("<p>a<br>b</p><p>c</p>")).toBe("a\nb\n\nc");
+  });
+});

--- a/src/__tests__/outreach-activity.test.ts
+++ b/src/__tests__/outreach-activity.test.ts
@@ -152,4 +152,21 @@ describe("html to text", () => {
   it("turns paragraph and break structure into newlines", () => {
     expect(htmlToDisplayText("<p>a<br>b</p><p>c</p>")).toBe("a\nb\n\nc");
   });
+
+  it("leaves no markup behind on tags nested to survive a naive strip", () => {
+    // Asserts the property that matters (no tags out), NOT that a single pass
+    // would have failed: for this pattern a second pass changes nothing, which
+    // I verified rather than assumed. These outputs are React text children
+    // and React escapes them, so this was never a live injection either way.
+    const nasty = "<p>hi <scr<script>ipt>alert(1)</script></p>";
+    expect(htmlToDisplayText(nasty)).not.toContain("<");
+    expect(htmlToPlain(nasty)).not.toContain("<");
+  });
+
+  it("is unchanged for ordinary content", () => {
+    // The fixed-point loop must be a no-op on anything real.
+    expect(htmlToPlain("<p>Hi Dana,</p><p>Thanks.</p>")).toBe(
+      "Hi Dana,\n\nThanks.",
+    );
+  });
 });

--- a/src/__tests__/outreach-status.test.ts
+++ b/src/__tests__/outreach-status.test.ts
@@ -8,7 +8,10 @@ import {
 describe("outreach status registry", () => {
   it("exposes a single canonical status for every lifecycle stage", () => {
     const keys = Object.keys(OUTREACH_STATUS) as OutreachStatus[];
+    // Exact on purpose. A new status is a product decision, so adding one
+    // should require saying so here rather than sliding in unnoticed.
     expect(keys).toEqual([
+      // review lifecycle
       "needs_review",
       "ready",
       "waiting",
@@ -16,7 +19,22 @@ describe("outreach status registry", () => {
       "replied",
       "blocked",
       "rejected",
+      // states the activity feed adds
+      "bounced",
+      "queued",
+      "scheduled",
+      "deferred",
+      "failed",
     ]);
+  });
+
+  it("keeps deferred visually distinct from the real failures", () => {
+    // Hitting the daily cap is routine and resolves itself tomorrow. Showing
+    // it in the same red as a bounce or an SMTP error would train users to
+    // ignore the states that actually need them.
+    expect(OUTREACH_STATUS.deferred.tone).toBe("muted");
+    expect(OUTREACH_STATUS.failed.tone).toBe("danger");
+    expect(OUTREACH_STATUS.bounced.tone).toBe("danger");
   });
 
   it("maps DB enrollment status to canonical status", () => {
@@ -30,9 +48,14 @@ describe("outreach status registry", () => {
     for (const def of Object.values(OUTREACH_STATUS)) {
       expect(def.label.length).toBeGreaterThan(0);
       expect(def.description.length).toBeGreaterThan(0);
-      expect(["primary", "warn", "muted", "success", "neutral"]).toContain(
-        def.tone,
-      );
+      expect([
+        "primary",
+        "warn",
+        "muted",
+        "success",
+        "neutral",
+        "danger",
+      ]).toContain(def.tone);
     }
   });
 });

--- a/src/__tests__/reply-backfill.test.ts
+++ b/src/__tests__/reply-backfill.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The reply backfill, and specifically the two ways it could misbehave.
+ *
+ * It re-enqueues itself while work remains. One-shot jobs are NOT covered by
+ * idx_jobs_one_recurring_per_type, so the database will happily accept an
+ * unbounded chain of them: MAX_PASSES in the executor is the only thing that
+ * stops it. That cap is the highest-risk line in the file.
+ *
+ * The other risk is cost. Every recovered body is its own IMAP connection, so
+ * a send whose reply already has a body must never be picked up again.
+ */
+
+vi.mock("@/lib/posthog-server", () => ({
+  getPostHogClient: () => ({ capture: vi.fn() }),
+}));
+vi.mock("@/lib/crypto", () => ({
+  decryptSecret: () => "app-password",
+  encryptSecret: (s: string) => s,
+}));
+vi.mock("@/lib/services/gmail-service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/services/gmail-service")>();
+  return {
+    ...actual,
+    fetchInboundSince: vi.fn(),
+    fetchMessageText: vi.fn(),
+  };
+});
+vi.mock("@/lib/services/jobs", () => ({ enqueueJob: vi.fn() }));
+
+const adminClient = { current: null as unknown };
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: () => adminClient.current,
+}));
+
+import {
+  fetchInboundSince,
+  fetchMessageText,
+  type InboundSummary,
+} from "@/lib/services/gmail-service";
+import { enqueueJob } from "@/lib/services/jobs";
+import { backfillReplyBodies } from "@/lib/jobs/executors/reply-backfill";
+
+const fetchInboundMock = vi.mocked(fetchInboundSince);
+const fetchBodyMock = vi.mocked(fetchMessageText);
+const enqueueMock = vi.mocked(enqueueJob);
+
+const OUR_MSG_ID = "<sent-1@signal>";
+
+function sentRow(replies: Array<{ id: string; body_text: string | null }>) {
+  return {
+    id: "se_1",
+    message_id: OUR_MSG_ID,
+    campaign_people_id: "cp_1",
+    user_id: "user_1",
+    status: "replied",
+    sent_at: new Date().toISOString(),
+    person_id: "per_1",
+    to_email: "dana@acme.test",
+    campaign_id: "camp_1",
+    email_replies: replies,
+  };
+}
+
+function inbound(): InboundSummary {
+  return {
+    fromAddress: "dana@acme.test",
+    inReplyTo: OUR_MSG_ID,
+    references: [],
+    bodyText: "",
+    subject: "Re: metering",
+    date: new Date("2026-08-03T10:00:00Z"),
+    uid: 11,
+    messageId: "<reply-1@acme.test>",
+  };
+}
+
+/** Minimal stand-in: enough query surface for the executor's three tables. */
+function makeDb(sentRows: unknown[], existingReply: { id: string } | null) {
+  const updates: Array<Record<string, unknown>> = [];
+  const db = {
+    updates,
+    from(table: string) {
+      const self: Record<string, unknown> = {};
+      const rows =
+        table === "sent_emails"
+          ? sentRows
+          : table === "user_settings"
+            ? [
+                {
+                  user_id: "user_1",
+                  gmail_address: "jay@sahnan.co",
+                  gmail_app_password_enc: "enc",
+                },
+              ]
+            : [];
+      const thenable = {
+        then: (res: (v: unknown) => unknown) =>
+          res({ data: rows, error: null }),
+      };
+      for (const m of ["select", "in", "gte", "order", "limit", "eq"]) {
+        self[m] = () => Object.assign(self, thenable);
+      }
+      self.maybeSingle = async () => ({ data: existingReply, error: null });
+      self.update = (payload: Record<string, unknown>) => {
+        updates.push(payload);
+        return Object.assign(self, thenable);
+      };
+      self.upsert = () => ({
+        select: async () => ({ data: [{ id: "r_new" }], error: null }),
+      });
+      return Object.assign(self, thenable);
+    },
+  };
+  return db;
+}
+
+beforeEach(() => {
+  fetchInboundMock.mockReset().mockResolvedValue([inbound()]);
+  fetchBodyMock
+    .mockReset()
+    .mockResolvedValue("Sounds good.\n\nOn Sun wrote:\n> pitch");
+  enqueueMock.mockReset().mockResolvedValue("job_1");
+});
+
+describe("reply backfill", () => {
+  it("fills in a reply that was matched but never captured", async () => {
+    const db = makeDb([sentRow([{ id: "r_1", body_text: null }])], {
+      id: "r_1",
+    });
+    adminClient.current = db;
+
+    const result = await backfillReplyBodies({ pass: 1 });
+
+    expect(result.filled).toBe(1);
+    expect(db.updates[0].body_text).toBe("Sounds good.");
+  });
+
+  it("skips a send whose reply already has a body", async () => {
+    // Every recovered body is its own IMAP connection. Re-downloading one we
+    // already hold is the expensive mistake this guard exists to prevent.
+    const db = makeDb([sentRow([{ id: "r_1", body_text: "already here" }])], {
+      id: "r_1",
+    });
+    adminClient.current = db;
+
+    const result = await backfillReplyBodies({ pass: 1 });
+
+    expect(result.filled).toBe(0);
+    expect(fetchInboundMock).not.toHaveBeenCalled();
+    expect(fetchBodyMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("re-enqueues itself while work remains", async () => {
+    // Two candidates, only one recoverable from the inbox, so a pass leaves
+    // work behind and has to come back for it.
+    const rows = [
+      sentRow([{ id: "r_1", body_text: null }]),
+      {
+        ...sentRow([{ id: "r_2", body_text: null }]),
+        id: "se_2",
+        message_id: "<sent-2@signal>",
+      },
+    ];
+    adminClient.current = makeDb(rows, { id: "r_1" });
+
+    const result = await backfillReplyBodies({ pass: 3 });
+
+    expect(result.requeued).toBe(true);
+    expect(enqueueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "email.backfill-replies",
+        payload: { pass: 4 },
+      }),
+    );
+  });
+
+  it("stops at the pass cap rather than looping forever", async () => {
+    // The database does not bound this: one-shot jobs are outside the partial
+    // unique index, so without the cap a stuck mailbox would enqueue passes
+    // every two minutes indefinitely.
+    const rows = [
+      sentRow([{ id: "r_1", body_text: null }]),
+      {
+        ...sentRow([{ id: "r_2", body_text: null }]),
+        id: "se_2",
+        message_id: "<sent-2@signal>",
+      },
+    ];
+    adminClient.current = makeDb(rows, { id: "r_1" });
+
+    const result = await backfillReplyBodies({ pass: 20 });
+
+    expect(result.requeued).toBe(false);
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is nothing to backfill", async () => {
+    adminClient.current = makeDb([], null);
+
+    const result = await backfillReplyBodies({});
+
+    expect(result).toMatchObject({ filled: 0, remaining: 0, requeued: false });
+    expect(fetchInboundMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/reply-capture.test.ts
+++ b/src/__tests__/reply-capture.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Reply capture, and specifically its idempotency.
+ *
+ * `email.track` re-polls the same 14-day window every 10 minutes, so every
+ * reply is re-matched dozens of times. Two things therefore have to hold, and
+ * they pull in opposite directions:
+ *
+ *   - re-seeing the SAME message must not insert a second row, and must not
+ *     re-download a body over a fresh IMAP connection;
+ *   - a SECOND, genuinely different reply in the same thread must still be
+ *     stored, even though `applyInboundStatus` refuses it (replied -> replied
+ *     fails the monotonic ladder).
+ *
+ * The obvious implementation, gating the insert on applyInboundStatus's return
+ * value, satisfies the first and silently breaks the second. That is the bug
+ * this file exists to catch.
+ */
+
+vi.mock("@/lib/posthog-server", () => ({
+  getPostHogClient: () => ({ capture: vi.fn() }),
+}));
+vi.mock("@/lib/services/email-pattern", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/services/email-pattern")>();
+  return { ...actual, recordBounce: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock("@/lib/crypto", () => ({
+  decryptSecret: () => "app-password",
+  encryptSecret: (s: string) => s,
+}));
+vi.mock("@/lib/services/gmail-service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/services/gmail-service")>();
+  // classifyInboundMessage stays REAL: the matching logic is the thing that
+  // decides which send a reply belongs to, and faking it would hollow out
+  // every assertion below.
+  return {
+    ...actual,
+    fetchInboundSince: vi.fn(),
+    fetchMessageText: vi.fn(),
+  };
+});
+
+const adminClient = { current: null as unknown };
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: () => adminClient.current,
+}));
+
+import {
+  fetchInboundSince,
+  fetchMessageText,
+  type InboundSummary,
+} from "@/lib/services/gmail-service";
+import { replyDedupeKey } from "@/lib/services/email-tracking";
+import { trackEmailReplies } from "@/lib/jobs/executors/email-track";
+
+const fetchInboundMock = vi.mocked(fetchInboundSince);
+const fetchBodyMock = vi.mocked(fetchMessageText);
+
+const SENT_ID = "se_1";
+const OUR_MSG_ID = "<sent-1@signal>";
+
+/**
+ * Rebuilt per test. A single shared mutable row meant a test that failed
+ * before restoring `status` poisoned every test after it, turning one real
+ * failure into three and hiding which was which.
+ */
+function makeSentEmail(status = "sent") {
+  return {
+    id: SENT_ID,
+    message_id: OUR_MSG_ID,
+    campaign_people_id: "cp_1",
+    user_id: "user_1",
+    status,
+    sent_at: new Date().toISOString(),
+    person_id: "per_1",
+    to_email: "dana@acme.test",
+    campaign_id: "camp_1",
+  };
+}
+
+const settingsRow = {
+  user_id: "user_1",
+  gmail_address: "jay@sahnan.co",
+  gmail_app_password_enc: "enc",
+};
+
+function inbound(over: Partial<InboundSummary> = {}): InboundSummary {
+  return {
+    fromAddress: "dana@acme.test",
+    inReplyTo: OUR_MSG_ID,
+    references: [],
+    bodyText: "",
+    subject: "Re: metering",
+    date: new Date("2026-08-03T10:00:00Z"),
+    uid: 11,
+    messageId: "<reply-1@acme.test>",
+    ...over,
+  };
+}
+
+/**
+ * A Supabase stand-in that models the one thing under test: an upsert with
+ * `ignoreDuplicates` against a real unique constraint. The shared fake in
+ * helpers/ models select and update only, and the conflict semantics are
+ * exactly what these assertions turn on, so this is deliberately its own.
+ */
+function makeDb(seedReplies: Array<Record<string, unknown>> = []) {
+  const replies = [...seedReplies];
+  const sentEmail = makeSentEmail();
+  const statusUpdates: Array<Record<string, unknown>> = [];
+
+  const db = {
+    replies,
+    statusUpdates,
+    sentEmail,
+    from(table: string) {
+      if (table === "sent_emails") {
+        return chain([sentEmail], (payload) => statusUpdates.push(payload));
+      }
+      if (table === "user_settings") return chain([settingsRow]);
+      if (table === "campaign_people") {
+        return chain([], (payload) => statusUpdates.push(payload));
+      }
+      if (table === "email_replies") {
+        return {
+          select: () => ({
+            in: async () => ({ data: replies, error: null }),
+          }),
+          upsert: (row: Record<string, unknown>) => ({
+            select: async () => {
+              const key = `${row.sent_email_id}|${row.dedupe_key}`;
+              const exists = replies.some(
+                (r) => `${r.sent_email_id}|${r.dedupe_key}` === key,
+              );
+              if (exists) return { data: [], error: null };
+              replies.push(row);
+              return { data: [{ id: `r_${replies.length}` }], error: null };
+            },
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+  return db;
+}
+
+function chain(
+  rows: unknown[],
+  onUpdate?: (p: Record<string, unknown>) => void,
+) {
+  const self: Record<string, unknown> = {};
+  const thenable = {
+    then: (res: (v: unknown) => unknown) => res({ data: rows, error: null }),
+  };
+  for (const m of ["select", "in", "gte", "order", "limit", "eq"]) {
+    self[m] = () => Object.assign(self, thenable);
+  }
+  self.update = (payload: Record<string, unknown>) => {
+    onUpdate?.(payload);
+    return Object.assign(self, thenable);
+  };
+  return Object.assign(self, thenable);
+}
+
+beforeEach(() => {
+  fetchInboundMock.mockReset();
+  fetchBodyMock.mockReset();
+  fetchBodyMock.mockResolvedValue(
+    "Sounds good, next week works.\n\nOn Sun wrote:\n> pitch",
+  );
+});
+
+describe("reply capture idempotency", () => {
+  it("stores a reply once, however many times the poll re-sees it", async () => {
+    const db = makeDb();
+    adminClient.current = db;
+    fetchInboundMock.mockResolvedValue([inbound()]);
+
+    const first = await trackEmailReplies();
+    expect(first.captured).toBe(1);
+    expect(db.replies).toHaveLength(1);
+    expect(db.replies[0].body_text).toBe("Sounds good, next week works.");
+
+    // Second poll, same inbox contents. The send is already 'replied', so the
+    // status ladder refuses it; the reply must not be stored twice either.
+    db.sentEmail.status = "replied";
+    const second = await trackEmailReplies();
+    expect(second.captured).toBe(0);
+    expect(db.replies).toHaveLength(1);
+  });
+
+  it("does not re-download a body it has already captured", async () => {
+    const db = makeDb();
+    adminClient.current = db;
+    fetchInboundMock.mockResolvedValue([inbound()]);
+
+    await trackEmailReplies();
+    expect(fetchBodyMock).toHaveBeenCalledTimes(1);
+
+    // A second run must reuse what is stored. Re-downloading here is what
+    // turns 20 replies into 20 IMAP connections every 10 minutes.
+    await trackEmailReplies();
+    expect(fetchBodyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores a second, different reply in the same thread", async () => {
+    const db = makeDb();
+    adminClient.current = db;
+
+    fetchInboundMock.mockResolvedValue([inbound()]);
+    await trackEmailReplies();
+    expect(db.replies).toHaveLength(1);
+
+    // They followed up. applyInboundStatus returns false for this one
+    // (replied -> replied), so anything gating the insert on it loses this.
+    db.sentEmail.status = "replied";
+    fetchInboundMock.mockResolvedValue([
+      inbound(),
+      inbound({
+        messageId: "<reply-2@acme.test>",
+        uid: 12,
+        subject: "Re: metering (one more thing)",
+      }),
+    ]);
+    const run = await trackEmailReplies();
+
+    expect(run.captured).toBe(1);
+    expect(db.replies).toHaveLength(2);
+    expect(db.replies[1].message_id).toBe("<reply-2@acme.test>");
+  });
+
+  it("stores null, not empty string, when no body was captured", async () => {
+    const db = makeDb();
+    adminClient.current = db;
+    fetchInboundMock.mockResolvedValue([inbound()]);
+    fetchBodyMock.mockResolvedValue("");
+
+    await trackEmailReplies();
+
+    // null means "we never got the words" and is retryable on a later poll.
+    // "" would read as a genuinely empty reply and would never be retried.
+    expect(db.replies[0].body_text).toBeNull();
+  });
+
+  it("captures a bounce without a second download", async () => {
+    const db = makeDb();
+    adminClient.current = db;
+    fetchInboundMock.mockResolvedValue([
+      inbound({
+        fromAddress: "mailer-daemon@googlemail.com",
+        inReplyTo: OUR_MSG_ID,
+        bodyText: "550 5.1.1 The email account does not exist.",
+        messageId: "<dsn-1@googlemail.com>",
+      }),
+    ]);
+
+    await trackEmailReplies();
+
+    // fetchInboundSince already downloaded the daemon body to match the quoted
+    // Message-ID, so bounce capture is free.
+    expect(fetchBodyMock).not.toHaveBeenCalled();
+    expect(db.replies[0].kind).toBe("bounce");
+    expect(db.replies[0].body_text).toContain("550 5.1.1");
+  });
+});
+
+describe("replyDedupeKey", () => {
+  const identity = {
+    messageId: "<a@b>",
+    uid: 7,
+    fromAddress: "Dana@Acme.test",
+    date: new Date("2026-08-03T10:00:00Z"),
+    subject: "Re: metering",
+  };
+
+  it("prefers the sender's own Message-ID", () => {
+    expect(replyDedupeKey(identity)).toBe("<a@b>");
+  });
+
+  it("falls back to the IMAP UID when the header is absent", () => {
+    expect(replyDedupeKey({ ...identity, messageId: null })).toBe("uid:7");
+  });
+
+  it("falls back to sender, time and subject when both are absent", () => {
+    expect(replyDedupeKey({ ...identity, messageId: null, uid: null })).toBe(
+      `dana@acme.test|${identity.date.getTime()}|Re: metering`,
+    );
+  });
+
+  it("is stable across polls for the same message", () => {
+    expect(replyDedupeKey(identity)).toBe(replyDedupeKey({ ...identity }));
+  });
+});

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,5 +1,16 @@
 import { getSupabaseAndUser } from "@/lib/supabase/server";
 
+/**
+ * Dashboard aggregates.
+ *
+ * There is deliberately no "opened" metric. Signal sends no tracking pixel, so
+ * nothing anywhere writes outreach_status = 'opened' -- which meant the old
+ * opened bucket ('opened' OR 'replied') was exactly equal to replied, and the
+ * dashboard showed the same number twice under two labels, one of them a
+ * metric the product does not collect. 'opened' survives only inside the
+ * membership tests below, where it keeps legacy rows counted as sent.
+ */
+
 export async function GET(request: Request) {
   const ctx = await getSupabaseAndUser();
   if (!ctx) {
@@ -22,7 +33,6 @@ export async function GET(request: Request) {
   const [
     leadsRes,
     sentRes,
-    openedRes,
     repliedRes,
     bouncedRes,
     timeSeriesRes,
@@ -36,11 +46,16 @@ export async function GET(request: Request) {
     supabase
       .from("campaign_people")
       .select("*", { count: "exact", head: true })
-      .in("outreach_status", ["sent", "opened", "replied"]),
-    supabase
-      .from("campaign_people")
-      .select("*", { count: "exact", head: true })
-      .in("outreach_status", ["opened", "replied"]),
+      // A send that bounced still left. Excluding it shrank the denominator
+      // every rate is measured against, and would have made the new bounce
+      // card move the wrong way.
+      .in("outreach_status", [
+        "sent",
+        "opened",
+        "replied",
+        "bounced",
+        "complained",
+      ]),
     supabase
       .from("campaign_people")
       .select("*", { count: "exact", head: true })
@@ -77,7 +92,6 @@ export async function GET(request: Request) {
   const totals = {
     leads: leadsRes.count ?? 0,
     sent: sentRes.count ?? 0,
-    opened: openedRes.count ?? 0,
     replied: repliedRes.count ?? 0,
     bounced: bouncedRes.count ?? 0,
   };
@@ -87,7 +101,7 @@ export async function GET(request: Request) {
   for (const event of timeSeriesRes.data ?? []) {
     const day = event.created_at.slice(0, 10);
     if (!eventsByDay.has(day)) {
-      eventsByDay.set(day, { sent: 0, opened: 0, replied: 0, bounced: 0 });
+      eventsByDay.set(day, { sent: 0, replied: 0, bounced: 0 });
     }
     const bucket = eventsByDay.get(day)!;
     if (bucket[event.status] !== undefined) {
@@ -102,43 +116,33 @@ export async function GET(request: Request) {
   const campaignPeople = allPeopleRes.data ?? [];
   const campaignMap = new Map<
     string,
-    { leads: number; sent: number; opened: number; replied: number }
+    { leads: number; sent: number; replied: number }
   >();
 
   for (const row of campaignPeople) {
     if (!campaignMap.has(row.campaign_id)) {
-      campaignMap.set(row.campaign_id, {
-        leads: 0,
-        sent: 0,
-        opened: 0,
-        replied: 0,
-      });
+      campaignMap.set(row.campaign_id, { leads: 0, sent: 0, replied: 0 });
     }
     const stats = campaignMap.get(row.campaign_id)!;
     stats.leads++;
-    if (["sent", "opened", "replied"].includes(row.outreach_status))
+    if (
+      ["sent", "opened", "replied", "bounced", "complained"].includes(
+        row.outreach_status,
+      )
+    )
       stats.sent++;
-    if (["opened", "replied"].includes(row.outreach_status)) stats.opened++;
     if (row.outreach_status === "replied") stats.replied++;
   }
 
   const campaigns = (campaignsRes.data ?? [])
     .map((c) => {
-      const stats = campaignMap.get(c.id) ?? {
-        leads: 0,
-        sent: 0,
-        opened: 0,
-        replied: 0,
-      };
+      const stats = campaignMap.get(c.id) ?? { leads: 0, sent: 0, replied: 0 };
       return {
         id: c.id,
         name: c.name,
         status: c.status,
         leads: stats.leads,
         sent: stats.sent,
-        opened: stats.opened,
-        openRate:
-          stats.sent > 0 ? Math.round((stats.opened / stats.sent) * 100) : 0,
         replied: stats.replied,
         replyRate:
           stats.sent > 0 ? Math.round((stats.replied / stats.sent) * 100) : 0,

--- a/src/app/api/outreach/activity/[id]/route.ts
+++ b/src/app/api/outreach/activity/[id]/route.ts
@@ -1,0 +1,95 @@
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { gmailSearchUrl } from "@/lib/outreach/activity";
+import { htmlToDisplayText } from "@/lib/email/html-to-plain";
+
+/**
+ * One sent email, with its body and every reply it drew.
+ *
+ * Split from the list route because the list rides a 10s poll and bodies have
+ * no business being re-fetched every ten seconds. This is loaded once, when a
+ * row is expanded.
+ *
+ * RLS does the scoping (see the note in ../route.ts).
+ */
+/**
+ * The row shape this route selects. Declared by hand because PostgREST's
+ * inferred types give up on a two-level embed and widen the whole result to an
+ * error type.
+ */
+interface SentDetailRow {
+  id: string;
+  subject: string;
+  to_email: string;
+  from_email: string | null;
+  status: string;
+  sent_at: string;
+  message_id: string | null;
+  draft: { body_html: string | null; body_text: string | null } | null;
+  email_replies: Array<{
+    kind: string;
+    from_email: string;
+    subject: string;
+    received_at: string;
+    body_text: string | null;
+  }> | null;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase } = ctx;
+  const { id } = await params;
+
+  const { data: sent, error } = await supabase
+    .from("sent_emails")
+    .select(
+      "id, subject, to_email, from_email, status, sent_at, message_id, " +
+        "draft:email_drafts(body_html, body_text), " +
+        "email_replies(kind, from_email, subject, received_at, body_text)",
+    )
+    .eq("id", id)
+    .maybeSingle<SentDetailRow>();
+
+  if (error) {
+    console.error("[activity/detail] query failed:", error);
+    return Response.json({ error: "Could not load message" }, { status: 500 });
+  }
+  // Also the RLS-denied case: a row belonging to someone else reads as absent,
+  // which is the correct thing to tell the caller.
+  if (!sent) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const draft = Array.isArray(sent.draft) ? sent.draft[0] : sent.draft;
+
+  // The sent body lives only on the draft row, reached through draft_id. That
+  // FK is ON DELETE SET NULL and email_drafts cascades from sequences, so
+  // deleting a sequence destroys the body while the sent_emails row survives.
+  // Say so plainly rather than rendering an empty email.
+  const bodyText =
+    draft?.body_text ??
+    (draft?.body_html ? htmlToDisplayText(draft.body_html) : null);
+
+  const replies = (sent.email_replies ?? [])
+    .slice()
+    .sort((a, b) => a.received_at.localeCompare(b.received_at));
+
+  return Response.json({
+    sent: {
+      subject: sent.subject,
+      to_email: sent.to_email,
+      from_email: sent.from_email,
+      sent_at: sent.sent_at,
+      status: sent.status,
+      body_text: bodyText,
+      body_available: bodyText !== null,
+    },
+    replies,
+    gmail_url: gmailSearchUrl(sent.message_id, sent.from_email),
+  });
+}

--- a/src/app/api/outreach/activity/route.ts
+++ b/src/app/api/outreach/activity/route.ts
@@ -2,10 +2,10 @@ import { getSupabaseAndUser } from "@/lib/supabase/server";
 import {
   classifyPending,
   classifySent,
+  filterActivity,
   gmailSearchUrl,
   replySnippet,
   type ActivityItem,
-  type ActivityState,
 } from "@/lib/outreach/activity";
 
 /**
@@ -30,15 +30,6 @@ import {
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
-
-/** Filters the UI offers, mapped to the states they cover. */
-const FILTERS: Record<string, ActivityState[]> = {
-  replied: ["replied"],
-  bounced: ["bounced"],
-  sent: ["sent"],
-  pending: ["queued", "scheduled", "deferred"],
-  failed: ["failed", "blocked"],
-};
 
 /**
  * The organizations embed names its foreign key on purpose. people has TWO
@@ -108,7 +99,6 @@ export async function GET(request: Request) {
     MAX_LIMIT,
   );
 
-  const wanted = FILTERS[filter] ?? null;
   const campaignId = searchParams.get("campaignId");
 
   // Over-fetch each side by the page size: the two are merged and re-sorted in
@@ -215,9 +205,7 @@ export async function GET(request: Request) {
     });
   }
 
-  const filtered = wanted
-    ? items.filter((i) => wanted.includes(i.state))
-    : items;
+  const filtered = filterActivity(items, filter);
   filtered.sort((a, b) => b.at.localeCompare(a.at));
   const page = filtered.slice(0, limit);
 

--- a/src/app/api/outreach/activity/route.ts
+++ b/src/app/api/outreach/activity/route.ts
@@ -1,0 +1,233 @@
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import {
+  classifyPending,
+  classifySent,
+  gmailSearchUrl,
+  replySnippet,
+  type ActivityItem,
+  type ActivityState,
+} from "@/lib/outreach/activity";
+
+/**
+ * The outreach activity feed: what went out, what came back, and what did not
+ * send.
+ *
+ * A union of two sources, because neither alone answers the question. Sent
+ * mail lives in sent_emails; mail that is approved but has not left has no
+ * sent_emails row at all, which is precisely why queued, scheduled and failed
+ * sends are invisible everywhere in the product today.
+ *
+ * Auth is RLS, via getSupabaseAndUser, exactly as /api/dashboard does. There
+ * is deliberately NO user_id filter in this file: adding one would mask a
+ * policy that was written wrong, and the policies are the thing that has to be
+ * right. (Contrast /api/outreach/send-now, which does use the admin client,
+ * but only because it must, and pays for it with an explicit ownership check.)
+ *
+ * Bodies are not included here. This rides the outreach page's existing 10s
+ * poll, and shipping every sent body on every poll would be gratuitous; the
+ * detail route loads one on expand.
+ */
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+/** Filters the UI offers, mapped to the states they cover. */
+const FILTERS: Record<string, ActivityState[]> = {
+  replied: ["replied"],
+  bounced: ["bounced"],
+  sent: ["sent"],
+  pending: ["queued", "scheduled", "deferred"],
+  failed: ["failed", "blocked"],
+};
+
+/**
+ * The organizations embed names its foreign key on purpose. people has TWO
+ * FKs to organizations -- organization_id and affiliation_detached_from, the
+ * latter added by 20260802000000 -- so an unqualified embed is ambiguous and
+ * PostgREST refuses the whole query with "more than one relationship was
+ * found". Removing the constraint name turns this route into a 500.
+ */
+interface PersonJoin {
+  name: string | null;
+  title: string | null;
+  organizations: { name: string | null } | null;
+}
+
+/**
+ * Row shapes declared by hand. PostgREST's inferred types give up on a
+ * two-level embed and widen the whole result to an error type, which then
+ * hides every real field access behind a single unhelpful error.
+ */
+interface SentRow {
+  id: string;
+  subject: string;
+  to_email: string;
+  from_email: string | null;
+  status: string;
+  sent_at: string;
+  message_id: string | null;
+  person: PersonJoin | PersonJoin[] | null;
+  email_replies: Array<{
+    kind: string;
+    body_text: string | null;
+    received_at: string;
+  }> | null;
+}
+
+interface PendingRow {
+  id: string;
+  subject: string;
+  to_email: string;
+  status: string;
+  created_at: string;
+  last_error: string | null;
+  last_error_at: string | null;
+  last_error_kind: string | null;
+  person: PersonJoin | PersonJoin[] | null;
+  enrollment: { next_send_at: string | null } | null;
+}
+
+/** PostgREST returns an embedded to-one as an object, or an array in some shapes. */
+function one<T>(value: T | T[] | null): T | null {
+  if (!value) return null;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
+}
+
+export async function GET(request: Request) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase } = ctx;
+
+  const { searchParams } = new URL(request.url);
+  const filter = searchParams.get("filter") ?? "all";
+  const before = searchParams.get("before");
+  const limit = Math.min(
+    Number(searchParams.get("limit")) || DEFAULT_LIMIT,
+    MAX_LIMIT,
+  );
+
+  const wanted = FILTERS[filter] ?? null;
+  const campaignId = searchParams.get("campaignId");
+
+  // Over-fetch each side by the page size: the two are merged and re-sorted in
+  // JS, so either could contribute the whole page.
+  let sentQuery = supabase
+    .from("sent_emails")
+    .select(
+      "id, subject, to_email, from_email, status, sent_at, message_id, " +
+        "person:people(name, title, organizations!people_organization_id_fkey(name)), " +
+        "email_replies(kind, from_email, subject, received_at, body_text)",
+    )
+    .order("sent_at", { ascending: false })
+    .limit(limit);
+  if (before) sentQuery = sentQuery.lt("sent_at", before);
+  if (campaignId) sentQuery = sentQuery.eq("campaign_id", campaignId);
+
+  let pendingQuery = supabase
+    .from("email_drafts")
+    .select(
+      "id, subject, to_email, status, created_at, last_error, last_error_at, last_error_kind, " +
+        "person:people(name, title, organizations!people_organization_id_fkey(name)), " +
+        "enrollment:sequence_enrollments(next_send_at)",
+    )
+    .eq("review_status", "approved")
+    .in("status", ["draft", "queued"])
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (campaignId) pendingQuery = pendingQuery.eq("campaign_id", campaignId);
+
+  const [sentRes, pendingRes] = await Promise.all([sentQuery, pendingQuery]);
+  if (sentRes.error || pendingRes.error) {
+    console.error(
+      "[activity] query failed:",
+      sentRes.error ?? pendingRes.error,
+    );
+    return Response.json({ error: "Could not load activity" }, { status: 500 });
+  }
+
+  const items: ActivityItem[] = [];
+
+  for (const row of (sentRes.data ?? []) as unknown as SentRow[]) {
+    const person = one(row.person);
+    const replies = row.email_replies ?? [];
+    // Newest reply drives both the snippet and the sort position, so a thread
+    // that just got a response rises to the top of the feed.
+    const newest = replies
+      .slice()
+      .sort((a, b) => b.received_at.localeCompare(a.received_at))[0];
+
+    items.push({
+      id: row.id,
+      source: "sent",
+      state: classifySent(row.status),
+      person_name: person?.name ?? null,
+      person_title: person?.title ?? null,
+      company_name: one(person?.organizations ?? null)?.name ?? null,
+      to_email: row.to_email,
+      subject: row.subject,
+      at: newest?.received_at ?? row.sent_at,
+      sent_at: row.sent_at,
+      next_send_at: null,
+      reply_count: replies.length,
+      reply_snippet: replySnippet(newest?.body_text ?? null),
+      // A reply we matched but never captured the words of. Distinct from an
+      // empty reply, and the row has to say so rather than showing nothing.
+      reply_captured: !!newest && newest.body_text !== null,
+      error: null,
+      gmail_url: gmailSearchUrl(row.message_id, row.from_email),
+    });
+  }
+
+  for (const row of (pendingRes.data ?? []) as unknown as PendingRow[]) {
+    const person = one(row.person);
+    const nextSendAt = one(row.enrollment)?.next_send_at ?? null;
+
+    items.push({
+      id: `draft:${row.id}`,
+      source: "pending",
+      state: classifyPending({
+        status: row.status,
+        last_error_kind: row.last_error_kind,
+        next_send_at: nextSendAt,
+      }),
+      person_name: person?.name ?? null,
+      person_title: person?.title ?? null,
+      company_name: one(person?.organizations ?? null)?.name ?? null,
+      to_email: row.to_email,
+      subject: row.subject,
+      at: row.last_error_at ?? nextSendAt ?? row.created_at,
+      sent_at: null,
+      next_send_at: nextSendAt,
+      reply_count: 0,
+      reply_snippet: null,
+      reply_captured: false,
+      error: row.last_error
+        ? {
+            kind: row.last_error_kind ?? "failed",
+            message: row.last_error,
+            at: row.last_error_at ?? row.created_at,
+          }
+        : null,
+      // A draft has not been sent, so there is no message in Gmail to open.
+      gmail_url: null,
+    });
+  }
+
+  const filtered = wanted
+    ? items.filter((i) => wanted.includes(i.state))
+    : items;
+  filtered.sort((a, b) => b.at.localeCompare(a.at));
+  const page = filtered.slice(0, limit);
+
+  return Response.json({
+    items: page,
+    // Only sent rows are cursor-paginated (pending mail is a bounded set), so
+    // the cursor is the oldest sent_at on the page.
+    nextCursor:
+      page.length === limit
+        ? (page.filter((i) => i.sent_at).at(-1)?.sent_at ?? null)
+        : null,
+  });
+}

--- a/src/app/outreach/page.tsx
+++ b/src/app/outreach/page.tsx
@@ -10,6 +10,9 @@ import {
 } from "@/components/outreach/outreach-drafts-panel";
 import { ReadyToSendHero } from "@/components/outreach/ready-to-send-hero";
 import { OutreachTabs } from "@/components/outreach/outreach-tabs";
+import { apiFetch } from "@/lib/api-fetch";
+import type { ActivityItem } from "@/lib/outreach/activity";
+import type { ActivityFilter } from "@/components/outreach/outreach-activity-panel";
 
 export interface SequenceRow {
   id: string;
@@ -42,6 +45,8 @@ export default function OutreachPage() {
   const [sequences, setSequences] = useState<SequenceRow[]>([]);
   const [enrollments, setEnrollments] = useState<EnrollmentCard[]>([]);
   const [drafts, setDrafts] = useState<DraftRow[]>([]);
+  const [activity, setActivity] = useState<ActivityItem[]>([]);
+  const [activityFilter, setActivityFilter] = useState<ActivityFilter>("all");
   const [loading, setLoading] = useState(true);
   const mountedRef = useRef(true);
 
@@ -55,6 +60,7 @@ export default function OutreachPage() {
       draftsRes,
       settingsRes,
       stepRowsRes,
+      activityRes,
     ] = await Promise.all([
       supabase
         .from("sequences")
@@ -91,6 +97,18 @@ export default function OutreachPage() {
         .limit(200),
       supabase.from("user_settings").select("gmail_address").maybeSingle(),
       supabase.from("sequence_steps").select("sequence_id, step_number"),
+      // In the same batch rather than after it, so the activity feed rides
+      // the page's existing visibility-aware 10s poll without adding a second
+      // timer or an extra round trip. Goes through apiFetch because it is an
+      // API route, not a direct Supabase read like everything above.
+      //
+      // Fetched unfiltered and narrowed in the client: the whole set is what
+      // the Sent tab's reply count is derived from, so refetching per chip
+      // click would make that badge flicker between filters.
+      apiFetch("/api/outreach/activity")
+        .then((r) => r.json())
+        // A failed activity fetch must not blank the rest of the page.
+        .catch(() => ({ items: [] as ActivityItem[] })),
     ]);
 
     if (!mountedRef.current) return;
@@ -211,6 +229,11 @@ export default function OutreachPage() {
     setSequences(sequenceRows);
     setEnrollments(enrollmentCards);
     setDrafts(draftRows);
+    setActivity(
+      Array.isArray(activityRes?.items)
+        ? (activityRes.items as ActivityItem[])
+        : [],
+    );
     setLoading(false);
   }, []);
 
@@ -269,7 +292,10 @@ export default function OutreachPage() {
             <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
             <span className="text-muted-foreground text-sm">Loading...</span>
           </div>
-        ) : sequences.length === 0 ? (
+        ) : // Also gated on activity: mail sent through the agent's sendEmail
+        // tool has no sequence, and this empty state would otherwise hide the
+        // whole Sent tab from anyone who has only ever sent that way.
+        sequences.length === 0 && activity.length === 0 ? (
           <div className="border-border flex flex-col items-center gap-2 rounded-lg border border-dashed px-6 py-12 text-center">
             <p className="text-sm font-medium">No outreach sequences yet</p>
             <p className="text-muted-foreground text-xs">
@@ -287,6 +313,10 @@ export default function OutreachPage() {
               drafts={drafts}
               sequences={sequences}
               enrollments={enrollments}
+              activity={activity}
+              activityFilter={activityFilter}
+              onActivityFilterChange={setActivityFilter}
+              activityLoading={loading}
               onRefresh={load}
             />
           </>

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -22,23 +22,12 @@ import {
 import { createClient } from "@/lib/supabase/client";
 import type { CampaignContact, EnrichmentData } from "@/lib/types/campaign";
 import { apiFetch } from "@/lib/api-fetch";
+import { htmlToPlain } from "@/lib/email/html-to-plain";
 
-function htmlToPlain(html: string): string {
-  if (!html) return "";
-  return html
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
-    .replace(/<p[^>]*>/gi, "")
-    .replace(/<\/p>/gi, "")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .trim();
-}
+// Moved to src/lib/email/html-to-plain.ts so the read-only activity view can
+// share it. Deliberately the LOSSY variant: this feeds a textarea that
+// plainToHtml re-serialises on save, so a link-preserving version here would
+// write "text (url)" back into the body as literal text.
 
 function plainToHtml(text: string): string {
   const paragraphs = text

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,14 +29,12 @@ interface DashboardData {
   totals: {
     leads: number;
     sent: number;
-    opened: number;
     replied: number;
     bounced: number;
   };
   timeSeries: Array<{
     date: string;
     sent: number;
-    opened: number;
     replied: number;
     bounced: number;
   }>;
@@ -46,8 +44,6 @@ interface DashboardData {
     status: string;
     leads: number;
     sent: number;
-    opened: number;
-    openRate: number;
     replied: number;
     replyRate: number;
   }>;

--- a/src/components/dashboard/campaign-table.tsx
+++ b/src/components/dashboard/campaign-table.tsx
@@ -14,8 +14,6 @@ interface CampaignRow {
   status: string;
   leads: number;
   sent: number;
-  opened: number;
-  openRate: number;
   replied: number;
   replyRate: number;
 }
@@ -59,8 +57,6 @@ export function CampaignTable({ campaigns }: CampaignTableProps) {
               <th className="px-4 py-2.5 text-left font-medium">Campaign</th>
               <th className="px-4 py-2.5 text-right font-medium">Leads</th>
               <th className="px-4 py-2.5 text-right font-medium">Sent</th>
-              <th className="px-4 py-2.5 text-right font-medium">Opened</th>
-              <th className="px-4 py-2.5 text-right font-medium">Open Rate</th>
               <th className="px-4 py-2.5 text-right font-medium">Replied</th>
               <th className="px-4 py-2.5 text-right font-medium">Reply Rate</th>
               <th className="px-4 py-2.5 text-left font-medium">Status</th>
@@ -85,12 +81,6 @@ export function CampaignTable({ campaigns }: CampaignTableProps) {
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {c.sent}
-                </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">
-                  {c.opened}
-                </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">
-                  {c.openRate}%
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">
                   {c.replied}

--- a/src/components/dashboard/outreach-chart.tsx
+++ b/src/components/dashboard/outreach-chart.tsx
@@ -17,14 +17,13 @@ import { EmptyState } from "@/components/ui/empty-state";
 // the accent on the matching stat card above it.
 const series = [
   { key: "sent", name: "Sent", color: "var(--color-info)" },
-  { key: "opened", name: "Opened", color: "var(--color-warn)" },
+  { key: "bounced", name: "Bounced", color: "var(--color-warn)" },
   { key: "replied", name: "Replied", color: "var(--color-success)" },
 ] as const;
 
 interface TimeSeriesPoint {
   date: string;
   sent: number;
-  opened: number;
   replied: number;
   bounced: number;
 }
@@ -68,7 +67,7 @@ export function OutreachChart({
           icon={Activity}
           accent="info"
           title="No outreach activity yet"
-          description="Sends, opens, and replies will chart here once your first sequence goes out."
+          description="Sends, replies, and bounces will chart here once your first sequence goes out."
           className="h-[200px] py-0"
         />
       ) : (

--- a/src/components/dashboard/stat-cards.tsx
+++ b/src/components/dashboard/stat-cards.tsx
@@ -1,11 +1,10 @@
-import { MailOpen, MessageSquareReply, Send, Users } from "lucide-react";
+import { MailWarning, MessageSquareReply, Send, Users } from "lucide-react";
 
 import { StatCard } from "@/components/ui/stat-card";
 
 interface DashboardTotals {
   leads: number;
   sent: number;
-  opened: number;
   replied: number;
   bounced: number;
 }
@@ -15,8 +14,8 @@ interface StatCardsProps {
 }
 
 export function StatCards({ totals }: StatCardsProps) {
-  const openRate =
-    totals.sent > 0 ? Math.round((totals.opened / totals.sent) * 100) : 0;
+  const bounceRate =
+    totals.sent > 0 ? Math.round((totals.bounced / totals.sent) * 100) : 0;
   const replyRate =
     totals.sent > 0 ? Math.round((totals.replied / totals.sent) * 100) : 0;
 
@@ -36,12 +35,15 @@ export function StatCards({ totals }: StatCardsProps) {
         icon={Send}
         className="animate-rise [--rise-delay:60ms]"
       />
+      {/* Was "Opened", which could only ever read zero: Signal sends no
+          tracking pixel, so nothing writes that status. Bounced was already
+          being computed by the API and rendered nowhere. */}
       <StatCard
-        label="Opened"
-        value={totals.opened}
-        sublabel={totals.sent > 0 ? `${openRate}% open rate` : undefined}
+        label="Bounced"
+        value={totals.bounced}
+        sublabel={totals.sent > 0 ? `${bounceRate}% bounce rate` : undefined}
         accent="warn"
-        icon={MailOpen}
+        icon={MailWarning}
         className="animate-rise [--rise-delay:120ms]"
       />
       <StatCard

--- a/src/components/outreach/activity-detail.tsx
+++ b/src/components/outreach/activity-detail.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLink, Loader2 } from "lucide-react";
+
+import { apiFetch } from "@/lib/api-fetch";
+import { RelativeTime } from "@/components/ui/relative-time";
+
+interface DetailPayload {
+  sent: {
+    subject: string;
+    to_email: string;
+    from_email: string | null;
+    sent_at: string;
+    status: string;
+    body_text: string | null;
+    body_available: boolean;
+  };
+  replies: Array<{
+    kind: string;
+    from_email: string;
+    subject: string;
+    received_at: string;
+    body_text: string | null;
+  }>;
+  gmail_url: string | null;
+}
+
+/**
+ * The expanded half of an activity row: what we sent, and everything that came
+ * back.
+ *
+ * Fetched on first expand rather than with the list, because the list rides a
+ * 10-second poll and email bodies have no business being re-fetched every ten
+ * seconds.
+ *
+ * Bodies render as plain text in a pre-wrap block. Nothing in this app uses
+ * dangerouslySetInnerHTML and this does not start: reply text arrives from
+ * strangers, and our own sent HTML is only <p>/<br>/<a>, which the server has
+ * already flattened while keeping link targets visible.
+ */
+export function ActivityDetail({
+  id,
+  error,
+}: {
+  id: string;
+  error: { kind: string; message: string; at: string } | null;
+}) {
+  const [data, setData] = useState<DetailPayload | null>(null);
+  // Starts as "loading" rather than being set to it inside the effect: this
+  // component only mounts when a row is expanded, so loading IS its initial
+  // state, and setting it in the effect body is a cascading render.
+  const [state, setState] = useState<"idle" | "loading" | "failed">("loading");
+
+  // A pending draft has no sent_emails row, so there is nothing to fetch. Its
+  // whole story is the error already handed down from the list.
+  const isPending = id.startsWith("draft:");
+
+  useEffect(() => {
+    if (isPending || data) return;
+    let cancelled = false;
+    apiFetch(`/api/outreach/activity/${id}`)
+      .then((r) => r.json())
+      .then((payload: DetailPayload) => {
+        if (!cancelled) {
+          setData(payload);
+          setState("idle");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setState("failed");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, isPending, data]);
+
+  if (error) {
+    return (
+      <div className="space-y-2 px-4 py-3">
+        <p className="text-sm font-medium">
+          {error.kind === "deferred"
+            ? "Waiting for tomorrow"
+            : error.kind === "blocked"
+              ? "Blocked before sending"
+              : "The send failed"}
+        </p>
+        {/* Verbatim. These sentences are written for a person to read and say
+            what to do about it, so paraphrasing them here loses the fix. */}
+        <p className="text-muted-foreground text-sm">{error.message}</p>
+        <p className="text-muted-foreground text-xs">
+          <RelativeTime iso={error.at} />
+        </p>
+      </div>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <p className="text-muted-foreground px-4 py-3 text-sm">
+        Approved and waiting to send. Nothing has left yet.
+      </p>
+    );
+  }
+
+  if (state === "loading") {
+    return (
+      <p className="text-muted-foreground flex items-center gap-2 px-4 py-3 text-sm">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        Loading the message...
+      </p>
+    );
+  }
+
+  if (state === "failed" || !data) {
+    return (
+      <p className="text-muted-foreground px-4 py-3 text-sm">
+        Could not load this message.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4 px-4 py-3">
+      <section className="space-y-1.5">
+        <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
+          <span>To {data.sent.to_email}</span>
+          {data.sent.from_email && <span>from {data.sent.from_email}</span>}
+          <RelativeTime iso={data.sent.sent_at} />
+        </div>
+        <p className="text-sm font-medium">{data.sent.subject}</p>
+        {data.sent.body_available ? (
+          <p className="text-muted-foreground text-sm whitespace-pre-wrap">
+            {data.sent.body_text}
+          </p>
+        ) : (
+          // sent_emails.draft_id is ON DELETE SET NULL and drafts cascade from
+          // sequences, so deleting a sequence destroys the body while the send
+          // record survives. Say so rather than rendering an empty email.
+          <p className="text-muted-foreground text-sm italic">
+            This email&apos;s body is no longer stored.
+          </p>
+        )}
+      </section>
+
+      {data.replies.map((reply, i) => (
+        <section
+          key={`${reply.received_at}-${i}`}
+          className="border-border space-y-1.5 border-l-2 pl-3"
+        >
+          <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
+            <span className="font-medium">
+              {reply.kind === "bounce" ? "Bounced" : reply.from_email}
+            </span>
+            <RelativeTime iso={reply.received_at} />
+          </div>
+          {reply.body_text ? (
+            <p className="text-sm whitespace-pre-wrap">{reply.body_text}</p>
+          ) : (
+            // Distinct from an empty reply: we matched the message but never
+            // captured its words, which is the permanent state for anything
+            // that replied before capture existed.
+            <p className="text-muted-foreground text-sm italic">
+              We know this arrived but did not capture the text. Open it in
+              Gmail to read it.
+            </p>
+          )}
+        </section>
+      ))}
+
+      {data.gmail_url ? (
+        <a
+          href={data.gmail_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary inline-flex items-center gap-1 text-xs font-medium hover:underline"
+        >
+          Open in Gmail
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      ) : (
+        <p
+          className="text-muted-foreground text-xs"
+          title="No Message-ID was recorded for this send, so there is nothing to look up."
+        >
+          No Gmail link for this one
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/outreach/outreach-activity-panel.tsx
+++ b/src/components/outreach/outreach-activity-panel.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { ChevronRight, Mail } from "lucide-react";
+
+import { ActivityDetail } from "@/components/outreach/activity-detail";
+import { EmptyState } from "@/components/ui/empty-state";
+import { StatusPill } from "@/components/ui/status-pill";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { TogglePill } from "@/components/ui/toggle-pill";
+import { cn } from "@/lib/utils";
+import { filterActivity, type ActivityItem } from "@/lib/outreach/activity";
+import type { OutreachStatus } from "@/lib/outreach/status";
+
+/**
+ * Everything that has happened to your mail: what went out, what came back,
+ * and what did not send.
+ *
+ * Rows are master-detail on the pattern established by
+ * components/campaign/contacts-table.tsx: a Fragment per row, a Set of
+ * expanded ids, aria-expanded on the trigger and the detail in a full-width
+ * cell. That structure is already keyboard-accessible, so this inherits it.
+ */
+
+const FILTERS = [
+  { key: "all", label: "All" },
+  { key: "replied", label: "Replied" },
+  { key: "sent", label: "Sent" },
+  { key: "pending", label: "Waiting" },
+  { key: "failed", label: "Needs attention" },
+  { key: "bounced", label: "Bounced" },
+] as const;
+
+export type ActivityFilter = (typeof FILTERS)[number]["key"];
+
+interface Props {
+  items: ActivityItem[];
+  filter: ActivityFilter;
+  onFilterChange: (f: ActivityFilter) => void;
+  loading?: boolean;
+}
+
+export function OutreachActivityPanel({
+  items,
+  filter,
+  onFilterChange,
+  loading,
+}: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // The full set arrives from the page so the tab's reply count stays stable
+  // across chip clicks; narrowing happens here, with the same map the API
+  // uses server-side.
+  const shown = filterActivity(items, filter);
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {FILTERS.map((f) => (
+          <TogglePill
+            key={f.key}
+            active={filter === f.key}
+            onClick={() => onFilterChange(f.key)}
+          >
+            {f.label}
+          </TogglePill>
+        ))}
+      </div>
+
+      {shown.length === 0 ? (
+        <EmptyState
+          icon={Mail}
+          title={loading ? "Loading..." : "Nothing here yet"}
+          description={
+            loading
+              ? "Fetching your outbound mail."
+              : filter === "all"
+                ? "Once the agent sends an email it shows up here, along with anything that comes back."
+                : "No mail in this state right now."
+          }
+        />
+      ) : (
+        <div className="border-border overflow-hidden rounded-lg border">
+          <table className="w-full text-sm">
+            <tbody>
+              {shown.map((item) => {
+                const isOpen = expanded.has(item.id);
+                return (
+                  <Fragment key={item.id}>
+                    <tr
+                      className={cn(
+                        "border-border hover:bg-muted/40 cursor-pointer border-b transition-colors",
+                        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                      )}
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={isOpen}
+                      onClick={() => toggle(item.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          toggle(item.id);
+                        }
+                      }}
+                    >
+                      <td className="w-6 py-2 pl-3">
+                        <ChevronRight
+                          className={cn(
+                            "text-muted-foreground h-3.5 w-3.5 transition-transform",
+                            isOpen && "rotate-90",
+                          )}
+                        />
+                      </td>
+                      <td className="py-2 pr-3">
+                        <div className="flex flex-wrap items-baseline gap-x-2">
+                          <span className="font-medium">
+                            {item.person_name ?? item.to_email}
+                          </span>
+                          {item.company_name && (
+                            <span className="text-muted-foreground text-xs">
+                              {item.company_name}
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-muted-foreground truncate text-xs">
+                          {item.subject}
+                        </div>
+                        {/* The reply, visible without opening anything and
+                            without filtering. Replies being findable is the
+                            entire point of this surface. */}
+                        {item.state === "replied" &&
+                          (item.reply_snippet ? (
+                            <div className="text-foreground/80 mt-0.5 truncate text-xs">
+                              {item.reply_snippet}
+                            </div>
+                          ) : (
+                            <div className="text-muted-foreground mt-0.5 text-xs italic">
+                              Replied, content not captured
+                            </div>
+                          ))}
+                        {item.error && item.state !== "deferred" && (
+                          <div className="text-destructive/90 mt-0.5 truncate text-xs">
+                            {item.error.message}
+                          </div>
+                        )}
+                      </td>
+                      <td className="py-2 pr-3 text-right whitespace-nowrap">
+                        <StatusPill status={item.state as OutreachStatus} />
+                      </td>
+                      <td className="text-muted-foreground py-2 pr-3 text-right text-xs whitespace-nowrap">
+                        <RelativeTime iso={item.at} />
+                      </td>
+                    </tr>
+                    {isOpen && (
+                      <tr className="border-border bg-muted/20 border-b">
+                        <td colSpan={4}>
+                          <ActivityDetail id={item.id} error={item.error} />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/outreach/outreach-tabs.tsx
+++ b/src/components/outreach/outreach-tabs.tsx
@@ -9,12 +9,21 @@ import {
 } from "@/components/outreach/outreach-drafts-panel";
 import { SequenceList } from "@/components/outreach/sequence-list";
 import { SignalKanban } from "@/components/outreach/signal-kanban";
+import {
+  OutreachActivityPanel,
+  type ActivityFilter,
+} from "@/components/outreach/outreach-activity-panel";
+import type { ActivityItem } from "@/lib/outreach/activity";
 import type { EnrollmentCard, SequenceRow } from "@/app/outreach/page";
 
 interface OutreachTabsProps {
   drafts: DraftRow[];
   sequences: SequenceRow[];
   enrollments: EnrollmentCard[];
+  activity: ActivityItem[];
+  activityFilter: ActivityFilter;
+  onActivityFilterChange: (f: ActivityFilter) => void;
+  activityLoading?: boolean;
   onRefresh: () => void;
 }
 
@@ -22,9 +31,14 @@ export function OutreachTabs({
   drafts,
   sequences,
   enrollments,
+  activity,
+  activityFilter,
+  onActivityFilterChange,
+  activityLoading,
   onRefresh,
 }: OutreachTabsProps) {
   const [selectedSequence, setSelectedSequence] = useState<string | null>(null);
+  const replyCount = activity.filter((a) => a.state === "replied").length;
   const filteredEnrollments = selectedSequence
     ? enrollments.filter((e) => e.sequence_id === selectedSequence)
     : enrollments;
@@ -40,12 +54,31 @@ export function OutreachTabs({
             </span>
           )}
         </TabsTrigger>
+        <TabsTrigger value="sent">
+          Sent
+          {/* Counts REPLIES, not sends. Replies are the thing worth coming
+              back for; a count of how much mail left is not actionable. */}
+          {replyCount > 0 && (
+            <span className="text-muted-foreground ml-1 text-xs tabular-nums">
+              {replyCount}
+            </span>
+          )}
+        </TabsTrigger>
         <TabsTrigger value="pipeline">Pipeline</TabsTrigger>
         <TabsTrigger value="sequences">Sequences</TabsTrigger>
       </TabsList>
 
       <TabsContent value="inbox">
         <OutreachDraftsPanel drafts={drafts} onRefresh={onRefresh} />
+      </TabsContent>
+
+      <TabsContent value="sent">
+        <OutreachActivityPanel
+          items={activity}
+          filter={activityFilter}
+          onFilterChange={onActivityFilterChange}
+          loading={activityLoading}
+        />
       </TabsContent>
 
       <TabsContent value="pipeline">

--- a/src/components/ui/status-pill.tsx
+++ b/src/components/ui/status-pill.tsx
@@ -11,6 +11,9 @@ const TONE_STYLES: Record<OutreachTone, string> = {
   muted: "bg-muted text-muted-foreground",
   success: "bg-success/10 text-success",
   neutral: "bg-muted text-muted-foreground",
+  // Matches outreachStatusStyles.bounced in lib/status-styles.ts, so the two
+  // status vocabularies stay visually consistent while remaining separate.
+  danger: "bg-destructive/10 text-destructive",
 };
 
 interface StatusPillProps {

--- a/src/lib/email/html-to-plain.ts
+++ b/src/lib/email/html-to-plain.ts
@@ -35,6 +35,35 @@ function blockToNewlines(html: string): string {
 }
 
 /**
+ * Removes tags, repeating until the string stops changing.
+ *
+ * Being straight about what this is and is not:
+ *
+ * NOT a sanitizer, and nothing here may be used as one. These outputs become
+ * React text children, which React escapes, so markup surviving would render
+ * as visible text rather than an element. If a caller ever needs real HTML,
+ * the answer is a sandboxed iframe, not this.
+ *
+ * The loop is defence in depth, not a fix for a live hole. CodeQL flags a
+ * single-pass tag strip (js/incomplete-multi-character-sanitization) because
+ * removing an inner tag can reassemble an outer one. For THIS pattern that
+ * turns out not to happen -- `<scr<script>ipt>` becomes `ipt>` in one pass and
+ * a second pass changes nothing, which I checked rather than assumed. The loop
+ * earns its place by making that property hold for whatever the pattern
+ * becomes later, instead of resting on a hand-check of today's regex.
+ *
+ * Terminates because any pass that changes the string strictly shortens it.
+ */
+function stripTags(input: string): string {
+  let out = input;
+  for (;;) {
+    const next = out.replace(/<[^>]+>/g, "");
+    if (next === out) return out;
+    out = next;
+  }
+}
+
+/**
  * Lossy conversion used by the draft editor's round-trip.
  *
  * Anchors collapse to their text and the href is discarded. That is wrong for
@@ -47,9 +76,7 @@ function blockToNewlines(html: string): string {
  */
 export function htmlToPlain(html: string): string {
   if (!html) return "";
-  return decodeEntities(
-    blockToNewlines(html).replace(/<[^>]+>/g, ""),
-  ).trim();
+  return decodeEntities(stripTags(blockToNewlines(html))).trim();
 }
 
 /**
@@ -69,12 +96,12 @@ export function htmlToDisplayText(html: string): string {
   const withLinks = blockToNewlines(html).replace(
     /<a\b[^>]*href\s*=\s*["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
     (_match, href: string, inner: string) => {
-      const text = decodeEntities(inner.replace(/<[^>]+>/g, "")).trim();
+      const text = decodeEntities(stripTags(inner)).trim();
       const url = decodeEntities(href).trim();
       if (!url) return text;
       if (!text) return url;
       return text === url ? url : `${text} (${url})`;
     },
   );
-  return decodeEntities(withLinks.replace(/<[^>]+>/g, "")).trim();
+  return decodeEntities(stripTags(withLinks)).trim();
 }

--- a/src/lib/email/html-to-plain.ts
+++ b/src/lib/email/html-to-plain.ts
@@ -1,0 +1,80 @@
+/**
+ * Turning our own email HTML back into text.
+ *
+ * Two functions on purpose, because the two callers want different things and
+ * conflating them silently destroys links.
+ *
+ * `htmlToPlain` is the editor's half of a round-trip: the review page renders a
+ * draft into a textarea and re-serialises it with plainToHtml on save. It must
+ * stay lossy in exactly the way it always has been, because whatever it emits
+ * is what the user then edits and saves back.
+ *
+ * `htmlToDisplayText` is for read-only surfaces. It keeps a link's URL, which
+ * the editor's version throws away.
+ */
+
+const ENTITIES: Array<[RegExp, string]> = [
+  [/&nbsp;/g, " "],
+  [/&amp;/g, "&"],
+  [/&lt;/g, "<"],
+  [/&gt;/g, ">"],
+  [/&quot;/g, '"'],
+  [/&#39;/g, "'"],
+];
+
+function decodeEntities(s: string): string {
+  return ENTITIES.reduce((acc, [re, to]) => acc.replace(re, to), s);
+}
+
+function blockToNewlines(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
+    .replace(/<p[^>]*>/gi, "")
+    .replace(/<\/p>/gi, "");
+}
+
+/**
+ * Lossy conversion used by the draft editor's round-trip.
+ *
+ * Anchors collapse to their text and the href is discarded. That is wrong for
+ * display but right here: the output goes into a textarea, and preserving the
+ * URL inline would mean plainToHtml re-serialised it as literal text on save,
+ * permanently destroying the link.
+ *
+ * Moved out of outreach/review/page.tsx unchanged so both surfaces share one
+ * implementation.
+ */
+export function htmlToPlain(html: string): string {
+  if (!html) return "";
+  return decodeEntities(
+    blockToNewlines(html).replace(/<[^>]+>/g, ""),
+  ).trim();
+}
+
+/**
+ * Read-only conversion that keeps link targets.
+ *
+ * The composer is allowed to emit anchors (skill.ts permits <p>, <br> and <a>),
+ * so stripping tags blindly loses the URL entirely and a reader cannot tell
+ * where "book a time" pointed. Renders `<a href="X">Y</a>` as `Y (X)`, and as
+ * plain `X` when the text already is the URL, so a bare link does not come out
+ * as the useless `https://x (https://x)`.
+ *
+ * Never use this for the editor: `Y (X)` round-trips back through plainToHtml
+ * as literal text, which would destroy the anchor on the next save.
+ */
+export function htmlToDisplayText(html: string): string {
+  if (!html) return "";
+  const withLinks = blockToNewlines(html).replace(
+    /<a\b[^>]*href\s*=\s*["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    (_match, href: string, inner: string) => {
+      const text = decodeEntities(inner.replace(/<[^>]+>/g, "")).trim();
+      const url = decodeEntities(href).trim();
+      if (!url) return text;
+      if (!text) return url;
+      return text === url ? url : `${text} (${url})`;
+    },
+  );
+  return decodeEntities(withLinks.replace(/<[^>]+>/g, "")).trim();
+}

--- a/src/lib/jobs/executors/email-track.ts
+++ b/src/lib/jobs/executors/email-track.ts
@@ -3,11 +3,27 @@ import { decryptSecret } from "@/lib/crypto";
 import {
   classifyInboundMessage,
   fetchInboundSince,
+  fetchMessageText,
+  type InboundSummary,
 } from "@/lib/services/gmail-service";
 import {
   applyInboundStatus,
+  recordInboundReply,
+  replyDedupeKey,
   type TrackedEmail,
 } from "@/lib/services/email-tracking";
+import { stripQuotedReply } from "@/lib/services/email-test";
+
+/**
+ * Reply bodies downloaded per run, across all users.
+ *
+ * Each one is its own short-lived IMAP connection (fetchMessageText opens its
+ * own client on purpose). Gmail allows roughly 15 simultaneous connections per
+ * account, and the job runs inside a 300s budget, so this bounds a first run
+ * against a busy mailbox without starving the status updates that matter more.
+ * Anything skipped is picked up by the next poll ten minutes later.
+ */
+const MAX_BODY_FETCHES_PER_RUN = 25;
 
 /**
  * Reply/bounce tracking (recurring job, every 10 min). Polls each user's
@@ -25,6 +41,7 @@ import {
 export async function trackEmailReplies(): Promise<{
   checked: number;
   updated: number;
+  captured: number;
 }> {
   const supabase = getAdminClient();
 
@@ -35,7 +52,7 @@ export async function trackEmailReplies(): Promise<{
   const { data: emails, error } = await supabase
     .from("sent_emails")
     .select(
-      "id, message_id, campaign_people_id, user_id, status, sent_at, person_id, to_email",
+      "id, message_id, campaign_people_id, user_id, status, sent_at, person_id, to_email, campaign_id",
     )
     .in("status", ["sent", "delivered", "opened"])
     .gte("sent_at", windowStart)
@@ -43,7 +60,7 @@ export async function trackEmailReplies(): Promise<{
     .limit(100);
 
   if (error || !emails || emails.length === 0) {
-    return { checked: 0, updated: 0 };
+    return { checked: 0, updated: 0, captured: 0 };
   }
 
   // Load gmail credentials for the affected users
@@ -79,6 +96,30 @@ export async function trackEmailReplies(): Promise<{
   }
 
   let updated = 0;
+  let captured = 0;
+  let bodyFetches = 0;
+
+  // Replies already captured, so a re-poll never re-downloads a body it has.
+  // Loaded once for every candidate send rather than per user: without it,
+  // every 10-minute run opens a fresh IMAP connection for every reply inside
+  // the 14-day window, which is the single most expensive mistake available
+  // in this file.
+  const capturedKeys = new Set<string>();
+  {
+    const { data: existing } = await supabase
+      .from("email_replies")
+      .select("sent_email_id, dedupe_key, body_text")
+      .in(
+        "sent_email_id",
+        emails.map((e) => e.id),
+      );
+    for (const row of existing ?? []) {
+      // A row whose body was never captured is deliberately NOT counted as
+      // done: leaving it out lets a later poll retry the download that failed.
+      if (row.body_text)
+        capturedKeys.add(`${row.sent_email_id}|${row.dedupe_key}`);
+    }
+  }
 
   for (const [userId, userEmails] of emailsByUser) {
     const creds = credsByUser.get(userId);
@@ -97,19 +138,78 @@ export async function trackEmailReplies(): Promise<{
       userEmails[0].sent_at,
     );
 
+    let inbound: InboundSummary[];
     try {
-      const inbound = await fetchInboundSince(creds, new Date(oldest));
-      for (const message of inbound) {
-        const hit = classifyInboundMessage(message, pending, creds.address);
-        if (!hit) continue;
-        const email = userEmails.find((e) => e.id === hit.sentEmailId);
-        if (!email) continue;
-        if (await applyInboundStatus(supabase, email, hit.status)) updated++;
-      }
+      inbound = await fetchInboundSince(creds, new Date(oldest));
     } catch {
-      // One user's IMAP failure must not break the whole run
+      // One user's IMAP failure must not break the whole run.
+      continue;
+    }
+
+    // Phase 1: classify. Deliberately separate from the body downloads below.
+    // fetchInboundSince returns a fully-drained array today, but interleaving a
+    // download with the fetch generator deadlocks imapflow, and keeping the two
+    // phases textually apart is what stops a future refactor reintroducing it.
+    // See the regression test in gmail-imap.test.ts.
+    const hits: Array<{
+      email: TrackedEmail;
+      status: "replied" | "bounced";
+      message: InboundSummary;
+    }> = [];
+    for (const message of inbound) {
+      const hit = classifyInboundMessage(message, pending, creds.address);
+      if (!hit) continue;
+      const email = userEmails.find((e) => e.id === hit.sentEmailId);
+      if (!email) continue;
+      hits.push({ email, status: hit.status, message });
+    }
+
+    // Phase 2: apply status, then capture content. Each step is guarded on its
+    // own so a failure to store a reply body can never cost the status update,
+    // which is the more important of the two.
+    for (const { email, status, message } of hits) {
+      try {
+        if (await applyInboundStatus(supabase, email, status)) updated++;
+      } catch (err) {
+        console.error("[email-track] applyInboundStatus failed:", err);
+      }
+
+      const key = `${email.id}|${replyDedupeKey(message)}`;
+      if (capturedKeys.has(key)) continue;
+
+      let bodyText: string | null = null;
+      if (status === "bounced") {
+        // Already downloaded by fetchInboundSince to match the quoted
+        // Message-ID, so bounce capture costs nothing extra.
+        bodyText = message.bodyText || null;
+      } else if (
+        message.uid !== null &&
+        bodyFetches < MAX_BODY_FETCHES_PER_RUN
+      ) {
+        bodyFetches++;
+        try {
+          const raw = await fetchMessageText(creds, message.uid);
+          bodyText = raw ? stripQuotedReply(raw) : null;
+        } catch (err) {
+          // A missing body is cosmetic. The row is still worth storing, and
+          // leaving body_text null lets a later poll retry the download.
+          console.error("[email-track] fetchMessageText failed:", err);
+        }
+      }
+
+      if (
+        await recordInboundReply(supabase, {
+          email,
+          message,
+          kind: status === "bounced" ? "bounce" : "reply",
+          bodyText,
+        })
+      ) {
+        captured++;
+        if (bodyText) capturedKeys.add(key);
+      }
     }
   }
 
-  return { checked: emails.length, updated };
+  return { checked: emails.length, updated, captured };
 }

--- a/src/lib/jobs/executors/index.ts
+++ b/src/lib/jobs/executors/index.ts
@@ -5,6 +5,7 @@ import {
   processOutreach,
   type Payload,
 } from "@/lib/jobs/executors/outreach-process";
+import { backfillReplyBodies } from "@/lib/jobs/executors/reply-backfill";
 import { dispatchDueTracking } from "@/lib/jobs/executors/tracking-dispatch";
 import { runTrackingConfig } from "@/lib/jobs/executors/tracking-run";
 
@@ -17,6 +18,8 @@ export type JobExecutor = (
 export const executors: Record<string, JobExecutor> = {
   "email.track": () => trackEmailReplies(),
   "email.cleanup": () => cleanupEmails(),
+  // One-shot, not recurring. Re-enqueues itself while work remains, capped.
+  "email.backfill-replies": (payload) => backfillReplyBodies(payload),
   "tracking.dispatch": () => dispatchDueTracking(),
   "outreach.process": (payload) =>
     processOutreach(payload as unknown as Payload),

--- a/src/lib/jobs/executors/reply-backfill.ts
+++ b/src/lib/jobs/executors/reply-backfill.ts
@@ -1,0 +1,237 @@
+import { getAdminClient } from "@/lib/supabase/admin";
+import { decryptSecret } from "@/lib/crypto";
+import {
+  classifyInboundMessage,
+  fetchInboundSince,
+  fetchMessageText,
+  type InboundSummary,
+} from "@/lib/services/gmail-service";
+import {
+  recordInboundReply,
+  replyDedupeKey,
+  type TrackedEmail,
+} from "@/lib/services/email-tracking";
+import { stripQuotedReply } from "@/lib/services/email-test";
+import { enqueueJob } from "@/lib/services/jobs";
+
+/**
+ * One-shot backfill of reply content for replies that were matched before
+ * capture existed.
+ *
+ * Before 20260803000000 the tracker matched an inbound message, wrote
+ * "replied" onto sent_emails.status and threw the message away. Those rows now
+ * show a reply with no words, which is honest but unhelpful, so this walks
+ * back over them once and fills in what it can still find.
+ *
+ * WHAT IT CANNOT RECOVER, and this matters more than what it can:
+ *
+ *   - The historical tracker only ever considered sends inside a 14-day
+ *     window, 100 rows per run. A reply to an older send, or one that lost the
+ *     limit-100 race, was never matched at all: its status is still 'sent', so
+ *     it is not in the candidate set here either and never will be.
+ *   - fetchInboundSince searches INBOX only. Anything the user has since
+ *     archived, deleted or filtered out is gone as far as this is concerned.
+ *
+ * So a materially incomplete result is the expected outcome, not a bug. The
+ * body_text IS NULL state in the UI is permanent for a real share of rows.
+ *
+ * Runs as a one-shot job that re-enqueues itself while work remains. One-shot
+ * rows are NOT covered by idx_jobs_one_recurring_per_type, so nothing in the
+ * database stops a runaway loop: MAX_PASSES is the only backstop and has to
+ * stay.
+ */
+
+/** Users processed per pass. Each costs one IMAP envelope scan. */
+const USERS_PER_PASS = 10;
+/** Bodies downloaded per pass, across all users. One connection each. */
+const MAX_BODY_FETCHES = 50;
+/** Sends considered. Older than this and the historical tracker never saw it. */
+const LOOKBACK_DAYS = 30;
+/** The only thing preventing an unbounded re-enqueue loop. */
+const MAX_PASSES = 20;
+
+interface BackfillResult {
+  pass: number;
+  users: number;
+  filled: number;
+  remaining: number;
+  requeued: boolean;
+}
+
+export async function backfillReplyBodies(
+  payload: Record<string, unknown> = {},
+): Promise<BackfillResult> {
+  const pass = typeof payload.pass === "number" ? payload.pass : 1;
+  const supabase = getAdminClient();
+
+  const windowStart = new Date(
+    Date.now() - LOOKBACK_DAYS * 86400_000,
+  ).toISOString();
+
+  // Candidates: a send that reached a terminal state, whose reply we either
+  // never stored or stored without a body.
+  const { data: emails } = await supabase
+    .from("sent_emails")
+    .select(
+      "id, message_id, campaign_people_id, user_id, status, sent_at, person_id, to_email, campaign_id, " +
+        "email_replies(id, body_text)",
+    )
+    .in("status", ["replied", "bounced"])
+    .gte("sent_at", windowStart)
+    .order("sent_at", { ascending: false })
+    .limit(500);
+
+  // Typed by hand: PostgREST's inference gives up on the embed and widens the
+  // whole result to an error type.
+  type CandidateRow = TrackedEmail & {
+    email_replies: Array<{ id: string; body_text: string | null }> | null;
+  };
+
+  const needsBody = ((emails ?? []) as unknown as CandidateRow[]).filter(
+    (e) => {
+      const replies = e.email_replies ?? [];
+      // Nothing stored at all, or stored without words. Either is a candidate;
+      // a row that already has a body is done and must not be re-downloaded.
+      return replies.length === 0 || replies.every((r) => !r.body_text);
+    },
+  ) as TrackedEmail[];
+
+  if (needsBody.length === 0) {
+    return { pass, users: 0, filled: 0, remaining: 0, requeued: false };
+  }
+
+  const byUser = new Map<string, TrackedEmail[]>();
+  for (const e of needsBody) {
+    const list = byUser.get(e.user_id) ?? [];
+    list.push(e);
+    byUser.set(e.user_id, list);
+  }
+
+  const userIds = [...byUser.keys()].slice(0, USERS_PER_PASS);
+  const { data: settingsRows } = await supabase
+    .from("user_settings")
+    .select("user_id, gmail_address, gmail_app_password_enc")
+    .in("user_id", userIds);
+
+  const credsByUser = new Map<
+    string,
+    { address: string; appPassword: string }
+  >();
+  for (const row of settingsRows ?? []) {
+    if (row.gmail_address && row.gmail_app_password_enc) {
+      try {
+        credsByUser.set(row.user_id, {
+          address: row.gmail_address,
+          appPassword: decryptSecret(row.gmail_app_password_enc),
+        });
+      } catch {
+        // Rotated EMAIL_CREDENTIALS_KEY. Nothing to do until they reconnect.
+      }
+    }
+  }
+
+  let filled = 0;
+  let bodyFetches = 0;
+
+  for (const userId of userIds) {
+    const creds = credsByUser.get(userId);
+    const userEmails = byUser.get(userId) ?? [];
+    if (!creds || userEmails.length === 0) continue;
+
+    const pending = new Map<string, string>();
+    for (const e of userEmails) {
+      if (e.message_id?.startsWith("<")) pending.set(e.message_id, e.id);
+    }
+    if (pending.size === 0) continue;
+
+    const oldest = userEmails.reduce(
+      (min, e) => (e.sent_at < min ? e.sent_at : min),
+      userEmails[0].sent_at,
+    );
+
+    // Replays the tracker: UIDs were never persisted and there is no thread
+    // id, so the only way back to a message is to re-scan and re-match it.
+    let inbound: InboundSummary[];
+    try {
+      inbound = await fetchInboundSince(creds, new Date(oldest));
+    } catch {
+      continue;
+    }
+
+    // Same two-phase shape as email-track, and for the same reason: a download
+    // must never be interleaved with the fetch generator.
+    const hits: Array<{
+      email: TrackedEmail;
+      status: "replied" | "bounced";
+      message: InboundSummary;
+    }> = [];
+    for (const message of inbound) {
+      const hit = classifyInboundMessage(message, pending, creds.address);
+      if (!hit) continue;
+      const email = userEmails.find((e) => e.id === hit.sentEmailId);
+      if (email) hits.push({ email, status: hit.status, message });
+    }
+
+    for (const { email, status, message } of hits) {
+      if (bodyFetches >= MAX_BODY_FETCHES) break;
+
+      let bodyText: string | null = null;
+      if (status === "bounced") {
+        bodyText = message.bodyText || null;
+      } else if (message.uid !== null) {
+        bodyFetches++;
+        try {
+          const raw = await fetchMessageText(creds, message.uid);
+          bodyText = raw ? stripQuotedReply(raw) : null;
+        } catch {
+          // Leave it null; the row stays a candidate for a later pass.
+        }
+      }
+      if (!bodyText) continue;
+
+      // The row may already exist without a body, so update rather than
+      // relying on the insert path's conflict-ignore, which would no-op.
+      const dedupeKey = replyDedupeKey(message);
+      const { data: existing } = await supabase
+        .from("email_replies")
+        .select("id")
+        .eq("sent_email_id", email.id)
+        .eq("dedupe_key", dedupeKey)
+        .maybeSingle();
+
+      if (existing) {
+        const { error } = await supabase
+          .from("email_replies")
+          .update({ body_text: bodyText, imap_uid: message.uid })
+          .eq("id", existing.id);
+        if (!error) filled++;
+      } else if (
+        await recordInboundReply(supabase, {
+          email,
+          message,
+          kind: status === "bounced" ? "bounce" : "reply",
+          bodyText,
+        })
+      ) {
+        filled++;
+      }
+    }
+  }
+
+  const remaining = Math.max(needsBody.length - filled, 0);
+  // Re-enqueue while there is work AND we are under the pass cap. The delay
+  // keeps a stuck mailbox from spinning the queue.
+  const requeued = remaining > 0 && pass < MAX_PASSES;
+  if (requeued) {
+    await enqueueJob({
+      type: "email.backfill-replies",
+      payload: { pass: pass + 1 },
+      runAt: new Date(Date.now() + 120_000),
+      // No retries. A failed pass just means the next one picks the same
+      // candidates back up, and retrying would double-scan a mailbox.
+      maxAttempts: 1,
+    });
+  }
+
+  return { pass, users: userIds.length, filled, remaining, requeued };
+}

--- a/src/lib/outreach/activity.ts
+++ b/src/lib/outreach/activity.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure helpers for the outreach activity feed.
+ *
+ * No React and no Supabase, so the interesting logic (which state a row is in,
+ * where "Open in Gmail" points) is unit-testable without jsdom or a database.
+ */
+
+/**
+ * What a row in the feed is doing right now.
+ *
+ * `sent` rows come from sent_emails; the rest come from email_drafts that have
+ * no sent_emails row yet, which is exactly why queued, scheduled and failed
+ * mail is invisible in the product today.
+ */
+export type ActivityState =
+  | "replied"
+  | "bounced"
+  | "sent"
+  | "queued"
+  | "scheduled"
+  | "deferred"
+  | "blocked"
+  | "failed";
+
+export interface ActivityReply {
+  kind: "reply" | "bounce";
+  from_email: string;
+  subject: string;
+  received_at: string;
+  body_text: string | null;
+}
+
+export interface ActivityItem {
+  id: string;
+  source: "sent" | "pending";
+  state: ActivityState;
+  person_name: string | null;
+  person_title: string | null;
+  company_name: string | null;
+  to_email: string;
+  subject: string;
+  /** Sort key: newest reply, else sent_at, else the scheduled send time. */
+  at: string;
+  sent_at: string | null;
+  next_send_at: string | null;
+  reply_count: number;
+  reply_snippet: string | null;
+  /**
+   * False when a reply arrived but its words were never captured. Distinct
+   * from an empty reply, and the row has to say so rather than showing blank.
+   */
+  reply_captured: boolean;
+  error: { kind: string; message: string; at: string } | null;
+  gmail_url: string | null;
+}
+
+/** First line or so of a reply, for the collapsed row. */
+export const SNIPPET_CHARS = 180;
+
+export function replySnippet(body: string | null): string | null {
+  if (!body) return null;
+  const oneLine = body.replace(/\s+/g, " ").trim();
+  if (!oneLine) return null;
+  return oneLine.length > SNIPPET_CHARS
+    ? oneLine.slice(0, SNIPPET_CHARS).trimEnd() + "…"
+    : oneLine;
+}
+
+/**
+ * The state of a row that came from sent_emails.
+ *
+ * sent_emails.status only ever holds 'sent', 'replied' or 'bounced' in
+ * practice; anything else is a legacy value and reads as plain sent.
+ */
+export function classifySent(status: string): ActivityState {
+  if (status === "replied") return "replied";
+  if (status === "bounced") return "bounced";
+  return "sent";
+}
+
+/**
+ * The state of a row that came from email_drafts and has not sent.
+ *
+ * The error kind wins when there is one, because "why it did not send" is more
+ * useful than "it is waiting". Note `deferred` is deliberately its own state
+ * and not a failure: hitting the daily cap is routine, and showing it as
+ * failed would bury the two kinds that need attention.
+ */
+export function classifyPending(draft: {
+  status: string;
+  last_error_kind: string | null;
+  next_send_at: string | null;
+}): ActivityState {
+  if (draft.last_error_kind === "failed") return "failed";
+  if (draft.last_error_kind === "blocked") return "blocked";
+  if (draft.last_error_kind === "deferred") return "deferred";
+  if (draft.status === "queued") return "queued";
+  return draft.next_send_at ? "scheduled" : "queued";
+}
+
+/**
+ * A link that opens this exact message in Gmail.
+ *
+ * There is no thread id to work with: agentmail_thread_id was dropped in
+ * 20260730000001 and nothing replaced it. `rfc822msgid:` is the remaining
+ * handle, and it is enough, because Gmail threads on References, so resolving
+ * the *sent* message lands the reader in the conversation with the replies.
+ *
+ * Two details that are behaviour, not decoration:
+ *
+ * - Angle brackets are stripped. Gmail tolerates them inconsistently.
+ * - `authuser=<from address>` rather than `/u/0/`. We know which mailbox sent
+ *   this, and /u/0 is whichever Google account the reader happened to sign
+ *   into first, which for anyone with a personal and a work account is a coin
+ *   flip that lands on "no results".
+ *
+ * Returns null when there is no Message-ID. Deliberately does NOT fall back to
+ * a subject search: on a cold email that is a shotgun, and silently opening
+ * the wrong thread is worse than opening nothing.
+ */
+export function gmailSearchUrl(
+  messageId: string | null,
+  fromEmail: string | null,
+): string | null {
+  if (!messageId) return null;
+  const bare = messageId.replace(/^</, "").replace(/>$/, "").trim();
+  if (!bare) return null;
+  const query = encodeURIComponent(`rfc822msgid:${bare}`);
+  const account = fromEmail ? `?authuser=${encodeURIComponent(fromEmail)}` : "";
+  return `https://mail.google.com/mail/u/${account}#search/${query}`;
+}

--- a/src/lib/outreach/activity.ts
+++ b/src/lib/outreach/activity.ts
@@ -54,6 +54,33 @@ export interface ActivityItem {
   gmail_url: string | null;
 }
 
+/**
+ * The filters the UI offers, and the states each one covers.
+ *
+ * Shared by the API route and the panel on purpose. The list is fetched
+ * unfiltered and narrowed in the client, so if these two disagreed the chip
+ * counts and the rows behind them would drift apart.
+ *
+ * "Needs attention" folds blocked in with failed because both are waiting on
+ * the user; deferred is deliberately filed under "waiting" instead, since the
+ * daily cap resolves itself tomorrow.
+ */
+export const FILTER_STATES: Record<string, ActivityState[]> = {
+  replied: ["replied"],
+  bounced: ["bounced"],
+  sent: ["sent"],
+  pending: ["queued", "scheduled", "deferred"],
+  failed: ["failed", "blocked"],
+};
+
+export function filterActivity(
+  items: ActivityItem[],
+  filter: string,
+): ActivityItem[] {
+  const wanted = FILTER_STATES[filter];
+  return wanted ? items.filter((i) => wanted.includes(i.state)) : items;
+}
+
 /** First line or so of a reply, for the collapsed row. */
 export const SNIPPET_CHARS = 180;
 

--- a/src/lib/outreach/status.ts
+++ b/src/lib/outreach/status.ts
@@ -1,4 +1,10 @@
-export type OutreachTone = "primary" | "warn" | "muted" | "success" | "neutral";
+export type OutreachTone =
+  | "primary"
+  | "warn"
+  | "muted"
+  | "success"
+  | "neutral"
+  | "danger";
 
 export interface OutreachStatusDef {
   label: string;
@@ -41,6 +47,38 @@ export const OUTREACH_STATUS = {
     label: "Rejected",
     description: "Won't send; here for reference",
     tone: "neutral",
+  },
+  // ── states the activity feed adds ────────────────────────────────────────
+  // These describe a piece of mail rather than a review decision, which is why
+  // they live here beside the others rather than in status-styles.ts: that map
+  // renders the campaign_people.outreach_status enum, and these are not values
+  // of it.
+  bounced: {
+    label: "Bounced",
+    description: "The address rejected it; verification was cleared",
+    tone: "danger",
+  },
+  queued: {
+    label: "Queued",
+    description: "Claimed and about to go out",
+    tone: "muted",
+  },
+  scheduled: {
+    label: "Scheduled",
+    description: "Approved, waiting for its send time",
+    tone: "muted",
+  },
+  // Deliberately muted, not danger. Hitting the daily cap is routine, and the
+  // draft goes out tomorrow on its own.
+  deferred: {
+    label: "Deferred",
+    description: "Daily send limit reached; will go tomorrow",
+    tone: "muted",
+  },
+  failed: {
+    label: "Failed",
+    description: "The send errored and can be retried",
+    tone: "danger",
   },
 } as const satisfies Record<string, OutreachStatusDef>;
 

--- a/src/lib/services/email-test.ts
+++ b/src/lib/services/email-test.ts
@@ -63,19 +63,24 @@ export interface TestReply {
   uid: number | null;
 }
 
-/** Longest reply excerpt we store and render. */
+/** Longest reply excerpt the Settings test card stores and renders. */
 export const REPLY_SNIPPET_MAX = 400;
 
 /**
- * Reduces a raw text/plain reply body to just what the person actually typed.
+ * Reduces a raw text/plain reply body to just what the person actually typed,
+ * at full length.
  *
  * Mail clients append the entire quoted original below an attribution line, so
  * a two-word reply arrives as several hundred characters of our own copy. We
  * drop everything from the attribution onwards, plus any quoted ">" lines,
- * which is what makes the excerpt readable proof that the reply is genuinely
- * theirs rather than an echo of the test we sent.
+ * which is what makes the result readable proof that the reply is genuinely
+ * theirs rather than an echo of what we sent.
+ *
+ * Split out of extractReplyText so reply capture can store a whole reply while
+ * the Settings test card keeps its 400-character excerpt. Truncation is the
+ * caller's decision, not this function's.
  */
-export function extractReplyText(raw: string): string {
+export function stripQuotedReply(raw: string): string {
   const lines = raw.replace(/\r\n/g, "\n").split("\n");
   const kept: string[] = [];
 
@@ -88,10 +93,20 @@ export function extractReplyText(raw: string): string {
     kept.push(line);
   }
 
-  const text = kept
+  return kept
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+/**
+ * The Settings test card's excerpt: stripped, then capped.
+ *
+ * Behaviour is unchanged from before the split, which its existing tests
+ * assert. Reply capture deliberately does not use this.
+ */
+export function extractReplyText(raw: string): string {
+  const text = stripQuotedReply(raw);
   return text.length > REPLY_SNIPPET_MAX
     ? text.slice(0, REPLY_SNIPPET_MAX).trimEnd() + "…"
     : text;

--- a/src/lib/services/email-tracking.ts
+++ b/src/lib/services/email-tracking.ts
@@ -22,6 +22,12 @@ export interface TrackedEmail {
   /** Both needed to attribute a bounce back to a contact and address. */
   person_id: string | null;
   to_email: string | null;
+  /**
+   * Needed by recordInboundReply: email_replies.campaign_id is NOT NULL
+   * because its select policy is transitive through campaigns, so a row
+   * without one would be invisible to its own owner.
+   */
+  campaign_id: string;
 }
 
 export const STATUS_EVENT: Record<string, string> = {
@@ -100,4 +106,100 @@ export async function applyInboundStatus(
   }
 
   return true;
+}
+
+/** The fields of an inbound message that identify it, for deduping. */
+export interface InboundIdentity {
+  messageId: string | null;
+  uid: number | null;
+  fromAddress: string;
+  date: Date | null;
+  subject: string;
+}
+
+/**
+ * A stable identity for one inbound message, scoped to the send it answers.
+ *
+ * The tracker re-polls the same 14-day window every 10 minutes, so the same
+ * reply is re-matched dozens of times and something has to make the insert
+ * idempotent. The status ladder cannot: it is about status, and a *second*
+ * genuine reply in a thread fails it (replied -> replied) while still needing
+ * to be stored.
+ *
+ * Preference order matters:
+ *   1. The sender's own Message-ID. Globally unique by spec and stable across
+ *      mailbox rebuilds.
+ *   2. The IMAP UID. Unique only within a UIDVALIDITY generation, so a rebuilt
+ *      mailbox can renumber it and re-admit a duplicate. Acceptable fallback,
+ *      never a first choice.
+ *   3. Sender, timestamp and subject. Last resort for a sender that omits the
+ *      header and a fetch that lost the UID. Two distinct replies sent in the
+ *      same second with the same subject would collide, which is a far better
+ *      failure than storing the same reply forever.
+ */
+export function replyDedupeKey(m: InboundIdentity): string {
+  if (m.messageId) return m.messageId;
+  if (m.uid !== null) return `uid:${m.uid}`;
+  return `${m.fromAddress.toLowerCase()}|${m.date?.getTime() ?? 0}|${m.subject}`;
+}
+
+/**
+ * Stores the content of one inbound reply or bounce.
+ *
+ * Three rules, all deliberate:
+ *
+ * - Called INDEPENDENTLY of applyInboundStatus's return value. Gating on it
+ *   would mean the second reply in a thread is never stored, and a transient
+ *   body-fetch failure could never be retried on a later poll.
+ * - Never throws upward. Losing a reply body must not cost the status update,
+ *   matching the recordBounce precedent above.
+ * - Writes body_text: null rather than "" when nothing was captured, so
+ *   "we never got the words" stays distinguishable from "they sent an empty
+ *   reply". The UI and the backfill both depend on that distinction.
+ *
+ * Returns true when a row was actually inserted.
+ */
+export async function recordInboundReply(
+  supabase: SupabaseClient,
+  params: {
+    email: TrackedEmail;
+    message: InboundIdentity;
+    kind: "reply" | "bounce";
+    bodyText: string | null;
+  },
+): Promise<boolean> {
+  const { email, message, kind, bodyText } = params;
+  try {
+    const { data, error } = await supabase
+      .from("email_replies")
+      .upsert(
+        {
+          sent_email_id: email.id,
+          user_id: email.user_id,
+          campaign_id: email.campaign_id,
+          person_id: email.person_id,
+          kind,
+          from_email: message.fromAddress,
+          subject: message.subject ?? "",
+          message_id: message.messageId,
+          imap_uid: message.uid,
+          body_text: bodyText && bodyText.length > 0 ? bodyText : null,
+          received_at: (message.date ?? new Date()).toISOString(),
+          dedupe_key: replyDedupeKey(message),
+        },
+        { onConflict: "sent_email_id,dedupe_key", ignoreDuplicates: true },
+      )
+      .select("id");
+
+    if (error) {
+      console.error("[email-tracking] recordInboundReply failed:", error);
+      return false;
+    }
+    // ignoreDuplicates returns zero rows when the conflict target already
+    // existed, which is the steady state on every poll after the first.
+    return (data?.length ?? 0) > 0;
+  } catch (err) {
+    console.error("[email-tracking] recordInboundReply threw:", err);
+    return false;
+  }
 }

--- a/src/lib/services/gmail-service.ts
+++ b/src/lib/services/gmail-service.ts
@@ -109,6 +109,15 @@ export interface InboundSummary {
   date: Date | null;
   /** IMAP UID, so a caller can fetch this message's body later. */
   uid: number | null;
+  /**
+   * This message's OWN RFC 5322 Message-ID (not the one it replies to).
+   *
+   * The envelope is already requested, so reading it costs nothing extra. It
+   * is what email_replies dedupes on: the tracker re-polls the same 14-day
+   * window every 10 minutes, and a sender-supplied id is the only key that
+   * survives a mailbox rebuild renumbering UIDs.
+   */
+  messageId: string | null;
 }
 
 /**
@@ -158,6 +167,7 @@ export async function fetchInboundSince(
           subject: msg.envelope?.subject ?? "",
           date: msg.envelope?.date ?? null,
           uid: msg.uid ?? null,
+          messageId: msg.envelope?.messageId?.trim() || null,
         });
         if (isDaemon && msg.uid) {
           daemonDownloads.push({ uid: msg.uid, index: results.length - 1 });

--- a/src/lib/services/outreach-sender.ts
+++ b/src/lib/services/outreach-sender.ts
@@ -43,6 +43,57 @@ export type SendResult =
   | { ok: false; reason: string };
 
 /**
+ * Why a send did not happen, classified at the point of refusal.
+ *
+ * `deferred` is the important one to keep separate. Hitting the daily cap is
+ * the most common non-send and is completely normal, so folding it in with
+ * real failures would fill the failed list with noise within a week of any new
+ * mailbox connecting, and the user would stop reading it.
+ */
+export type SendErrorKind = "deferred" | "blocked" | "failed";
+
+/**
+ * Records why a draft did not send, so the reason survives to the UI.
+ *
+ * These sentences are already written for a person to read ("Not sending to
+ * x@y.com: ...", "Draft is addressed to ... but the contact's verified address
+ * on file is ..."). Storing them verbatim beats paraphrasing at read time.
+ *
+ * Never throws: bookkeeping about a refusal must not become a second failure
+ * on top of it, matching how recordBounce is treated in email-tracking.
+ */
+async function recordSendFailure(
+  supabase: SupabaseClient,
+  draftId: string,
+  kind: SendErrorKind,
+  reason: string,
+): Promise<void> {
+  try {
+    await supabase
+      .from("email_drafts")
+      .update({
+        last_error: reason,
+        last_error_at: new Date().toISOString(),
+        last_error_kind: kind,
+      })
+      .eq("id", draftId);
+  } catch (err) {
+    console.error("[outreach-sender] recordSendFailure failed:", err);
+  }
+}
+
+/** Refuse, and leave the reason on the draft for the user to act on. */
+async function refuse(
+  supabase: SupabaseClient,
+  draftId: string,
+  kind: SendErrorKind,
+  reason: string,
+): Promise<{ ok: false; reason: string }> {
+  await recordSendFailure(supabase, draftId, kind, reason);
+  return { ok: false, reason };
+}
+
+/**
  * The one path an email leaves through. Enforces the warmup-ramped daily
  * cap, claims the draft atomically, sends via the user's Gmail, and does the
  * bookkeeping. Every sender — the followups cron, send-now, and the agent's
@@ -82,10 +133,12 @@ export async function claimAndSendDraft(
     // that a database hiccup disables. Not sending is always recoverable;
     // sending is not.
     if (personError || !person) {
-      return {
-        ok: false,
-        reason: `Not sending to ${draft.to_email}: could not load the contact to check it (${personError?.message ?? "no such person"}).`,
-      };
+      return refuse(
+        supabase,
+        draft.id,
+        "failed",
+        `Not sending to ${draft.to_email}: could not load the contact to check it (${personError?.message ?? "no such person"}).`,
+      );
     }
 
     // Just-in-time verification — the only place provider credits are spent.
@@ -115,10 +168,12 @@ export async function claimAndSendDraft(
       if (jit.outcome !== "verified") {
         // blocked and unavailable both refuse; only `blocked` wrote a verdict.
         // Unavailable is retryable — the next attempt re-checks for free.
-        return {
-          ok: false,
-          reason: `Not sending to ${draft.to_email}: ${jit.reason}.`,
-        };
+        return refuse(
+          supabase,
+          draft.id,
+          "blocked",
+          `Not sending to ${draft.to_email}: ${jit.reason}.`,
+        );
       }
 
       // The service just wrote verification (and possibly an affiliation
@@ -131,20 +186,24 @@ export async function claimAndSendDraft(
         .eq("id", draft.person_id)
         .maybeSingle();
       if (refreshError || !refreshed) {
-        return {
-          ok: false,
-          reason: `Not sending to ${draft.to_email}: could not re-read the contact after verification (${refreshError?.message ?? "no such person"}).`,
-        };
+        return refuse(
+          supabase,
+          draft.id,
+          "failed",
+          `Not sending to ${draft.to_email}: could not re-read the contact after verification (${refreshError?.message ?? "no such person"}).`,
+        );
       }
       gated = refreshed as unknown as typeof gated;
     }
 
     const check = canSendTo(gated);
     if (!check.ok) {
-      return {
-        ok: false,
-        reason: `Not sending to ${draft.to_email}: ${check.reason}.`,
-      };
+      return refuse(
+        supabase,
+        draft.id,
+        "blocked",
+        `Not sending to ${draft.to_email}: ${check.reason}.`,
+      );
     }
 
     // The gate's verdict is about the person's address on file — but the mail
@@ -159,10 +218,12 @@ export async function claimAndSendDraft(
       personEmail &&
       draft.to_email.toLowerCase() !== personEmail.toLowerCase()
     ) {
-      return {
-        ok: false,
-        reason: `Draft is addressed to ${draft.to_email}, but the contact's verified address on file is ${personEmail}. Regenerate the draft so it uses the current address.`,
-      };
+      return refuse(
+        supabase,
+        draft.id,
+        "blocked",
+        `Draft is addressed to ${draft.to_email}, but the contact's verified address on file is ${personEmail}. Regenerate the draft so it uses the current address.`,
+      );
     }
   }
 
@@ -206,12 +267,14 @@ export async function claimAndSendDraft(
       .update({ status: "draft", updated_at: new Date().toISOString() })
       .eq("id", draft.id)
       .eq("status", "queued");
-    return {
-      ok: false,
-      reason: `Daily send limit reached (${effectiveLimit}/day${
+    return refuse(
+      supabase,
+      draft.id,
+      "deferred",
+      `Daily send limit reached (${effectiveLimit}/day${
         effectiveLimit < sender.dailyLimit ? ", warmup ramp" : ""
       }), draft left for tomorrow`,
-    };
+    );
   }
 
   // Only a failure of the send itself releases the claim. Once the email has
@@ -242,7 +305,7 @@ export async function claimAndSendDraft(
       .eq("status", "queued");
 
     const reason = err instanceof Error ? err.message : "Send failed";
-    return { ok: false, reason };
+    return refuse(supabase, draft.id, "failed", reason);
   }
 
   // message_id is the RFC 5322 Message-ID — the key IMAP reply/bounce
@@ -297,7 +360,17 @@ export async function claimAndSendDraft(
 
   await supabase
     .from("email_drafts")
-    .update({ status: "sent", sent_at: now, updated_at: now })
+    .update({
+      status: "sent",
+      sent_at: now,
+      updated_at: now,
+      // Clear any earlier refusal. A draft that was blocked on Monday for an
+      // unverified address and sends on Tuesday must not keep showing the
+      // Monday reason next to a sent email.
+      last_error: null,
+      last_error_at: null,
+      last_error_kind: null,
+    })
     .eq("id", draft.id);
 
   if (draft.campaign_people_id) {

--- a/supabase/migrations/20260803000000_reply_capture.sql
+++ b/supabase/migrations/20260803000000_reply_capture.sql
@@ -1,0 +1,102 @@
+-- Reply capture: store the content of inbound replies and bounces
+-- 2026-08-03
+--
+-- Until now the reply pipeline threw away everything it learned. email-track
+-- matched an inbound message to a send, wrote the single word "replied" onto
+-- sent_emails.status and campaign_people.outreach_status, and dropped the
+-- from-address, the subject, the date and the words the person actually typed
+-- on the floor: classifyInboundMessage returns only {status, sentEmailId}, so
+-- the message never survives the classifier boundary. Worse, reply bodies were
+-- never fetched at all -- fetchInboundSince downloads a body only for
+-- mailer-daemon mail, purely so a bounce report can be matched on a quoted
+-- Message-ID. A user could see THAT someone replied and could not see WHAT
+-- they said, anywhere in the product.
+--
+-- One row per inbound message rather than per send: a thread can carry several
+-- replies, and each is its own artifact with its own timestamp and body.
+--
+-- IDEMPOTENCY. email.track re-polls every 600s over a 14-day window, so the
+-- same inbound message is re-matched dozens of times. sent_emails.status is
+-- protected by the monotonic STATUS_PRIORITY ladder in email-tracking.ts, but
+-- that guard is about status and cannot protect a row insert -- and must not be
+-- borrowed for one, because a SECOND reply in the same thread also fails the
+-- ladder (replied -> replied) while genuinely needing to be stored. So this
+-- table carries its own key: the inbound message's own RFC 5322 Message-ID,
+-- which the IMAP envelope already supplies at no extra cost. Writers upsert on
+-- (sent_email_id, dedupe_key) and ignore duplicates; they never consult the
+-- status ladder.
+create table if not exists email_replies (
+  id uuid primary key default gen_random_uuid(),
+  sent_email_id uuid not null references sent_emails(id) on delete cascade,
+
+  -- Denormalised from sent_emails so the feed can filter and RLS can scope
+  -- without a join on every read. Clerk ids are text (20260427000000).
+  user_id text not null,
+  -- NOT NULL on purpose. The select policy below is transitive through
+  -- campaigns, so a null campaign_id would make a row invisible to its own
+  -- owner. Every sent_emails row has one, so there is nothing to relax.
+  campaign_id uuid not null references campaigns(id) on delete cascade,
+  person_id uuid references people(id) on delete set null,
+
+  kind text not null check (kind in ('reply', 'bounce')),
+  from_email text not null,
+  subject text not null default '',
+
+  -- The inbound message's own Message-ID. Nullable because a minority of
+  -- senders omit the header; dedupe_key always has a value regardless.
+  message_id text,
+  -- IMAP UID at capture time, so a later re-fetch does not have to re-scan the
+  -- mailbox. NOT a key: UIDs are unique only within a mailbox's UIDVALIDITY
+  -- generation, and a mailbox rebuild silently renumbers them.
+  imap_uid bigint,
+
+  -- Plain text only, quoted history and attribution already stripped. Never
+  -- HTML: nothing in this app renders email HTML, and adding a sanitizer to do
+  -- it would put a new dependency directly in the blast radius of text written
+  -- by strangers.
+  --
+  -- NULL means "a reply arrived and we never captured its words". That is a
+  -- real and permanent state -- every row that predates this migration is in
+  -- it, and a body fetch that fails leaves a row in it too. It is NOT the same
+  -- as an empty reply, and the UI has to say so rather than rendering blank.
+  body_text text,
+  -- Backstop only. fetchMessageText already slices the raw part at 20k chars,
+  -- so this should never fire; without it a future caller that forgets to slice
+  -- turns a pathological quoted thread into a multi-MB row on a 10-minute poll.
+  constraint email_replies_body_bounded
+    check (body_text is null or char_length(body_text) <= 32768),
+
+  received_at timestamptz not null,
+  created_at timestamptz not null default now(),
+
+  -- coalesce(message_id, 'uid:'||imap_uid, from|epoch|subject).
+  -- Built by replyDedupeKey() in src/lib/services/email-tracking.ts.
+  dedupe_key text not null,
+  unique (sent_email_id, dedupe_key)
+);
+
+-- The activity feed's only access pattern: one user's mail, newest first.
+create index if not exists idx_email_replies_user_received
+  on email_replies (user_id, received_at desc);
+-- Fan-in from a sent_emails row to its replies, for detail expansion and for
+-- the tracker's pre-loaded dedupe check.
+create index if not exists idx_email_replies_sent_email
+  on email_replies (sent_email_id);
+
+-- Mirrors sent_emails (20260427000000:359-370) deliberately: transitive via
+-- campaigns for select, direct owner for write. Identical shape means anyone
+-- who can see a send can see its replies, and never the reverse.
+alter table email_replies enable row level security;
+
+create policy "email_replies_select" on email_replies
+  for select using (
+    exists (
+      select 1 from campaigns c
+      where c.id = email_replies.campaign_id
+        and c.user_id = requesting_user_id()
+    )
+  );
+create policy "email_replies_insert" on email_replies
+  for insert with check (user_id = requesting_user_id());
+create policy "email_replies_update" on email_replies
+  for update using (user_id = requesting_user_id());

--- a/supabase/migrations/20260803000001_send_failure_record.sql
+++ b/supabase/migrations/20260803000001_send_failure_record.sql
@@ -1,0 +1,44 @@
+-- Record why a send did not happen
+-- 2026-08-03
+--
+-- claimAndSendDraft refuses to send at seven distinct points: an unloadable
+-- contact, a just-in-time verification that came back blocked, a canSendTo
+-- gate, an address that drifted from the contact's verified one, the
+-- warmup-ramped daily cap, and an SMTP error. Every one of them returns a
+-- complete, already user-readable sentence, and every one of those sentences
+-- is currently thrown away -- the only consumer anywhere in the codebase is a
+-- console.error in the followups executor. From the user's side an approved
+-- draft simply sits there, forever, with no explanation.
+--
+-- These columns live on email_drafts rather than sent_emails because a refused
+-- send produces no sent_emails row by definition, and because the draft is the
+-- thing that is still retryable, so the error belongs on the object the user
+-- would act on.
+alter table email_drafts
+  add column if not exists last_error text,
+  add column if not exists last_error_at timestamptz,
+  -- Three outcomes that read alike as strings and must not look alike in the
+  -- UI:
+  --
+  --   deferred  Nothing is wrong. The daily cap or warmup ramp was reached and
+  --             the draft is queued for tomorrow. This is the MOST COMMON
+  --             non-send, so filing it under "Failed" would make the failed
+  --             list mostly noise within a week of any new mailbox connecting,
+  --             and users would stop reading it.
+  --   blocked   A data-quality gate refused: unverified address, unconfirmed
+  --             employer, address drift. The user can fix it, and the stored
+  --             sentence already says how.
+  --   failed    SMTP or the database actually errored. Retry is the answer.
+  --
+  -- claimAndSendDraft knows which kind it is at each return site, so this is
+  -- classified at the write. Never string-match the reason at read time.
+  add column if not exists last_error_kind text
+    check (last_error_kind is null
+           or last_error_kind in ('deferred', 'blocked', 'failed')),
+  add column if not exists send_attempts integer not null default 0;
+
+-- Partial: the activity feed only ever asks for drafts currently carrying an
+-- error, which is a handful of rows out of the whole table.
+create index if not exists idx_email_drafts_last_error
+  on email_drafts (user_id, last_error_at desc)
+  where last_error_at is not null;

--- a/supabase/migrations/20260803000002_seed_reply_backfill.sql
+++ b/supabase/migrations/20260803000002_seed_reply_backfill.sql
@@ -1,0 +1,28 @@
+-- Kick off the one-shot reply backfill
+-- 2026-08-03
+--
+-- Replies matched before 20260803000000 have a status and no words. This
+-- enqueues a single job to walk back over them once and fill in what can still
+-- be found. It is deliberately modest about that: the historical tracker only
+-- ever looked at a 14-day window, 100 rows per run, and only in INBOX, so a
+-- meaningful share of old replies are unrecoverable and will keep showing
+-- "content not captured" forever. That is the honest outcome, not a failure.
+--
+-- recurring_interval_seconds is NULL on purpose. This is not a schedule: the
+-- executor re-enqueues itself while work remains and stops at MAX_PASSES.
+-- Note the partial unique index idx_jobs_one_recurring_per_type only covers
+-- recurring rows, which is exactly what lets a one-shot re-enqueue itself, and
+-- also exactly why the cap in the executor is the only thing bounding it.
+--
+-- run_at is 15 minutes out. execute.ts forces a job whose type has no
+-- registered executor straight to 'dead' with no retry, and migrations are
+-- pushed on merge while the code deploys separately, so a migration landing
+-- first would kill this job on the very next tick.
+insert into jobs (type, payload, recurring_interval_seconds, max_attempts, run_at)
+values (
+  'email.backfill-replies',
+  '{"pass": 1}'::jsonb,
+  null,
+  1,
+  now() + interval '15 minutes'
+);


### PR DESCRIPTION
You could not see a single sent email or a single reply anywhere in the product. This adds both, inside `/outreach`.

**It was not just a missing screen.** The reply pipeline matched an inbound message, wrote the word `replied` onto `sent_emails.status`, and discarded the sender, subject, date and body at the `classifyInboundMessage` boundary. Reply bodies were never even fetched. There was nothing in the database to show.

## What you get

A fourth tab on `/outreach`. Rows carry the person, subject, status and time; the reply snippet sits **on the collapsed row**, because a reply should be findable without filtering or clicking. Expanding loads the sent body and every reply, with a link out to Gmail to respond there.

It also covers the mail that never left: queued, scheduled, deferred, blocked and failed. Those have no `sent_emails` row at all, which is exactly why they were invisible.

## Commits

| | |
|---|---|
| `9888bcb` | `email_replies` + capture in the tracker |
| `9cc0e6e` | why a send did not happen, and shared text helpers |
| `05800f2` | `/api/outreach/activity` and `/[id]` |
| `f5c59a3` | the Sent tab |
| `59f4543` | dashboard opens/bounces fix + one-shot backfill |

## Things worth a careful look

**Dashboard numbers will move.** `sent` excluded `bounced`, so a send that bounced vanished from the total. It now counts, because it did leave. Sent goes up by the number of bounces. That is a correction, but it will read as a regression if it arrives unannounced.

**The Opened metric was fiction.** `/api/dashboard` counted opens as `outreach_status IN ('opened','replied')` and nothing writes `'opened'` — Signal sends no tracking pixel. So `totals.opened === totals.replied` and `openRate === replyRate`: the same number, twice, under two labels. Removed. `'opened'` stays inside the *sent* membership tests so legacy rows keep counting.

**Idempotency deliberately does not use the status ladder.** Gating the reply insert on `applyInboundStatus` handles the re-poll case and silently loses every *second* reply in a thread (`replied → replied` fails the ladder). `email_replies` carries its own `dedupe_key` instead.

**The re-download guard is required, not an optimisation.** Without the pre-loaded `capturedKeys` set, every 10-minute poll opens a fresh IMAP connection per reply in the 14-day window — 20 replies is 20 connections every ten minutes against Gmail's ~15 concurrent limit.

**`deferred` is not a failure.** Hitting the daily cap is the most common non-send and resolves itself tomorrow. It stays muted and off the "needs attention" filter, or that list becomes noise nobody reads.

**The backfill's pass cap is load-bearing.** One-shot jobs sit outside `idx_jobs_one_recurring_per_type`, so nothing in the database bounds a self-re-enqueueing chain. Its seed migration runs 15 minutes out, because `execute.ts` kills an unregistered job type with no retry and the migration can land ahead of the deploy.

## One bug this caught

`people` has **two** foreign keys to `organizations` since `20260802000000` added `affiliation_detached_from`, so the unqualified PostgREST embed was ambiguous and 500'd the whole feed. It typechecked fine; only a real database found it. Both embeds now name the constraint.

## Verification

- **627 tests**, typecheck, lint and prettier clean
- Mutation-tested the four claims that matter: gating the insert on the status ladder, dropping the re-download guard, classifying the daily cap as failed, and removing the backfill pass cap each fail exactly the test written for them
- Migrations applied against a real database in a transaction before any code was written against them
- API probed end to end with seeded data: the feed returns a replied send with its snippet beside a blocked draft with its reason, filters narrow, the detail returns the body with `book a time (https://arbor.dev/demo)` — link target preserved — plus the reply text, and a second user gets 404 and an empty feed

**Not verified: how the Sent tab looks.** Clerk's dev-browser handshake blocked a scripted screenshot. Behaviour is component-tested; the visual pass is owed, and the preview deploy on this PR is the place to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)