### PR TITLE
feat(campaign): enrich all contacts at a company, and stop force-opening rows

### DIFF
--- a/src/__tests__/enrich-all-button.test.tsx
+++ b/src/__tests__/enrich-all-button.test.tsx
@@ -1,0 +1,126 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * "Enrich all" spends money per contact, so the two things worth protecting
+ * are that it asks first and that a failure is not reported as a success.
+ */
+
+vi.mock("@/lib/api-fetch", () => ({ apiFetch: vi.fn() }));
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (m: string) => toastSuccess(m),
+    error: (m: string) => toastError(m),
+  },
+}));
+
+import { apiFetch } from "@/lib/api-fetch";
+import { EnrichAllButton } from "@/components/company/enrich-all-button";
+
+const fetchMock = vi.mocked(apiFetch);
+
+afterEach(cleanup);
+beforeEach(() => {
+  fetchMock.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+});
+
+function renderButton(count = 3) {
+  const onDone = vi.fn();
+  render(
+    <EnrichAllButton
+      campaignId="camp_1"
+      organizationId="org_1"
+      unenrichedCount={count}
+      onDone={onDone}
+    />,
+  );
+  return { onDone };
+}
+
+const ok = (body: unknown) =>
+  ({ ok: true, json: async () => body }) as unknown as Response;
+
+describe("<EnrichAllButton>", () => {
+  it("does not spend anything until the confirm is accepted", () => {
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: /Enrich all/ }));
+
+    // Dialog open, nothing requested yet.
+    expect(screen.getByText("Enrich 3 contacts?")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("cancelling spends nothing", () => {
+    renderButton();
+    fireEvent.click(screen.getByRole("button", { name: /Enrich all/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("runs on confirm and reports the route's own summary", async () => {
+    // The route knows about the batch cap and the skip; its sentence is the
+    // accurate one, so the button must not paraphrase it.
+    fetchMock.mockResolvedValue(
+      ok({
+        enriched: 3,
+        summary: "Enriched 3 of 3. 2 already enriched, skipped.",
+      }),
+    );
+    const { onDone } = renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: /Enrich all/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Enrich 3" }));
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/enrich/bulk",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Enriched 3 of 3. 2 already enriched, skipped.",
+    );
+  });
+
+  it("treats a non-2xx as a failure, not a run that enriched nobody", async () => {
+    // apiFetch returns the Response unchanged and never throws, so without an
+    // explicit ok check an error body reads as a successful empty run.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "Forbidden" }),
+    } as unknown as Response);
+    const { onDone } = renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: /Enrich all/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Enrich 3" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Forbidden"));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there is nobody left to enrich", () => {
+    renderButton(0);
+    expect(
+      screen.queryByRole("button", { name: /Enrich all/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the singular for one contact", () => {
+    renderButton(1);
+    fireEvent.click(screen.getByRole("button", { name: /Enrich all/ }));
+    expect(screen.getByText("Enrich 1 contact?")).toBeInTheDocument();
+  });
+});

--- a/src/app/api/enrich/bulk/route.ts
+++ b/src/app/api/enrich/bulk/route.ts
@@ -1,0 +1,159 @@
+import { NextResponse } from "next/server";
+
+import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { isRecentlyEnriched } from "@/lib/services/knowledge-base";
+import {
+  enrichPerson,
+  PERSON_ENRICH_COLUMNS,
+  type PersonForEnrichment,
+} from "@/lib/services/person-enrichment";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Bulk "Enrich all" for one company's contacts.
+ *
+ * Deliberately capped and re-clickable rather than unbounded. A single
+ * enrichment is allowed 120s of its own (see /api/enrich), so a 40-contact
+ * company cannot possibly finish inside one request: the honest design is a
+ * small batch plus "click again", the same shape /api/find-email/bulk already
+ * uses for the same reason.
+ */
+const MAX_PER_REQUEST = 10;
+
+/**
+ * Enrichments in flight at once.
+ *
+ * find-email/bulk is sequential ON PURPOSE, because the first lookup at an org
+ * caches an email pattern the rest derive from for free. Enrichment has no
+ * such dependency -- each contact is independent -- so serialising it would
+ * only make a batch four times slower. Kept modest because each one fans out
+ * to LinkedIn, X and three Exa searches.
+ */
+const CONCURRENCY = 4;
+
+/** organizationId is required: one click = one company, never a campaign-wide fanout. */
+export async function POST(req: Request) {
+  const ctx = await getSupabaseAndUser();
+  if (!ctx) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { supabase, user } = ctx;
+
+  let body: { campaignId?: string; organizationId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { campaignId, organizationId } = body;
+  if (!campaignId) {
+    return NextResponse.json({ error: "campaignId required" }, { status: 400 });
+  }
+  if (!organizationId) {
+    return NextResponse.json(
+      { error: "organizationId required (one company per request)" },
+      { status: 400 },
+    );
+  }
+
+  const { data: campaign } = await supabase
+    .from("campaigns")
+    .select("user_id")
+    .eq("id", campaignId)
+    .maybeSingle();
+  if (!campaign || campaign.user_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data: rows, error } = await supabase
+    .from("campaign_people")
+    .select(
+      `person:people!inner(id, organization_id, ${PERSON_ENRICH_COLUMNS})`,
+    )
+    .eq("campaign_id", campaignId);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  type Row = {
+    person:
+      | (PersonForEnrichment & { id: string; organization_id: string | null })
+      | null;
+  };
+
+  const candidates: Array<{ id: string; person: PersonForEnrichment }> = [];
+  for (const row of (rows ?? []) as unknown as Row[]) {
+    const person = row.person;
+    if (!person) continue;
+    if (person.organization_id !== organizationId) continue;
+    candidates.push({ id: person.id, person });
+  }
+
+  // Skip anyone already enriched recently. isRecentlyEnriched's default window
+  // is 7 days, so genuinely stale data still refreshes rather than being
+  // frozen forever by one old run.
+  const fresh = await Promise.all(
+    candidates.map((c) => isRecentlyEnriched("people", c.id)),
+  );
+  const pending = candidates.filter((_, i) => !fresh[i]);
+  const alreadyEnriched = candidates.length - pending.length;
+
+  const targets = pending.slice(0, MAX_PER_REQUEST);
+
+  const enriched: string[] = [];
+  const failed: Array<{ personId: string; reason?: string }> = [];
+
+  // Simple worker pool: CONCURRENCY workers pulling from one cursor.
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, targets.length) }, async () => {
+      for (;;) {
+        const index = cursor++;
+        if (index >= targets.length) return;
+        const target = targets[index];
+        try {
+          const result = await enrichPerson(supabase, target.id, target.person);
+          if (result.status === "enriched") enriched.push(target.id);
+          else
+            failed.push({
+              personId: target.id,
+              reason: result.errors?.[0] ?? "No data found",
+            });
+        } catch (err) {
+          failed.push({
+            personId: target.id,
+            reason: err instanceof Error ? err.message : "Unknown error",
+          });
+        }
+      }
+    }),
+  );
+
+  const remaining = Math.max(0, pending.length - targets.length);
+
+  // Report the skip rather than dropping it: without this, clicking Enrich all
+  // on a fully-enriched company looks like the button did nothing.
+  const skipNote =
+    alreadyEnriched > 0 ? ` ${alreadyEnriched} already enriched, skipped.` : "";
+
+  return NextResponse.json({
+    enriched: enriched.length,
+    failed: failed.length,
+    attempted: targets.length,
+    pendingTotal: pending.length,
+    remaining,
+    alreadyEnriched,
+    failures: failed,
+    summary:
+      targets.length === 0
+        ? alreadyEnriched > 0
+          ? `Nothing to do: all ${alreadyEnriched} contacts are already enriched.`
+          : "No contacts to enrich at this company."
+        : remaining > 0
+          ? `Enriched ${enriched.length} of ${targets.length} (${remaining} more to go, click again).${skipNote}`
+          : `Enriched ${enriched.length} of ${targets.length}.${skipNote}`,
+  });
+}

--- a/src/app/api/enrich/route.ts
+++ b/src/app/api/enrich/route.ts
@@ -1,12 +1,10 @@
-import { withAction } from "@/lib/services/cost-tracker";
 import { getSupabaseAndUser } from "@/lib/supabase/server";
-import { ExaService } from "@/lib/services/exa-service";
-import { LinkedinService } from "@/lib/services/linkedin-service";
-import { XService } from "@/lib/services/x-service";
+import { isRecentlyEnriched } from "@/lib/services/knowledge-base";
 import {
-  mergeEnrichmentData,
-  isRecentlyEnriched,
-} from "@/lib/services/knowledge-base";
+  enrichPerson,
+  PERSON_ENRICH_COLUMNS,
+  type PersonForEnrichment,
+} from "@/lib/services/person-enrichment";
 
 export const maxDuration = 120;
 
@@ -58,9 +56,7 @@ export async function POST(request: Request) {
 
   const { data: personData, error: fetchError } = await supabase
     .from("people")
-    .select(
-      "name, title, linkedin_url, twitter_url, organization:organizations(name)",
-    )
+    .select(PERSON_ENRICH_COLUMNS)
     .eq("id", personId)
     .single();
 
@@ -68,13 +64,7 @@ export async function POST(request: Request) {
     return Response.json({ error: "Contact not found" }, { status: 404 });
   }
 
-  const person = personData as {
-    name: string;
-    title: string | null;
-    linkedin_url: string | null;
-    twitter_url: string | null;
-    organization: { name?: string } | null;
-  };
+  const person = personData as unknown as PersonForEnrichment;
 
   // Check recency
   const recent = await isRecentlyEnriched("people", personId);
@@ -92,207 +82,12 @@ export async function POST(request: Request) {
     });
   }
 
-  const contactName = person.name || "Unknown";
-  const companyName = person.organization?.name || null;
-  const actionLabel = companyName
-    ? `Enrich person: ${contactName} (${companyName})`
-    : `Enrich person: ${contactName}`;
+  const result = await enrichPerson(supabase, personId, person);
 
-  return withAction(actionLabel, async () => {
-    // Mark as in_progress
-    await supabase
-      .from("people")
-      .update({ enrichment_status: "in_progress" })
-      .eq("id", personId);
-
-    const enrichmentData: Record<string, unknown> = {};
-    const errors: string[] = [];
-    const promises: Promise<void>[] = [];
-
-    if (person.linkedin_url) {
-      promises.push(
-        (async () => {
-          try {
-            const linkedin = new LinkedinService();
-            const scrapeResult = await linkedin.scrapeProfile(
-              person.linkedin_url!,
-            );
-            enrichmentData.linkedin = {
-              profileInfo: scrapeResult.profile || null,
-              posts: scrapeResult.posts.slice(0, 10),
-            };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            console.error(`[enrich API] LinkedIn scrape failed: ${msg}`);
-            errors.push(`LinkedIn: ${msg}`);
-          }
-        })(),
-      );
-    }
-
-    if (person.twitter_url) {
-      promises.push(
-        (async () => {
-          try {
-            const x = new XService();
-            const result = await x.enrichTwitterProfile(person.twitter_url!);
-            enrichmentData.twitter = {
-              user: result.user,
-              tweets: result.tweets.slice(0, 10),
-            };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            console.error(`[enrich API] Twitter enrich failed: ${msg}`);
-            errors.push(`Twitter: ${msg}`);
-          }
-        })(),
-      );
-    }
-
-    // Exa web searches for the person
-    if (contactName !== "Unknown") {
-      const exa = new ExaService();
-
-      const contactTitle = person.title || null;
-      const queryParts = [`"${contactName}"`];
-      if (companyName) queryParts.push(`"${companyName}"`);
-      if (contactTitle) queryParts.push(contactTitle);
-      const specificQuery = queryParts.join(" ");
-
-      // Collect URLs already in the company's enrichment data so we don't
-      // show the same links on both the company and contact cards.
-      const companyUrls = new Set<string>();
-      if (person.organization) {
-        const { data: orgRow } = await supabase
-          .from("organizations")
-          .select("enrichment_data")
-          .eq("name", (person.organization as { name?: string }).name ?? "")
-          .maybeSingle();
-
-        const orgEnrichment = orgRow?.enrichment_data as Record<
-          string,
-          unknown
-        > | null;
-        if (orgEnrichment) {
-          const searches = orgEnrichment.searches as
-            | Array<{ results: Array<{ url: string }> }>
-            | undefined;
-          if (searches) {
-            for (const s of searches) {
-              for (const r of s.results) {
-                if (r.url) companyUrls.add(r.url);
-              }
-            }
-          }
-        }
-      }
-
-      const dedup = (
-        results: Array<{
-          title: string;
-          url: string;
-          publishedDate: string | null;
-          text: string | null;
-        }>,
-      ) => results.filter((r) => !companyUrls.has(r.url));
-
-      promises.push(
-        (async () => {
-          try {
-            const result = await exa.search(
-              `${specificQuery} news announcement`,
-              { numResults: 3, includeText: true, category: "news" },
-            );
-            enrichmentData.news = dedup(
-              result.results.map((r) => ({
-                title: r.title,
-                url: r.url,
-                publishedDate: r.publishedDate,
-                text: r.text || null,
-              })),
-            );
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            errors.push(`News: ${msg}`);
-          }
-        })(),
-      );
-
-      promises.push(
-        (async () => {
-          try {
-            const result = await exa.search(
-              `${specificQuery} article talk interview podcast`,
-              { numResults: 3, includeText: true },
-            );
-            enrichmentData.articles = dedup(
-              result.results.map((r) => ({
-                title: r.title,
-                url: r.url,
-                publishedDate: r.publishedDate,
-                text: r.text || null,
-              })),
-            );
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            errors.push(`Articles: ${msg}`);
-          }
-        })(),
-      );
-
-      promises.push(
-        (async () => {
-          try {
-            const result = await exa.search(
-              `${specificQuery} background bio profile`,
-              { numResults: 3, includeText: true },
-            );
-            enrichmentData.background = dedup(
-              result.results.map((r) => ({
-                title: r.title,
-                url: r.url,
-                publishedDate: r.publishedDate,
-                text: r.text || null,
-              })),
-            );
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            errors.push(`Background: ${msg}`);
-          }
-        })(),
-      );
-    }
-
-    if (promises.length === 0) {
-      await supabase
-        .from("people")
-        .update({ enrichment_status: "failed" })
-        .eq("id", personId);
-
-      return Response.json({
-        contactId: personId,
-        status: "failed",
-        errors: ["No enrichment sources available"],
-      });
-    }
-
-    await Promise.all(promises);
-
-    const status =
-      Object.keys(enrichmentData).length > 0 ? "enriched" : "failed";
-
-    await mergeEnrichmentData(
-      "people",
-      personId,
-      enrichmentData,
-      status as "enriched" | "failed",
-    );
-
-    return Response.json({
-      contactId: personId,
-      status,
-      enrichmentData,
-      errors: errors.length > 0 ? errors : undefined,
-    });
-  }); // end withAction
+  return Response.json({
+    contactId: personId,
+    status: result.status,
+    enrichmentData: result.enrichmentData,
+    errors: result.errors,
+  });
 }

--- a/src/components/campaign/companies-list.tsx
+++ b/src/components/campaign/companies-list.tsx
@@ -172,8 +172,11 @@ export function CompaniesList({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ contactId }),
       });
+      // Deliberately does NOT expand the row. Enriching is something you do to
+      // a list, often several in a row, and force-opening each one shoves
+      // everything below it down the page mid-scan. The data updates in place;
+      // the row opens when the user asks it to.
       onDataChanged();
-      setExpandedContactIds((prev) => new Set(prev).add(contactId));
     } catch (err) {
       console.error(`[enrich] Failed:`, err);
     } finally {

--- a/src/components/campaign/companies-list.tsx
+++ b/src/components/campaign/companies-list.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { CompanyDetail } from "@/components/campaign/company-detail";
 import { ContactDetail } from "@/components/campaign/contact-detail";
 import { EmbeddedOrgChart } from "@/components/company/embedded-org-chart";
+import { EnrichAllButton } from "@/components/company/enrich-all-button";
 import { TogglePill } from "@/components/ui/toggle-pill";
 import { ReadinessBadge } from "@/components/tracking/readiness-badge";
 import { AffiliationBadge } from "@/components/ui/provenance-badge";
@@ -595,6 +596,18 @@ export function CompaniesList({
                           <Loader2 className="h-3 w-3 animate-spin" />
                           Enriching
                         </span>
+                      )}
+                      {company.organization_id && (
+                        <EnrichAllButton
+                          campaignId={campaignId}
+                          organizationId={company.organization_id}
+                          // Only what is actually left to do, so the number on
+                          // the button matches what the confirm will charge for.
+                          unenrichedCount={
+                            companyContacts.length - enrichedCount
+                          }
+                          onDone={onDataChanged}
+                        />
                       )}
                       {missingEmailCount > 0 &&
                         company.organization_id &&

--- a/src/components/company/enrich-all-button.tsx
+++ b/src/components/company/enrich-all-button.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { apiFetch } from "@/lib/api-fetch";
+
+interface BulkEnrichResponse {
+  enriched?: number;
+  failed?: number;
+  attempted?: number;
+  remaining?: number;
+  alreadyEnriched?: number;
+  summary?: string;
+}
+
+/**
+ * "Enrich all" for one company's contacts.
+ *
+ * Confirms first, and the dialog leads with the count. Enrichment spends real
+ * money per contact, so a mis-click on a large company is not something to
+ * find out about afterwards.
+ *
+ * Deliberately no cost figure. Each enrichment fans out to LinkedIn, X and
+ * three Exa searches and only one of those has a documented per-call price, so
+ * any number here would be invented -- and an invented number in a spend
+ * confirmation is worse than none, because it is the thing you would rely on.
+ */
+export function EnrichAllButton({
+  campaignId,
+  organizationId,
+  unenrichedCount,
+  onDone,
+}: {
+  campaignId: string;
+  organizationId: string;
+  unenrichedCount: number;
+  onDone: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [running, setRunning] = useState(false);
+
+  if (unenrichedCount <= 0) return null;
+
+  const run = async () => {
+    setRunning(true);
+    try {
+      const res = await apiFetch("/api/enrich/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ campaignId, organizationId }),
+      });
+      // apiFetch returns the Response unchanged and never throws on a non-2xx,
+      // so without this an error body reads as a run that enriched nobody.
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? `HTTP ${res.status}`);
+      }
+      const data = (await res
+        .json()
+        .catch(() => null)) as BulkEnrichResponse | null;
+
+      // The route caps each batch and skips anyone already enriched, so its
+      // own summary is the accurate sentence; the fallback only covers a
+      // response that predates it.
+      toast.success(
+        data?.summary ?? `Enriched ${data?.enriched ?? 0} contacts.`,
+      );
+      setOpen(false);
+      onDone();
+    } catch (err) {
+      console.error("[enrich/bulk] Failed:", err);
+      toast.error(err instanceof Error ? err.message : "Failed to enrich");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const noun = unenrichedCount === 1 ? "contact" : "contacts";
+
+  return (
+    <>
+      <Button
+        size="xs"
+        variant="outline"
+        onClick={() => setOpen(true)}
+        title={`Enrich ${unenrichedCount} ${noun} at this company`}
+      >
+        <Sparkles className="h-3 w-3" />
+        Enrich all ({unenrichedCount})
+      </Button>
+
+      <Dialog open={open} onOpenChange={(v) => !running && setOpen(v)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              Enrich {unenrichedCount} {noun}?
+            </DialogTitle>
+            <DialogDescription>
+              This spends enrichment credits, one charge per contact, and can
+              take a couple of minutes. Contacts enriched in the last week are
+              skipped.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setOpen(false)}
+              disabled={running}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" onClick={run} disabled={running}>
+              {running ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Enriching
+                </>
+              ) : (
+                `Enrich ${unenrichedCount}`
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/lib/services/person-enrichment.ts
+++ b/src/lib/services/person-enrichment.ts
@@ -1,0 +1,214 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { withAction } from "@/lib/services/cost-tracker";
+import { ExaService } from "@/lib/services/exa-service";
+import { LinkedinService } from "@/lib/services/linkedin-service";
+import { XService } from "@/lib/services/x-service";
+import { mergeEnrichmentData } from "@/lib/services/knowledge-base";
+
+/**
+ * Enriching one person: LinkedIn profile, X profile, and three Exa searches.
+ *
+ * Lifted out of POST /api/enrich unchanged so the bulk route can reuse it
+ * rather than carry a second copy of two hundred lines that would drift. The
+ * route keeps what is route-shaped -- auth, resolving a campaign_people id to
+ * a person, the recency short-circuit, HTTP status codes -- and this owns the
+ * work.
+ *
+ * Returns a plain object rather than a Response for the same reason.
+ */
+
+export interface PersonEnrichmentResult {
+  status: "enriched" | "failed";
+  enrichmentData: Record<string, unknown>;
+  errors?: string[];
+}
+
+/** The columns enrichment reads. Exported so callers can select exactly these. */
+export const PERSON_ENRICH_COLUMNS =
+  "name, title, linkedin_url, twitter_url, organization:organizations(name)";
+
+export interface PersonForEnrichment {
+  name: string;
+  title: string | null;
+  linkedin_url: string | null;
+  twitter_url: string | null;
+  organization: { name?: string } | null;
+}
+
+export async function enrichPerson(
+  supabase: SupabaseClient,
+  personId: string,
+  person: PersonForEnrichment,
+): Promise<PersonEnrichmentResult> {
+  const contactName = person.name || "Unknown";
+  const companyName = person.organization?.name || null;
+  const actionLabel = companyName
+    ? `Enrich person: ${contactName} (${companyName})`
+    : `Enrich person: ${contactName}`;
+
+  return withAction(actionLabel, async () => {
+    await supabase
+      .from("people")
+      .update({ enrichment_status: "in_progress" })
+      .eq("id", personId);
+
+    const enrichmentData: Record<string, unknown> = {};
+    const errors: string[] = [];
+    const promises: Promise<void>[] = [];
+
+    if (person.linkedin_url) {
+      promises.push(
+        (async () => {
+          try {
+            const linkedin = new LinkedinService();
+            const scrapeResult = await linkedin.scrapeProfile(
+              person.linkedin_url!,
+            );
+            enrichmentData.linkedin = {
+              profileInfo: scrapeResult.profile || null,
+              posts: scrapeResult.posts.slice(0, 10),
+            };
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : "Unknown error";
+            console.error(`[enrich] LinkedIn scrape failed: ${msg}`);
+            errors.push(`LinkedIn: ${msg}`);
+          }
+        })(),
+      );
+    }
+
+    if (person.twitter_url) {
+      promises.push(
+        (async () => {
+          try {
+            const x = new XService();
+            const result = await x.enrichTwitterProfile(person.twitter_url!);
+            enrichmentData.twitter = {
+              user: result.user,
+              tweets: result.tweets.slice(0, 10),
+            };
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : "Unknown error";
+            console.error(`[enrich] Twitter enrich failed: ${msg}`);
+            errors.push(`Twitter: ${msg}`);
+          }
+        })(),
+      );
+    }
+
+    if (contactName !== "Unknown") {
+      const exa = new ExaService();
+
+      const contactTitle = person.title || null;
+      const queryParts = [`"${contactName}"`];
+      if (companyName) queryParts.push(`"${companyName}"`);
+      if (contactTitle) queryParts.push(contactTitle);
+      const specificQuery = queryParts.join(" ");
+
+      // URLs already on the company's card, so the same link doesn't appear
+      // on both the company and the contact.
+      const companyUrls = new Set<string>();
+      if (person.organization) {
+        const { data: orgRow } = await supabase
+          .from("organizations")
+          .select("enrichment_data")
+          .eq("name", person.organization.name ?? "")
+          .maybeSingle();
+
+        const orgEnrichment = orgRow?.enrichment_data as Record<
+          string,
+          unknown
+        > | null;
+        if (orgEnrichment) {
+          const searches = orgEnrichment.searches as
+            | Array<{ results: Array<{ url: string }> }>
+            | undefined;
+          if (searches) {
+            for (const s of searches) {
+              for (const r of s.results) {
+                if (r.url) companyUrls.add(r.url);
+              }
+            }
+          }
+        }
+      }
+
+      const dedup = (
+        results: Array<{
+          title: string;
+          url: string;
+          publishedDate: string | null;
+          text: string | null;
+        }>,
+      ) => results.filter((r) => !companyUrls.has(r.url));
+
+      const search = (
+        key: "news" | "articles" | "background",
+        query: string,
+        label: string,
+        category?: "news",
+      ) =>
+        promises.push(
+          (async () => {
+            try {
+              const result = await exa.search(query, {
+                numResults: 3,
+                includeText: true,
+                ...(category ? { category } : {}),
+              });
+              enrichmentData[key] = dedup(
+                result.results.map((r) => ({
+                  title: r.title,
+                  url: r.url,
+                  publishedDate: r.publishedDate,
+                  text: r.text || null,
+                })),
+              );
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : "Unknown error";
+              errors.push(`${label}: ${msg}`);
+            }
+          })(),
+        );
+
+      search("news", `${specificQuery} news announcement`, "News", "news");
+      search(
+        "articles",
+        `${specificQuery} article talk interview podcast`,
+        "Articles",
+      );
+      search(
+        "background",
+        `${specificQuery} background bio profile`,
+        "Background",
+      );
+    }
+
+    // Nobody to ask: no LinkedIn, no X, and no usable name for a web search.
+    if (promises.length === 0) {
+      await supabase
+        .from("people")
+        .update({ enrichment_status: "failed" })
+        .eq("id", personId);
+      return {
+        status: "failed" as const,
+        enrichmentData: {},
+        errors: ["No enrichment sources available"],
+      };
+    }
+
+    await Promise.all(promises);
+
+    const status =
+      Object.keys(enrichmentData).length > 0 ? "enriched" : "failed";
+
+    await mergeEnrichmentData("people", personId, enrichmentData, status);
+
+    return {
+      status,
+      enrichmentData,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  });
+}


### PR DESCRIPTION
Two enrichment fixes reported together.

## Enriching a contact no longer forces its row open (`aebb250`)

`enrichContact` expanded the row it had just enriched. Enriching is something you do to a list, often several in a row, and force-opening each one shoves everything below it down the page mid-scan. The data already updates in place, so the expansion was doing nothing except moving the page under the cursor. One line removed.

**Left alone deliberately:** `enrichCompanyHandler` does the same thing ~25 lines down. That one is usually a single deliberate click where seeing the result is the point, and it was not what was reported. Same one-line change if you want it.

## Enrich all contacts at a company (`25b9545`)

New "Enrich all (N)" button on the expanded company row, beside Find emails, and `POST /api/enrich/bulk` behind it.

**It confirms first, and the dialog leads with the count**, because this spends money per contact and a mis-click on a large company is not something to discover afterwards.

**No dollar figure, on purpose.** Each enrichment fans out to LinkedIn, X and three Exa searches, and only Exa has a documented per-call price in this repo. Any number in that dialog would be invented, and an invented number in a spend confirmation is worse than none — it is the one thing you would rely on. If you tell me the real per-contact cost I will put it in and document the source.

**Capped at 10 per click**, with "click again for the rest". Not a preference: a single enrichment is allowed 120s of its own, so a 40-contact company cannot finish inside one request however the batch is arranged. Same shape `/api/find-email/bulk` already uses.

**Runs 4 at a time**, where `find-email/bulk` is deliberately sequential. That one serialises because the first lookup at an org caches an email pattern the rest derive from for free. Enrichment has no such dependency, so serialising it would only make a batch four times slower.

**Skips anyone enriched in the last week** via the existing `isRecentlyEnriched` helper, and says so in the result. Without that, clicking Enrich all on an already-enriched company looks like the button did nothing.

## The refactor worth reviewing

The ~200 lines of enrichment moved out of `POST /api/enrich` into `services/person-enrichment.ts` so both routes share one implementation instead of carrying copies that drift.

The route keeps what is route-shaped — auth, resolving a `campaign_people` id to a person, the recency short-circuit, status codes — and is now 93 lines instead of 298. **Its behaviour and response shape are unchanged**, which is the thing to check in review.

## Verification

- `pnpm test` 587 pass, typecheck, lint and prettier clean
- Mutation-tested: dropping the non-2xx check fails exactly the test asserting a failure must not be reported as a run that enriched nobody
- Not verified: how the dialog looks. Clerk's dev-browser handshake blocked scripted screenshots earlier in this work, so the preview deploy is the place to eyeball it

🤖 Generated with [Claude Code](https://claude.com/claude-code)