### PR TITLE
refactor(profiles): match the campaigns list-and-detail pattern

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  ListRowsSkeleton,
+  PageHeaderSkeleton,
+} from "@/components/ui/skeleton-presets";
+import { Textarea } from "@/components/ui/textarea";
+import { createClient } from "@/lib/supabase/client";
+import { useUser } from "@clerk/nextjs";
+import { profileDisplayName } from "@/lib/types/profile";
+import type { UserProfile, ProfileFormData } from "@/lib/types/profile";
+
+const emptyForm: ProfileFormData = {
+  label: "",
+  name: "",
+  email: "",
+  role_title: "",
+  company_name: "",
+  company_url: "",
+  personal_url: "",
+  linkedin_url: "",
+  twitter_url: "",
+  offering_summary: "",
+  notes: "",
+};
+
+/**
+ * Edits one profile, mirroring how /campaigns/[id] is the detail view for the
+ * /campaigns table. "/profile/new" lands here too — ids are UUIDs, so the
+ * literal segment "new" can only mean create mode.
+ */
+export default function ProfileDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const isNew = params.id === "new";
+
+  const { user: clerkUser } = useUser();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [form, setForm] = useState<ProfileFormData>(emptyForm);
+  const [loading, setLoading] = useState(!isNew);
+  const [notFound, setNotFound] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (isNew) return;
+
+    const load = async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("user_profile")
+        .select("*")
+        .eq("id", params.id)
+        .maybeSingle();
+
+      if (!data) {
+        setNotFound(true);
+        setLoading(false);
+        return;
+      }
+
+      const p = data as UserProfile;
+      setProfile(p);
+      setForm({
+        label: p.label ?? "",
+        name: p.name ?? "",
+        email: p.email ?? "",
+        role_title: p.role_title ?? "",
+        company_name: p.company_name ?? "",
+        company_url: p.company_url ?? "",
+        personal_url: p.personal_url ?? "",
+        linkedin_url: p.linkedin_url ?? "",
+        twitter_url: p.twitter_url ?? "",
+        offering_summary: p.offering_summary ?? "",
+        notes: p.notes ?? "",
+      });
+      setLoading(false);
+    };
+    void load();
+  }, [isNew, params.id]);
+
+  const update = (field: keyof ProfileFormData, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    const supabase = createClient();
+
+    const payload = Object.fromEntries(
+      Object.entries(form).map(([k, v]) => [k, v === "" ? null : v]),
+    );
+
+    try {
+      if (profile) {
+        const { error } = await supabase
+          .from("user_profile")
+          .update(payload)
+          .eq("id", profile.id);
+        if (error) throw error;
+
+        setProfile((prev) =>
+          prev ? ({ ...prev, ...payload } as UserProfile) : prev,
+        );
+        toast.success("Profile saved");
+      } else {
+        if (!clerkUser?.id) {
+          toast.error("Still signing in, try again in a moment");
+          setSaving(false);
+          return;
+        }
+        const { data, error } = await supabase
+          .from("user_profile")
+          .insert({ ...payload, user_id: clerkUser.id })
+          .select("*")
+          .single();
+        if (error) throw error;
+
+        const newProfile = data as UserProfile;
+        setProfile(newProfile);
+        toast.success("Profile created");
+        // The URL still says /profile/new; point it at the row that now
+        // exists so a reload edits instead of drafting a second copy.
+        router.replace(`/profile/${newProfile.id}`);
+      }
+    } catch (err) {
+      toast.error(
+        `Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex-1 overflow-y-auto">
+        <div className="space-y-8 p-4 md:p-6">
+          <PageHeaderSkeleton />
+          <ListRowsSkeleton count={4} />
+        </div>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-muted-foreground text-sm">Profile not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="space-y-8 p-4 md:p-6">
+        <div>
+          <h1 className="type-title">
+            {profile ? profileDisplayName(profile) : "New Profile"}
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            A seller identity with its own company, offering, and links.
+          </p>
+          <Link
+            href="/profile"
+            className="text-muted-foreground hover:text-foreground mt-2 inline-block text-xs underline underline-offset-2"
+          >
+            All profiles
+          </Link>
+        </div>
+
+        <Separator />
+
+        {/* Profile Label */}
+        <section className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="label" className="text-sm font-medium leading-none">
+              Profile Label
+            </label>
+            <Input
+              id="label"
+              value={form.label ?? ""}
+              onChange={(e) => update("label", e.target.value)}
+              placeholder="e.g. SaaS Sales, Consulting, Agency Work"
+            />
+            <p className="text-muted-foreground text-xs">
+              A short name to identify this profile when linking it to
+              campaigns.
+            </p>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Personal Info */}
+        <section className="space-y-4">
+          <h2 className="type-header">Personal Info</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                htmlFor="name"
+                className="text-sm font-medium leading-none"
+              >
+                Name
+              </label>
+              <Input
+                id="name"
+                value={form.name ?? ""}
+                onChange={(e) => update("name", e.target.value)}
+                placeholder="Your full name"
+                required
+                aria-required="true"
+              />
+            </div>
+            <div className="space-y-2">
+              <label
+                htmlFor="email"
+                className="text-sm font-medium leading-none"
+              >
+                Email
+              </label>
+              <Input
+                id="email"
+                type="email"
+                value={form.email ?? ""}
+                onChange={(e) => update("email", e.target.value)}
+                placeholder="you@company.com"
+                required
+                aria-required="true"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor="role_title"
+              className="text-sm font-medium leading-none"
+            >
+              Role / Title
+            </label>
+            <Input
+              id="role_title"
+              value={form.role_title ?? ""}
+              onChange={(e) => update("role_title", e.target.value)}
+              placeholder="e.g. Founder & CEO"
+            />
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* Company & Links */}
+        <section className="space-y-4">
+          <h2 className="type-header">Company & Links</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                htmlFor="company_name"
+                className="text-sm font-medium leading-none"
+              >
+                Company Name
+              </label>
+              <Input
+                id="company_name"
+                value={form.company_name ?? ""}
+                onChange={(e) => update("company_name", e.target.value)}
+                placeholder="Your company"
+              />
+            </div>
+            <div className="space-y-2">
+              <label
+                htmlFor="company_url"
+                className="text-sm font-medium leading-none"
+              >
+                Company Website
+              </label>
+              <Input
+                id="company_url"
+                type="url"
+                value={form.company_url ?? ""}
+                onChange={(e) => update("company_url", e.target.value)}
+                placeholder="https://yourcompany.com"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor="personal_url"
+              className="text-sm font-medium leading-none"
+            >
+              Personal Website
+            </label>
+            <Input
+              id="personal_url"
+              type="url"
+              value={form.personal_url ?? ""}
+              onChange={(e) => update("personal_url", e.target.value)}
+              placeholder="https://yoursite.com"
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                htmlFor="linkedin_url"
+                className="text-sm font-medium leading-none"
+              >
+                LinkedIn
+              </label>
+              <Input
+                id="linkedin_url"
+                type="url"
+                value={form.linkedin_url ?? ""}
+                onChange={(e) => update("linkedin_url", e.target.value)}
+                placeholder="https://linkedin.com/in/yourname"
+              />
+            </div>
+            <div className="space-y-2">
+              <label
+                htmlFor="twitter_url"
+                className="text-sm font-medium leading-none"
+              >
+                X / Twitter
+              </label>
+              <Input
+                id="twitter_url"
+                type="url"
+                value={form.twitter_url ?? ""}
+                onChange={(e) => update("twitter_url", e.target.value)}
+                placeholder="https://x.com/yourhandle"
+              />
+            </div>
+          </div>
+        </section>
+
+        <Separator />
+
+        {/* About Your Offering */}
+        <section className="space-y-4">
+          <h2 className="type-header">About Your Offering</h2>
+          <div className="space-y-2">
+            <label
+              htmlFor="offering_summary"
+              className="text-sm font-medium leading-none"
+            >
+              What are you selling?
+            </label>
+            <Textarea
+              id="offering_summary"
+              value={form.offering_summary ?? ""}
+              onChange={(e) => update("offering_summary", e.target.value)}
+              placeholder="Describe your product or service in a few sentences. What problem does it solve? Who is it for?"
+              rows={4}
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="notes" className="text-sm font-medium leading-none">
+              Additional Notes
+            </label>
+            <Textarea
+              id="notes"
+              value={form.notes ?? ""}
+              onChange={(e) => update("notes", e.target.value)}
+              placeholder="Anything else Signal should know -- target market, differentiators, constraints, tone preferences, etc."
+              rows={4}
+            />
+          </div>
+        </section>
+
+        <div className="flex justify-end pb-2">
+          <Button
+            onClick={handleSave}
+            disabled={saving || !form.name?.trim() || !form.email?.trim()}
+          >
+            {saving ? "Saving..." : profile ? "Save Profile" : "Create Profile"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,436 +1,182 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Select } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import {
-  ListRowsSkeleton,
-  PageHeaderSkeleton,
-} from "@/components/ui/skeleton-presets";
-import { Textarea } from "@/components/ui/textarea";
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { createClient } from "@/lib/supabase/client";
-import { useUser } from "@clerk/nextjs";
 import { profileDisplayName } from "@/lib/types/profile";
-import type { UserProfile, ProfileFormData } from "@/lib/types/profile";
+import type { UserProfile } from "@/lib/types/profile";
 
-const emptyForm: ProfileFormData = {
-  label: "",
-  name: "",
-  email: "",
-  role_title: "",
-  company_name: "",
-  company_url: "",
-  personal_url: "",
-  linkedin_url: "",
-  twitter_url: "",
-  offering_summary: "",
-  notes: "",
-};
-
-export default function ProfilePage() {
-  const { user: clerkUser } = useUser();
+export default function ProfilesIndexPage() {
   const [profiles, setProfiles] = useState<UserProfile[]>([]);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [form, setForm] = useState<ProfileFormData>(emptyForm);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-
-  const loadFormFromProfile = (p: UserProfile) => {
-    setForm({
-      label: p.label ?? "",
-      name: p.name ?? "",
-      email: p.email ?? "",
-      role_title: p.role_title ?? "",
-      company_name: p.company_name ?? "",
-      company_url: p.company_url ?? "",
-      personal_url: p.personal_url ?? "",
-      linkedin_url: p.linkedin_url ?? "",
-      twitter_url: p.twitter_url ?? "",
-      offering_summary: p.offering_summary ?? "",
-      notes: p.notes ?? "",
-    });
-  };
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    const load = async () => {
+    mountedRef.current = true;
+
+    const fetchProfiles = async () => {
       const supabase = createClient();
       const { data } = await supabase
         .from("user_profile")
         .select("*")
         .order("created_at", { ascending: false });
 
-      const list: UserProfile[] = Array.isArray(data) ? data : [];
-      setProfiles(list);
-
-      if (list.length > 0) {
-        setSelectedId(list[0].id);
-        loadFormFromProfile(list[0]);
+      if (mountedRef.current) {
+        setProfiles(Array.isArray(data) ? data : []);
+        setLoading(false);
       }
-      setLoading(false);
     };
-    void load();
+
+    fetchProfiles();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
-  const selectProfile = (id: string) => {
-    const p = profiles.find((pr) => pr.id === id);
-    if (!p) return;
-    setSelectedId(id);
-    loadFormFromProfile(p);
-  };
-
-  const startNewProfile = () => {
-    setSelectedId(null);
-    setForm(emptyForm);
-  };
-
-  const update = (field: keyof ProfileFormData, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    const supabase = createClient();
-
-    const payload = Object.fromEntries(
-      Object.entries(form).map(([k, v]) => [k, v === "" ? null : v]),
-    );
-
-    try {
-      if (selectedId) {
-        const { error } = await supabase
-          .from("user_profile")
-          .update(payload)
-          .eq("id", selectedId);
-        if (error) throw error;
-
-        setProfiles((prev) =>
-          prev.map((p) =>
-            p.id === selectedId ? ({ ...p, ...payload } as UserProfile) : p,
-          ),
-        );
-        toast.success("Profile saved");
-      } else {
-        if (!clerkUser?.id) {
-          toast.error("Still signing in, try again in a moment");
-          setSaving(false);
-          return;
-        }
-        const { data, error } = await supabase
-          .from("user_profile")
-          .insert({ ...payload, user_id: clerkUser.id })
-          .select("*")
-          .single();
-        if (error) throw error;
-
-        const newProfile = data as UserProfile;
-        setProfiles((prev) => [newProfile, ...prev]);
-        setSelectedId(newProfile.id);
-        toast.success("Profile created");
-      }
-    } catch (err) {
-      toast.error(
-        `Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`,
-      );
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleDelete = async () => {
-    if (!selectedId) return;
+  const handleDelete = async (profile: UserProfile) => {
     if (profiles.length <= 1) {
       toast.error("You need at least one profile");
       return;
     }
 
+    setDeletingId(profile.id);
     const supabase = createClient();
     const { error } = await supabase
       .from("user_profile")
       .delete()
-      .eq("id", selectedId);
+      .eq("id", profile.id);
 
     if (error) {
       toast.error(`Failed to delete: ${error.message}`);
+      setDeletingId(null);
       return;
     }
 
-    const remaining = profiles.filter((p) => p.id !== selectedId);
-    setProfiles(remaining);
-    if (remaining.length > 0) {
-      setSelectedId(remaining[0].id);
-      loadFormFromProfile(remaining[0]);
-    } else {
-      setSelectedId(null);
-      setForm(emptyForm);
-    }
-    toast.success("Profile deleted");
+    setProfiles((prev) => prev.filter((p) => p.id !== profile.id));
+    toast.success(`Deleted "${profileDisplayName(profile)}"`);
+    setDeletingId(null);
   };
-
-  if (loading) {
-    return (
-      <div className="flex-1 overflow-y-auto">
-        <div className="space-y-8 p-4 md:p-6">
-          <PageHeaderSkeleton />
-          <ListRowsSkeleton count={4} />
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="space-y-8 p-4 md:p-6">
-        <div>
-          <h1 className="type-title">Profiles</h1>
-          <p className="text-muted-foreground text-sm">
-            Create different profiles for different campaigns. Each profile is a
-            seller identity with its own company, offering, and links.
-          </p>
-        </div>
-
-        {/* Profile selector */}
-        <div className="flex items-center gap-3">
-          <div className="min-w-[12rem]">
-            <Select
-              value={selectedId ?? ""}
-              onValueChange={(next) => {
-                if (next) selectProfile(next);
-              }}
-              placeholder="New profile..."
-              aria-label="Select profile"
-              items={profiles.map((p) => ({
-                value: p.id,
-                label: profileDisplayName(p),
-              }))}
-            />
+      <div className="space-y-6 p-4 md:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="type-title">Profiles</h1>
+            <p className="text-muted-foreground text-sm">
+              Each profile is a seller identity with its own company, offering,
+              and links. Click a name to open it.
+            </p>
           </div>
-          <Button variant="outline" size="sm" onClick={startNewProfile}>
+          <Button
+            variant="outline"
+            size="sm"
+            render={<Link href="/profile/new" />}
+          >
             <Plus className="mr-1.5 h-4 w-4" />
             New Profile
           </Button>
-          {selectedId && profiles.length > 1 && (
-            <Button variant="ghost" size="sm" onClick={handleDelete}>
-              <Trash2 className="mr-1.5 h-4 w-4" />
-              Delete
-            </Button>
-          )}
         </div>
 
-        <Separator />
-
-        {/* Profile Label */}
-        <section className="space-y-4">
+        {loading ? (
           <div className="space-y-2">
-            <label htmlFor="label" className="text-sm font-medium leading-none">
-              Profile Label
-            </label>
-            <Input
-              id="label"
-              value={form.label ?? ""}
-              onChange={(e) => update("label", e.target.value)}
-              placeholder="e.g. SaaS Sales, Consulting, Agency Work"
-            />
-            <p className="text-muted-foreground text-xs">
-              A short name to identify this profile when linking it to
-              campaigns.
-            </p>
+            <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
+            <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
+            <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
           </div>
-        </section>
-
-        <Separator />
-
-        {/* Personal Info */}
-        <section className="space-y-4">
-          <h2 className="type-header">Personal Info</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <label
-                htmlFor="name"
-                className="text-sm font-medium leading-none"
-              >
-                Name
-              </label>
-              <Input
-                id="name"
-                value={form.name ?? ""}
-                onChange={(e) => update("name", e.target.value)}
-                placeholder="Your full name"
-                required
-                aria-required="true"
-              />
-            </div>
-            <div className="space-y-2">
-              <label
-                htmlFor="email"
-                className="text-sm font-medium leading-none"
-              >
-                Email
-              </label>
-              <Input
-                id="email"
-                type="email"
-                value={form.email ?? ""}
-                onChange={(e) => update("email", e.target.value)}
-                placeholder="you@company.com"
-                required
-                aria-required="true"
-              />
-            </div>
+        ) : profiles.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No profiles yet. Create one so the agent knows who it is writing as.
+          </p>
+        ) : (
+          <div className="border-border overflow-hidden rounded-lg border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-border bg-muted/50 border-b">
+                  <th className="px-4 py-2.5 text-left font-medium">Name</th>
+                  <th className="px-4 py-2.5 text-left font-medium">Company</th>
+                  <th className="w-12 px-4 py-2.5" />
+                </tr>
+              </thead>
+              <tbody>
+                {profiles.map((profile) => (
+                  <tr
+                    key={profile.id}
+                    className="border-border border-b last:border-b-0"
+                  >
+                    <td className="px-4 py-2.5">
+                      <Link
+                        href={`/profile/${profile.id}`}
+                        className="focus-visible:ring-ring rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2"
+                      >
+                        {profileDisplayName(profile)}
+                      </Link>
+                    </td>
+                    <td className="text-muted-foreground px-4 py-2.5">
+                      {profile.company_name ?? ""}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <Dialog>
+                        <DialogTrigger
+                          render={
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              aria-label="Delete profile"
+                              disabled={
+                                deletingId === profile.id ||
+                                profiles.length <= 1
+                              }
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          }
+                        />
+                        <DialogContent>
+                          <DialogTitle>Delete profile</DialogTitle>
+                          <DialogDescription>
+                            This will permanently delete &quot;
+                            {profileDisplayName(profile)}&quot;. Campaigns
+                            linked to it will be unlinked. This cannot be
+                            undone.
+                          </DialogDescription>
+                          <DialogFooter>
+                            <DialogClose render={<Button variant="outline" />}>
+                              Cancel
+                            </DialogClose>
+                            <Button
+                              variant="destructive"
+                              onClick={() => handleDelete(profile)}
+                              disabled={deletingId === profile.id}
+                            >
+                              {deletingId === profile.id
+                                ? "Deleting..."
+                                : "Delete Profile"}
+                            </Button>
+                          </DialogFooter>
+                        </DialogContent>
+                      </Dialog>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-          <div className="space-y-2">
-            <label
-              htmlFor="role_title"
-              className="text-sm font-medium leading-none"
-            >
-              Role / Title
-            </label>
-            <Input
-              id="role_title"
-              value={form.role_title ?? ""}
-              onChange={(e) => update("role_title", e.target.value)}
-              placeholder="e.g. Founder & CEO"
-            />
-          </div>
-        </section>
-
-        <Separator />
-
-        {/* Company & Links */}
-        <section className="space-y-4">
-          <h2 className="type-header">Company & Links</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <label
-                htmlFor="company_name"
-                className="text-sm font-medium leading-none"
-              >
-                Company Name
-              </label>
-              <Input
-                id="company_name"
-                value={form.company_name ?? ""}
-                onChange={(e) => update("company_name", e.target.value)}
-                placeholder="Your company"
-              />
-            </div>
-            <div className="space-y-2">
-              <label
-                htmlFor="company_url"
-                className="text-sm font-medium leading-none"
-              >
-                Company Website
-              </label>
-              <Input
-                id="company_url"
-                type="url"
-                value={form.company_url ?? ""}
-                onChange={(e) => update("company_url", e.target.value)}
-                placeholder="https://yourcompany.com"
-              />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <label
-              htmlFor="personal_url"
-              className="text-sm font-medium leading-none"
-            >
-              Personal Website
-            </label>
-            <Input
-              id="personal_url"
-              type="url"
-              value={form.personal_url ?? ""}
-              onChange={(e) => update("personal_url", e.target.value)}
-              placeholder="https://yoursite.com"
-            />
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <label
-                htmlFor="linkedin_url"
-                className="text-sm font-medium leading-none"
-              >
-                LinkedIn
-              </label>
-              <Input
-                id="linkedin_url"
-                type="url"
-                value={form.linkedin_url ?? ""}
-                onChange={(e) => update("linkedin_url", e.target.value)}
-                placeholder="https://linkedin.com/in/yourname"
-              />
-            </div>
-            <div className="space-y-2">
-              <label
-                htmlFor="twitter_url"
-                className="text-sm font-medium leading-none"
-              >
-                X / Twitter
-              </label>
-              <Input
-                id="twitter_url"
-                type="url"
-                value={form.twitter_url ?? ""}
-                onChange={(e) => update("twitter_url", e.target.value)}
-                placeholder="https://x.com/yourhandle"
-              />
-            </div>
-          </div>
-        </section>
-
-        <Separator />
-
-        {/* About Your Offering */}
-        <section className="space-y-4">
-          <h2 className="type-header">About Your Offering</h2>
-          <div className="space-y-2">
-            <label
-              htmlFor="offering_summary"
-              className="text-sm font-medium leading-none"
-            >
-              What are you selling?
-            </label>
-            <Textarea
-              id="offering_summary"
-              value={form.offering_summary ?? ""}
-              onChange={(e) => update("offering_summary", e.target.value)}
-              placeholder="Describe your product or service in a few sentences. What problem does it solve? Who is it for?"
-              rows={4}
-            />
-          </div>
-          <div className="space-y-2">
-            <label htmlFor="notes" className="text-sm font-medium leading-none">
-              Additional Notes
-            </label>
-            <Textarea
-              id="notes"
-              value={form.notes ?? ""}
-              onChange={(e) => update("notes", e.target.value)}
-              placeholder="Anything else Signal should know -- target market, differentiators, constraints, tone preferences, etc."
-              rows={4}
-            />
-          </div>
-        </section>
-
-        <div className="flex justify-end pb-2">
-          <Button
-            onClick={handleSave}
-            disabled={
-              saving || loading || !form.name?.trim() || !form.email?.trim()
-            }
-          >
-            {saving
-              ? "Saving..."
-              : selectedId
-                ? "Save Profile"
-                : "Create Profile"}
-          </Button>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -71,7 +71,7 @@ function getSuggestions(pathname: string, campaignId: string | null): string[] {
     ];
   }
 
-  if (pathname === "/profile") {
+  if (pathname.startsWith("/profile")) {
     return [
       "Update my profile with my company details",
       "Create a new profile for a different offering",
@@ -117,7 +117,8 @@ function pageContextFromPath(
     return "Signals library (browse, toggle, create signals)";
   if (pathname === "/tracking")
     return "Tracking page (monitored companies and signal history)";
-  if (pathname === "/profile") return "Profiles page (user seller profiles)";
+  if (pathname.startsWith("/profile"))
+    return "Profiles page (user seller profiles)";
   if (pathname === "/outreach")
     return "Outreach dashboard (sequences, signal queue, kanban pipeline)";
   if (pathname.startsWith("/outreach/review"))


### PR DESCRIPTION
/profile is now an index table like /campaigns (click a name to open, per-row delete with confirm dialog), with the edit form moved to /profile/[id] and /profile/new for creation. Agent panel matches /profile by prefix so subpages keep their context.

