### PR TITLE
Fix prod enrichment failures and polish the chat UI

### DIFF
--- a/docs/plans/2026-08-03-ui-fixes.md
+++ b/docs/plans/2026-08-03-ui-fixes.md
@@ -1,0 +1,144 @@
+# UI Fixes — 2026-08-03
+
+Status: implemented 2026-08-03 (all items, including both optional ones). Typecheck, lint, and unit tests (697) pass; the supabase test fake now models FK-column embed hints. Notable extras found during implementation: two additional ambiguous embeds fixed on the outreach page, and the campaign detail page now surfaces sub-query errors instead of rendering them as an empty campaign.
+
+## 1. Truncate the recent-chats list on the chat landing page
+
+**Problem:** `/chat` (`src/app/chat/page.tsx`) fetches up to 50 chats (`listChats(supabase, 50)`, line 38) and renders all of them. With months of history the list scrolls far past the viewport (entries from 95d ago are shown), burying the input and making the landing page feel endless.
+
+**Fix:** Show only the most recent handful and collapse the rest.
+
+- Render the first **8** chats by default (constant, e.g. `const VISIBLE_CHATS = 8`).
+- Below them, a "Show all (N)" ghost button that expands to the full fetched list; once expanded, optionally a "Show less". Simple `useState<boolean>` — no new deps.
+- Keep the fetch at 50 (cheap, single query) so expansion is instant with no second request.
+- Keep the existing delete behavior working in both collapsed and expanded states (it operates on `chats` state, so no change expected — just verify).
+
+**Files:** `src/app/chat/page.tsx` only.
+
+**Verify:** landing page with >8 chats shows 8 + the expand button; expanding shows the rest; deleting from the collapsed list promotes the next chat into view.
+
+## 2. Chat input should grow while typing, up to a modest max
+
+**Problem:** The composer (`src/components/chat/chat-input.tsx`) already auto-grows on input, but the cap is `72px` (~2 lines — see `max-h-[72px]` on line 109 and the matching `Math.min(target.scrollHeight, 72)` in the `onInput` handler, line 118). At that limit it barely registers as growing; longer messages immediately scroll inside a 2-line box.
+
+**Fix:** Raise the cap to something comfortable but restrained — **~160px (≈6 lines of `text-sm`)**.
+
+- Update both places the cap lives, and keep them as one shared constant so they can't drift: `const MAX_INPUT_HEIGHT = 160`, used in an inline `style={{ maxHeight: MAX_INPUT_HEIGHT }}` (or keep the Tailwind class in sync) and in the `onInput` `Math.min`.
+- Keep `overflow-y-auto` so content past the cap scrolls inside the textarea.
+- Keep the existing height reset in `handleSubmit` (`height = "auto"`) — verify it still snaps back to one line after send.
+- Edge case worth checking: height is only recalculated in `onInput`, so if the parent ever sets `input` programmatically (e.g. CSV upload flows or clearing), the height won't sync. If trivial, move the measurement into a small effect keyed on `input`; otherwise leave as-is and note it.
+
+**Files:** `src/components/chat/chat-input.tsx` only. This component is shared by `/chat` and the per-chat page, so the fix applies everywhere.
+
+**Verify:** typing multi-line text grows the box smoothly to ~6 lines then scrolls; sending resets to single-line; Shift+Enter newlines behave.
+
+## 3. Remove the Usage tab from Settings (prod) — future admin-only view
+
+**Problem:** Settings (`src/app/settings/page.tsx`) exposes a Usage tab (trigger on line 55, content on lines 77–79) rendering `CostCenter` (`src/components/settings/cost-center.tsx`) with full spend/token breakdowns. Jay doesn't want this user-facing in prod; it'll move to an admin view he'll configure later.
+
+**Fix:** Remove the tab from the settings UI, but keep the machinery for the future admin view.
+
+- Delete the `<TabsTrigger value="usage">` and its `<TabsContent>` block from `src/app/settings/page.tsx` (and the now-unused `CostCenter` import).
+- **Keep** `src/components/settings/cost-center.tsx` and the API route `src/app/api/settings/costs/route.ts` — the admin view will reuse both. Do not delete them.
+- Recommendation over env-gating: full removal from settings is simpler and matches "only on an admin view later". If dev-time visibility is still wanted, wrap the trigger + content in `process.env.NODE_ENV === "development"` instead of deleting — decide at implementation time; default to full removal.
+- **Note for the admin work later:** `/api/settings/costs` stays reachable by any authenticated user even after the tab is hidden. Fine for now (self-hosted, single user), but the admin view task should add an admin/role check on that route.
+
+**Files:** `src/app/settings/page.tsx` (edit). `cost-center.tsx` and `costs/route.ts` untouched.
+
+**Verify:** Settings shows only Email / Integrations / Preferences; default tab still opens; no unused-import lint error.
+
+## 4. Tool-call cards: user-facing labels, collapse repeated runs, show the subject
+
+Three related fixes to how the agent's tool calls render in chat (`src/components/chat/tool-call-card.tsx` + `src/components/chat/chat-message-bubble.tsx`).
+
+### 4a. Every tool gets a user-facing label
+
+**Problem:** `TOOL_CONFIG` (tool-call-card.tsx:31–45) maps only 10 tools to friendly labels; everything else falls back to the raw tool name, so chats show `enrichCompanies`, `scoreCompany`, `getCompanyDetail`, `listProfiles` verbatim.
+
+**Fix:** Complete the map for the full tool surface in `src/lib/tools/index.ts` (campaign, enrichment, email, sequence, signal, github tools). E.g. `enrichCompanies` → "Enriching companies", `scoreCompany` → "Scoring company", `getCompanyDetail` → "Loading company detail", `findContacts` → "Finding contacts", `writeEmail` → "Drafting email", etc. Keep the raw-name fallback for anything future. Consider deriving the list from the tool registry export so a new tool without a label is caught by a lint/test rather than silently shipping camelCase.
+
+### 4b. Collapse consecutive runs of the same tool
+
+**Problem:** Batch work produces long stacks of identical cards — 5× "Searching companies", 10× `scoreCompany` — each one row, filling the transcript.
+
+**Fix:** Group in `chat-message-bubble.tsx` where parts are mapped (lines 88–103): pre-process `message.parts` into runs of consecutive tool parts sharing a tool name. A run of **≥3** renders one collapsed group card — "Scoring companies ×10" with aggregate status (spinner while any in-flight, check when all done, error icon if any failed) — that expands on click to the full list of individual `ToolCallCard`s. Runs of 1–2 render as today. While the last call of a run is still streaming, the group stays visually live (spinner + count ticking up). Keep `key`s stable (first toolCallId of the run) so streaming doesn't remount.
+
+### 4c. Show what the call is operating on (company name, query, …)
+
+**Problem:** Cards say "Enriching companies" with no hint of _which_ companies. `ToolCallCard` already receives `input` (props line 25) but never reads it (destructuring at line 50–56 omits it).
+
+**Fix — two parts:**
+
+- **UI:** derive a subtitle from `input` per tool and render it after the label (muted, truncated): `searchCompanies` → the `query` string; `enrichContact`/`getCompanyDetail` → name when present; `saveCampaign` → campaign name.
+- **Data gap:** `enrichCompanies` and `scoreCompany` inputs are **UUID-only** (`companyIds`, `companyId` — see `src/lib/tools/enrichment-tools.ts:1494` ff. and `:1980` ff.), so there is nothing human-readable to show while the call runs. Add an optional display-only input field to those schemas (e.g. `companyNames: z.array(z.string()).optional().describe("Display names for the UI; not used for lookup")`) and instruct the model (tool description or system prompt) to pass names alongside IDs. Execute() must ignore it for correctness — IDs stay authoritative. Fallback: once output arrives, `enrichCompanies` output already includes `companyName` per company — show names from output for completed calls even when input lacked them.
+
+**Files:** `tool-call-card.tsx`, `chat-message-bubble.tsx`, `enrichment-tools.ts` (schema-only additions), possibly `system-prompt.ts`.
+
+**Verify:** run a batch enrich in a campaign chat — labels are all human-readable, 10 score calls collapse to one expandable row, and the enrich card names the companies it's working on both during and after the call.
+
+## 5. Bug (prod): claim extractor 400s on every call — `minimum`/`maximum` unsupported in structured output
+
+**Error (Vercel prod logs, Aug 4):**
+`[claim-extractor] failed, storing raw data only: AI_APICallError: output_config.format.schema: For 'number' type, properties maximum, minimum are not supported` — HTTP 400 from `api.anthropic.com/v1/messages`, `isRetryable: false`.
+
+**Root cause:** `src/lib/services/claim-extractor.ts:87` — `confidence: z.number().min(0).max(1)` inside the `generateObject` schema. Zod's `.min/.max` compile to JSON Schema `minimum`/`maximum`, which Anthropic's native structured-output schema (`output_config.format.schema`) rejects for number types. The API refuses the whole request, so **every** claim extraction fails, on every enrichment.
+
+**Impact:** `extractClaims` fails open to `[]` (by design, line 133–136), so enrichment still stores raw data — but no typed claims are ever produced, meaning claim reconciliation/verification downstream silently runs on nothing. The claims pipeline has been dead in prod without surfacing anywhere except logs.
+
+**Fix:**
+
+- Remove `.min(0).max(1)` from the `confidence` field; keep the range in prose: `z.number().describe("Confidence 0–1")`.
+- Clamp after parsing so garbage can't propagate: `confidence: Math.min(1, Math.max(0, c.confidence))` in the map at line 124–132.
+- **Swept the rest of the codebase:** all 14 `generateObject`/`streamObject` call sites checked; this is the only model-bound schema using number `min/max`. (`swipe-service.ts:100` has one too, but that's `VoiceRunBodySchema` — request validation, never sent to the model — leave it.)
+- Consider a guard for the future: a small unit test that walks every model-bound Zod schema and asserts no `minimum`/`maximum`/other unsupported keywords, so the next one is caught before prod.
+
+**Files:** `src/lib/services/claim-extractor.ts`.
+
+**Verify:** run an enrichment locally, confirm `[claim-extractor]` no longer errors and claims land in the DB. Note prod deploy topology: this fixes via normal Vercel deploy, no migration involved.
+
+## 6. Bugs (prod transcript): findContacts / getContacts / enrichContacts failures
+
+Three errors from one campaign-run transcript. They share a theme: tools take bare UUIDs of different kinds (person ID vs campaign-people link ID vs campaign-org link ID) with no validation, and DB errors surface raw or get swallowed.
+
+### 6a. findContacts: "Company not found: Cannot coerce the result to a single JSON object"
+
+**Cause:** `src/lib/tools/enrichment-tools.ts` (~line 1703): when `companyId` doesn't match a `campaign_organizations` row, `.single()` fails and the raw PostgREST coerce error is thrown at the agent. The agent had passed a wrong/stale ID (likely an organization ID in the `companyId` param — the tool accepts either kind in different params, easy to cross).
+
+**Fix:**
+
+- Use `.maybeSingle()` and on miss, probe whether the UUID is actually an `organizations.id` (and even a `campaign_people.id`) — if so, either auto-resolve and proceed, or return a precise, actionable error: "`<id>` is an organization ID, not a campaign-organization link — pass it as `organizationId`". Agents recover instantly from that; they flail on coerce errors.
+- Same treatment for the `companyId` filter lookup inside `getContacts` (silently ignores a bad ID today — filter just doesn't apply).
+
+### 6b. getContacts: "Could not embed because more than one relationship was found for 'people' and 'organizations'"
+
+**Cause:** migration `20260802000000_affiliation_detach.sql` added `people.affiliation_detached_from → organizations(id)` — a **second** FK from `people` to `organizations`. Every PostgREST embed of `organization:organizations(...)` from `people` without an FK hint is now ambiguous and errors (or worse, silently degrades where the error is discarded).
+
+**Fix:** add explicit hints — `organization:organizations!people_organization_id_fkey(...)` — at every `people`→`organizations` embed. Sweep results (all need the hint):
+
+- `src/lib/tools/enrichment-tools.ts:1781` (getContacts — the reported error)
+- `src/lib/tools/enrichment-tools.ts:1878` (getContactDetail)
+- `src/lib/tools/enrichment-tools.ts:509` (**inside `enrichContactById` — error is discarded**, so enrichment proceeds with `companyName = null`: person searches lose their company anchor, which feeds the known namesake-merge bug. This one is quietly the worst.)
+- `src/lib/services/person-enrichment.ts:29` (`PERSON_SELECT`)
+- `src/lib/email-skills/swipe-recipient.ts:32` (voice-swipe recipient loses company context)
+- `src/app/api/refresh-scores/route.ts:60`
+- `src/app/campaigns/[id]/page.tsx:95` — **user-visible symptom:** the campaign detail contacts query dies on this embed, and line 137's `contactsRes.data || []` swallows the error, so the page shows "0 contacts / 0 leads" and files all 105 companies under "Companies without leads" even though ~40 contacts are linked in the DB. The companies query on line 89 is `campaign_organizations`→`organizations` (single FK) and still works, which is why companies render but contacts don't. Beyond the FK hint, this fetch should surface query errors instead of coercing to `[]` — a thrown DB error rendering as "0 contacts" is what let this ship silently.
+- Verify-only (top-level table is not `people`, likely fine): `src/app/api/find-contacts/route.ts:56`, `src/app/api/enrich-company/route.ts:116`, `src/lib/tools/tracking-tools.ts:236`, `src/lib/tools/search-tools.ts` embeds, `src/lib/jobs/executors/tracking-run.ts:30`, `src/app/api/import-csv/route.ts:76`.
+- Add a regression test that runs each hinted select against the local schema so a future second FK on another pair fails loudly in CI, not in prod.
+
+### 6c. enrichContacts (batch): every contact "failed" while single enrichContact works
+
+**Diagnosis:** the transcript says the agent "retr[ied] enrichment with the campaign-people link IDs" — but `enrichContacts` takes **person IDs**. `enrichContactById` (enrichment-tools.ts:506 ff.) never checks that the person lookup returned a row: on a miss it proceeds with name "Unknown", no LinkedIn/Twitter, nothing to enrich → marks the person `failed`, yet the promise fulfills so the batch reports it under `succeeded` with `status: "failed"`. Single calls worked because the agent happened to use real person IDs there. (The 6b embed breakage may also have contributed by nulling company anchors.)
+
+**Fix:**
+
+- `enrichContactById`: fail fast when no `people` row matches — and check `campaign_people` for the UUID first so the error can say "that's a campaign-people link ID; its person_id is `<x>`" (or just auto-resolve it — cheap and unambiguous).
+- Batch result shape: don't file `status: "failed"` entries under `succeeded`. Count them as failures with a reason, so the summary (`succeeded: 9, failed: 0`) can't contradict its own rows.
+- Tool descriptions: state the accepted ID kind in the first sentence ("person IDs from `people.id`, NOT campaign_people link IDs").
+
+**Files:** `enrichment-tools.ts`, `person-enrichment.ts`, `swipe-recipient.ts`, `refresh-scores/route.ts`, plus test.
+
+**Verify:** rerun the transcript's flow on a campaign: findContacts with a deliberately wrong ID kind returns the actionable message; getContacts returns rows; batch enrichContacts with link IDs either auto-resolves or fails loudly per contact; single enrich still stores the company name on the enrichment record.
+
+## 7. (Observed while screenshotting, optional) Chat titles render raw markdown
+
+Several list entries show literal markdown from the first assistant/user message — `**6-10 word summary:**`, `# Nursing Homes in Birmingham…`, `**Short Chat Greeting**`. Titles should be stripped of markdown syntax (`#`, `**`, backticks) at display time, or better, at title-generation time so the stored title is clean. Not part of the truncation fix; listed here so it isn't forgotten.

--- a/src/__tests__/helpers/supabase-fake.ts
+++ b/src/__tests__/helpers/supabase-fake.ts
@@ -87,6 +87,13 @@ interface SelectSpec {
     alias: string;
     table: string;
     inner: boolean;
+    /**
+     * FK-column disambiguation hint (`alias:table!column(...)`), used when
+     * two FKs link the same pair of tables. The fake checks it against the
+     * registered relation's localKey so a hint naming the wrong column fails
+     * here the same way PostgREST would fail it in production.
+     */
+    hint: string | null;
     spec: SelectSpec;
   }>;
   /** The original string, quoted back in error messages. */
@@ -94,7 +101,7 @@ interface SelectSpec {
 }
 
 const EMBED =
-  /^([a-z_][a-z0-9_]*)\s*:\s*([a-z_][a-z0-9_]*)(![a-z]+)?\s*\(([\s\S]*)\)$/i;
+  /^([a-z_][a-z0-9_]*)\s*:\s*([a-z_][a-z0-9_]*)(![a-z0-9_]+)?\s*\(([\s\S]*)\)$/i;
 const PLAIN_COLUMN = /^[a-z_][a-z0-9_]*$/i;
 
 /**
@@ -161,15 +168,11 @@ export function parseSelect(source: string): SelectSpec {
     const embed = EMBED.exec(part);
     if (embed) {
       const [, alias, table, modifier, inner] = embed;
-      if (modifier && modifier !== "!inner") {
-        throw new Error(
-          `[supabase fake] select("${source}") uses the "${modifier}" hint, which this fake does not implement. Implement it here rather than working around it in the test.`,
-        );
-      }
       spec.embeds.push({
         alias,
         table,
         inner: modifier === "!inner",
+        hint: modifier && modifier !== "!inner" ? modifier.slice(1) : null,
         spec: parseSelect(inner),
       });
       continue;
@@ -261,6 +264,11 @@ export function createSupabaseFake(
       if (!relation) {
         throw new Error(
           `[supabase fake] select("${spec.source}") embeds "${embed.alias}" on "${table}", but no relation is registered for it. Declare it in the fake's \`relations\` so the join is modelled rather than guessed.`,
+        );
+      }
+      if (embed.hint && embed.hint !== relation.localKey) {
+        throw new Error(
+          `[supabase fake] select("${spec.source}") hints "${embed.alias}" through "${embed.hint}", but the registered relation joins via "${relation.localKey}". Either the hint names the wrong FK column or the relation registration is stale.`,
         );
       }
       const foreignKey = relation.foreignKey ?? "id";

--- a/src/app/api/refresh-scores/route.ts
+++ b/src/app/api/refresh-scores/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
     const { data: links, error: linksError } = await supabase
       .from("campaign_people")
       .select(
-        "id, person_id, person:people(id, name, title, linkedin_url, twitter_url, enrichment_data, enrichment_status, organization:organizations(name, domain, industry, enrichment_data))",
+        "id, person_id, person:people(id, name, title, linkedin_url, twitter_url, enrichment_data, enrichment_status, organization:organizations!organization_id(name, domain, industry, enrichment_data))",
       )
       .eq("campaign_id", campaignId);
 

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -92,7 +92,10 @@ export default function CampaignDetailPage() {
       supabase
         .from("campaign_people")
         .select(
-          "*, person:people(*, organization:organizations(name, domain, industry))",
+          // The !organization_id hint is load-bearing: people has a second FK
+          // to organizations (affiliation_detached_from), so an unhinted
+          // embed is ambiguous and the whole query errors.
+          "*, person:people(*, organization:organizations!organization_id(name, domain, industry))",
         )
         .eq("campaign_id", campaignId)
         .order("priority_score", { ascending: false, nullsFirst: false })
@@ -103,6 +106,15 @@ export default function CampaignDetailPage() {
 
     if (campaignRes.error) {
       setError("Campaign not found");
+      setLoading(false);
+      return;
+    }
+
+    // A failed sub-query must not render as an empty campaign: that is how a
+    // broken embed shipped as "0 contacts" without anyone noticing.
+    const subError = companiesRes.error || contactsRes.error;
+    if (subError) {
+      setError(`Failed to load campaign data: ${subError.message}`);
       setLoading(false);
       return;
     }
@@ -266,6 +278,7 @@ export default function CampaignDetailPage() {
     setCampaign(campaignRes.data as Campaign);
     setCompanies(newCompanies);
     setContacts(newContacts);
+    setError(null);
     setLoading(false);
   }, [campaignId]);
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -14,6 +14,22 @@ import {
 } from "@/lib/services/chat-history";
 import { createClient } from "@/lib/supabase/client";
 
+/** How many chats show before the list collapses behind "Show all". */
+const VISIBLE_CHATS = 8;
+
+/**
+ * Chat titles come from the first message and often carry raw markdown
+ * ("# Heading", "**bold**", backticks). Strip the syntax for the list.
+ */
+function cleanTitle(title: string): string {
+  return title
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/\*\*([^*]*)\*\*/g, "$1")
+    .replace(/\*([^*]*)\*/g, "$1")
+    .replace(/`([^`]*)`/g, "$1")
+    .trim();
+}
+
 function timeAgo(dateStr: string): string {
   const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
   if (seconds < 60) return "just now";
@@ -29,6 +45,7 @@ export default function ChatPage() {
   const router = useRouter();
   const [chats, setChats] = useState<ChatSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showAll, setShowAll] = useState(false);
   const [input, setInput] = useState("");
   const mountedRef = useRef(true);
 
@@ -90,7 +107,7 @@ export default function ChatPage() {
               <h3 className="text-muted-foreground mb-3 text-xs font-medium uppercase tracking-wide">
                 Recent chats
               </h3>
-              {chats.map((chat) => (
+              {(showAll ? chats : chats.slice(0, VISIBLE_CHATS)).map((chat) => (
                 <div
                   key={chat.id}
                   className="hover:bg-muted/50 group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors"
@@ -101,7 +118,7 @@ export default function ChatPage() {
                   >
                     <MessageCircle className="text-muted-foreground h-4 w-4 shrink-0" />
                     <span className="min-w-0 flex-1 truncate text-sm">
-                      {chat.title}
+                      {cleanTitle(chat.title)}
                     </span>
                     <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
                       {timeAgo(chat.updated_at)}
@@ -110,7 +127,7 @@ export default function ChatPage() {
                   <Button
                     variant="ghost"
                     size="icon"
-                    aria-label={`Delete chat "${chat.title}"`}
+                    aria-label={`Delete chat "${cleanTitle(chat.title)}"`}
                     className="text-muted-foreground hover:text-destructive h-7 w-7 shrink-0 opacity-60 transition-opacity hover:opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100"
                     onClick={(e) => {
                       e.preventDefault();
@@ -127,6 +144,16 @@ export default function ChatPage() {
                   </Button>
                 </div>
               ))}
+              {chats.length > VISIBLE_CHATS && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground w-full"
+                  onClick={() => setShowAll((prev) => !prev)}
+                >
+                  {showAll ? "Show less" : `Show all (${chats.length})`}
+                </Button>
+              )}
             </div>
           )}
         </div>

--- a/src/app/outreach/page.tsx
+++ b/src/app/outreach/page.tsx
@@ -73,7 +73,7 @@ export default function OutreachPage() {
           `
             id, sequence_id, person_id, campaign_people_id,
             current_step, status, next_send_at,
-            people(name, title, organization_id, organizations(name)),
+            people(name, title, organization_id, organizations!organization_id(name)),
             campaign_people(outreach_status),
             sequences(name)
           `,
@@ -89,7 +89,7 @@ export default function OutreachPage() {
             sequence_enrollments(next_send_at, sequence_id),
             sequence_steps(step_number),
             sequences(name),
-            people(name, title, organizations(name))
+            people(name, title, organizations!organization_id(name))
           `,
         )
         .in("status", ["draft"])

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,7 +5,6 @@ import { useTheme } from "next-themes";
 
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { CostCenter } from "@/components/settings/cost-center";
 import { EmailSettings } from "@/components/settings/email-settings";
 import { IntegrationsPanel } from "@/components/settings/integrations-panel";
 import { SettingsSection } from "@/components/settings/settings-section";
@@ -52,7 +51,6 @@ export default function SettingsPage() {
             <TabsTrigger value="email">Email</TabsTrigger>
             <TabsTrigger value="integrations">Integrations</TabsTrigger>
             <TabsTrigger value="preferences">Preferences</TabsTrigger>
-            <TabsTrigger value="usage">Usage</TabsTrigger>
           </TabsList>
 
           <TabsContent value="email" className="space-y-8">
@@ -74,9 +72,9 @@ export default function SettingsPage() {
             </SettingsSection>
           </TabsContent>
 
-          <TabsContent value="usage">
-            <CostCenter />
-          </TabsContent>
+          {/* Usage/cost reporting is intentionally not user-facing: the
+              CostCenter component and /api/settings/costs stay in the tree
+              for a future admin-only view. */}
         </Tabs>
       </div>
     </div>

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -18,6 +18,12 @@ interface ChatInputProps {
   disabled?: boolean;
 }
 
+/**
+ * Auto-grow ceiling (~6 lines of text-sm). One constant so the CSS max
+ * and the JS measurement can't drift apart; past this the textarea scrolls.
+ */
+const MAX_INPUT_HEIGHT = 160;
+
 export function ChatInput({
   input,
   isLoading,
@@ -106,7 +112,8 @@ export function ChatInput({
           <Textarea
             ref={textareaRef}
             placeholder="Ask Signal anything..."
-            className="max-h-[72px] min-h-[44px] resize-none overflow-y-auto text-sm transition-[height] duration-100"
+            className="min-h-[44px] resize-none overflow-y-auto text-sm transition-[height] duration-100"
+            style={{ maxHeight: MAX_INPUT_HEIGHT }}
             rows={1}
             value={input}
             disabled={disabled}
@@ -115,7 +122,7 @@ export function ChatInput({
             onInput={(e) => {
               const target = e.target as HTMLTextAreaElement;
               target.style.height = "auto";
-              target.style.height = `${Math.min(target.scrollHeight, 72)}px`;
+              target.style.height = `${Math.min(target.scrollHeight, MAX_INPUT_HEIGHT)}px`;
             }}
           />
           {isLoading ? (

--- a/src/components/chat/chat-message-bubble.tsx
+++ b/src/components/chat/chat-message-bubble.tsx
@@ -7,7 +7,15 @@ import type { UIMessage } from "ai";
 import { isToolUIPart, getToolName } from "ai";
 import { Bot, User } from "lucide-react";
 
-import { ToolCallCard } from "./tool-call-card";
+import {
+  INLINE_TOOLS,
+  ToolCallCard,
+  ToolCallGroup,
+  type ToolCallCardProps,
+} from "./tool-call-card";
+
+/** Runs of at least this many same-tool calls collapse into one group row. */
+const MIN_RUN_TO_COLLAPSE = 3;
 
 const Markdown = dynamic(
   () => import("@/components/ui/markdown").then((m) => m.Markdown),
@@ -85,44 +93,93 @@ export const ChatMessageBubble = memo(
           <Bot className="text-muted-foreground h-4 w-4" />
         </div>
         <div className="min-w-0 flex-1">
-          {parts.map((part, i) => {
-            if (isToolUIPart(part)) {
-              return (
-                <ToolCallCard
-                  key={part.toolCallId}
-                  toolName={getToolName(part)}
-                  state={part.state}
-                  input={"input" in part ? part.input : undefined}
-                  output={"output" in part ? part.output : undefined}
-                  errorText={
-                    "errorText" in part ? (part.errorText as string) : undefined
+          {(() => {
+            const toCardProps = (
+              part: Extract<(typeof parts)[number], { toolCallId: string }>,
+            ): ToolCallCardProps & { toolCallId: string } => ({
+              toolCallId: part.toolCallId,
+              toolName: getToolName(part),
+              state: part.state,
+              input: "input" in part ? part.input : undefined,
+              output: "output" in part ? part.output : undefined,
+              errorText:
+                "errorText" in part ? (part.errorText as string) : undefined,
+              liveViewUrl: liveViewByToolCall.get(part.toolCallId),
+            });
+
+            const rendered: React.ReactNode[] = [];
+            let i = 0;
+            while (i < parts.length) {
+              const part = parts[i];
+
+              if (isToolUIPart(part) && !INLINE_TOOLS.has(getToolName(part))) {
+                // Collect the run of consecutive same-tool calls. step-start
+                // markers between agent steps are invisible in the transcript,
+                // so a run may continue across them.
+                const name = getToolName(part);
+                const run = [part];
+                let j = i + 1;
+                while (j < parts.length) {
+                  const next = parts[j];
+                  if (next.type === "step-start") {
+                    j++;
+                    continue;
                   }
-                  liveViewUrl={liveViewByToolCall.get(part.toolCallId)}
-                />
-              );
+                  if (isToolUIPart(next) && getToolName(next) === name) {
+                    run.push(next);
+                    j++;
+                    continue;
+                  }
+                  break;
+                }
+
+                if (run.length >= MIN_RUN_TO_COLLAPSE) {
+                  rendered.push(
+                    <ToolCallGroup
+                      key={part.toolCallId}
+                      calls={run.map(toCardProps)}
+                    />,
+                  );
+                  i = j;
+                  continue;
+                }
+
+                const { toolCallId, ...cardProps } = toCardProps(part);
+                rendered.push(<ToolCallCard key={toolCallId} {...cardProps} />);
+                i++;
+                continue;
+              }
+
+              if (isToolUIPart(part)) {
+                const { toolCallId, ...cardProps } = toCardProps(part);
+                rendered.push(<ToolCallCard key={toolCallId} {...cardProps} />);
+                i++;
+                continue;
+              }
+
+              if (part.type === "text" && part.text) {
+                const isLastText = i === lastTextIndex;
+                const isActivelyStreaming = isStreaming && isLastText;
+
+                rendered.push(
+                  <div
+                    key={`text-${i}`}
+                    className="bg-muted/60 my-1 rounded-2xl rounded-bl-md px-4 py-2.5 text-sm"
+                  >
+                    {isActivelyStreaming ? (
+                      <StreamingMarkdown text={part.text} />
+                    ) : (
+                      <Markdown>{part.text}</Markdown>
+                    )}
+                  </div>,
+                );
+              }
+
+              // Other part types (step-start, reasoning, etc.) render nothing.
+              i++;
             }
-
-            if (part.type === "text" && part.text) {
-              const isLastText = i === lastTextIndex;
-              const isActivelyStreaming = isStreaming && isLastText;
-
-              return (
-                <div
-                  key={`text-${i}`}
-                  className="bg-muted/60 my-1 rounded-2xl rounded-bl-md px-4 py-2.5 text-sm"
-                >
-                  {isActivelyStreaming ? (
-                    <StreamingMarkdown text={part.text} />
-                  ) : (
-                    <Markdown>{part.text}</Markdown>
-                  )}
-                </div>
-              );
-            }
-
-            // Skip other part types (step-start, reasoning, etc.)
-            return null;
-          })}
+            return rendered;
+          })()}
         </div>
       </div>
     );

--- a/src/components/chat/tool-call-card.tsx
+++ b/src/components/chat/tool-call-card.tsx
@@ -2,19 +2,27 @@
 
 import { useState } from "react";
 import {
+  Activity,
+  AlertCircle,
+  BarChart3,
+  Bookmark,
   Building2,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
   ExternalLink,
-  Loader2,
-  Search,
-  Users,
-  BarChart3,
+  FileText,
+  Github,
   Globe,
-  Bookmark,
   List,
-  AlertCircle,
+  Loader2,
+  Mail,
+  Mic,
+  Search,
+  Send,
+  Star,
+  Trash2,
+  Users,
 } from "lucide-react";
 
 import { ContactCards } from "./contact-card";
@@ -28,28 +36,140 @@ export interface ToolCallCardProps {
   liveViewUrl?: string;
 }
 
+// Every tool in src/lib/tools/index.ts gets a user-facing label; the raw
+// camelCase name is only a fallback for tools added after this map.
 const TOOL_CONFIG: Record<
   string,
   { label: string; icon: React.ComponentType<{ className?: string }> }
 > = {
+  // Campaigns
   saveCampaign: { label: "Saving campaign", icon: Bookmark },
   getCampaign: { label: "Loading campaign", icon: Bookmark },
   listCampaigns: { label: "Listing campaigns", icon: List },
-  searchCompanies: { label: "Searching companies", icon: Search },
-  getCompanies: { label: "Loading companies", icon: Building2 },
   getCampaignSummary: { label: "Loading summary", icon: BarChart3 },
+  // Company search & discovery
+  searchCompanies: { label: "Searching companies", icon: Search },
+  discoverCompanies: { label: "Discovering companies", icon: Search },
+  searchYCCompanies: { label: "Searching YC companies", icon: Search },
+  getCompanies: { label: "Loading companies", icon: Building2 },
+  getCompanyDetail: { label: "Loading company detail", icon: Building2 },
+  updateCompanyStatus: { label: "Updating company status", icon: Building2 },
+  setCompanyWebsite: { label: "Setting company website", icon: Globe },
+  deleteCompanies: { label: "Removing companies", icon: Trash2 },
+  // Enrichment & scoring
+  enrichCompany: { label: "Enriching company", icon: Building2 },
+  enrichCompanies: { label: "Enriching companies", icon: Building2 },
+  scoreCompany: { label: "Scoring company", icon: Star },
+  scoreContact: { label: "Scoring contact", icon: Star },
+  getDataQualityReport: { label: "Checking data quality", icon: BarChart3 },
+  getGoogleReviews: { label: "Loading Google reviews", icon: Star },
+  // People & contacts
   searchPeople: { label: "Searching people", icon: Users },
-  enrichContact: { label: "Enriching contact", icon: Users },
-  extractWebContent: { label: "Extracting web content", icon: Globe },
+  findContacts: { label: "Finding contacts", icon: Users },
   getContacts: { label: "Loading contacts", icon: Users },
+  getContactDetail: { label: "Loading contact detail", icon: Users },
+  enrichContact: { label: "Enriching contact", icon: Users },
+  enrichContacts: { label: "Enriching contacts", icon: Users },
+  deleteContacts: { label: "Removing contacts", icon: Trash2 },
+  // Web & scraping
+  extractWebContent: { label: "Extracting web content", icon: Globe },
+  fetchSitemap: { label: "Fetching sitemap", icon: Globe },
+  scrapeJobListings: { label: "Scanning job listings", icon: Globe },
+  scrapeJobListingsBatch: { label: "Scanning job listings", icon: Globe },
+  // Profiles
+  getUserProfile: { label: "Loading profile", icon: Users },
+  updateUserProfile: { label: "Updating profile", icon: Users },
+  listProfiles: { label: "Listing profiles", icon: List },
+  // Signals
+  getSignalAuthoringGuide: { label: "Loading signal guide", icon: FileText },
+  testSignalRecipe: { label: "Testing signal recipe", icon: Activity },
+  getSignals: { label: "Loading signals", icon: Activity },
+  getSignalDetail: { label: "Loading signal detail", icon: Activity },
+  getCampaignSignals: { label: "Loading campaign signals", icon: Activity },
+  toggleCampaignSignal: { label: "Toggling campaign signal", icon: Activity },
+  createSignal: { label: "Creating signal", icon: Activity },
+  updateSignal: { label: "Updating signal", icon: Activity },
+  makeSignalPublic: { label: "Publishing signal", icon: Activity },
+  getSignalResults: { label: "Loading signal results", icon: Activity },
+  // GitHub
+  fetchGitHubStargazers: { label: "Fetching GitHub stargazers", icon: Github },
+  enrichGitHubProfiles: { label: "Enriching GitHub profiles", icon: Github },
+  searchGitHubRepos: { label: "Searching GitHub repos", icon: Github },
+  // Tracking
+  createTracking: { label: "Setting up tracking", icon: Activity },
+  bulkCreateTracking: { label: "Setting up tracking", icon: Activity },
+  getTrackingConfigs: { label: "Loading tracking", icon: Activity },
+  getTrackingHistory: { label: "Loading tracking history", icon: Activity },
+  updateTracking: { label: "Updating tracking", icon: Activity },
+  // Email
+  findEmail: { label: "Finding email address", icon: Mail },
+  findEmails: { label: "Finding email addresses", icon: Mail },
+  writeEmail: { label: "Drafting email", icon: Mail },
+  sendEmail: { label: "Sending email", icon: Send },
+  sendBulkEmails: { label: "Sending emails", icon: Send },
+  listDrafts: { label: "Listing drafts", icon: Mail },
+  discardDraft: { label: "Discarding draft", icon: Trash2 },
+  // Sequences
+  createSequence: { label: "Creating sequence", icon: List },
+  draftSequenceEmails: { label: "Drafting sequence emails", icon: Mail },
+  draftEmailsForSequence: { label: "Drafting sequence emails", icon: Mail },
+  getSequenceStatus: { label: "Loading sequence status", icon: List },
+  // Voice
+  startVoiceRun: { label: "Starting voice drafting", icon: Mic },
+  rewriteVoiceDrafts: { label: "Rewriting drafts", icon: Mic },
+  saveVoiceProfile: { label: "Saving voice profile", icon: Mic },
+  refineEmailVoice: { label: "Refining email voice", icon: Mic },
 };
 
 // Tools that show their results inline (not collapsible)
-const INLINE_TOOLS = new Set(["searchPeople"]);
+export const INLINE_TOOLS = new Set(["searchPeople"]);
+
+/**
+ * A short human-readable subject for a call — which company, query, or URL
+ * it is about — pulled from well-known input fields. Batch enrichment only
+ * carries UUIDs at input time, so completed calls fall back to the names in
+ * the output.
+ */
+function toolSubject(
+  toolName: string,
+  input: unknown,
+  output: unknown,
+): string | null {
+  const str = (v: unknown) =>
+    typeof v === "string" && v.trim() ? v.trim() : null;
+  const list = (v: unknown) =>
+    Array.isArray(v) && v.length > 0
+      ? v.filter((s): s is string => typeof s === "string").join(", ") || null
+      : null;
+
+  const d = (input ?? {}) as Record<string, unknown>;
+  const fromInput =
+    str(d.query) ??
+    str(d.companyName) ??
+    list(d.companyNames) ??
+    str(d.name) ??
+    str(d.url) ??
+    str(d.domain) ??
+    list(d.titles);
+  if (fromInput) return fromInput;
+
+  // enrichCompanies output names each company it touched
+  if (toolName === "enrichCompanies" && output && typeof output === "object") {
+    const results = (output as Record<string, unknown>).results;
+    if (Array.isArray(results)) {
+      const names = results
+        .map((r) => (r as Record<string, unknown>)?.companyName)
+        .filter((n): n is string => typeof n === "string");
+      if (names.length > 0) return names.join(", ");
+    }
+  }
+  return null;
+}
 
 export function ToolCallCard({
   toolName,
   state,
+  input,
   output,
   errorText,
   liveViewUrl,
@@ -60,6 +180,7 @@ export function ToolCallCard({
     icon: Search,
   };
   const Icon = config.icon;
+  const subject = toolSubject(toolName, input, output);
 
   const isLoading = state === "input-streaming" || state === "input-available";
   const hasOutput = state === "output-available";
@@ -75,6 +196,9 @@ export function ToolCallCard({
           <Icon className="text-muted-foreground h-4 w-4" />
           <span className="text-muted-foreground flex-1 truncate">
             {config.label}
+            {subject && (
+              <span className="text-muted-foreground/70"> · {subject}</span>
+            )}
           </span>
         </div>
         <InlineToolResult toolName={toolName} result={output} />
@@ -101,6 +225,9 @@ export function ToolCallCard({
           <Icon className="text-muted-foreground h-4 w-4" />
           <span className="text-muted-foreground flex-1 truncate">
             {isLoading ? config.label + "..." : config.label}
+            {subject && (
+              <span className="text-muted-foreground/70"> · {subject}</span>
+            )}
           </span>
         </button>
         {showLiveView && (
@@ -133,6 +260,67 @@ export function ToolCallCard({
           <CollapsibleToolResult toolName={toolName} result={output} />
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * A run of consecutive calls to the same tool, collapsed to a single row
+ * ("Scoring company ×10") that expands to the individual cards. Keeps batch
+ * work from filling the transcript with near-identical rows.
+ */
+export function ToolCallGroup({
+  calls,
+}: {
+  calls: Array<ToolCallCardProps & { toolCallId: string }>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const toolName = calls[0].toolName;
+  const config = TOOL_CONFIG[toolName] || { label: toolName, icon: Search };
+  const Icon = config.icon;
+
+  const anyLoading = calls.some(
+    (c) => c.state === "input-streaming" || c.state === "input-available",
+  );
+  const anyError = calls.some((c) => c.state === "output-error");
+  const doneCount = calls.filter((c) => c.state === "output-available").length;
+
+  return (
+    <div className="bg-muted/40 border-border my-1 overflow-hidden rounded-lg border text-sm">
+      <button
+        className="flex w-full items-center gap-2 px-3 py-2 text-left"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {anyLoading ? (
+          <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
+        ) : anyError ? (
+          <AlertCircle className="h-4 w-4 text-destructive" />
+        ) : (
+          <CheckCircle2 className="h-4 w-4 text-success" />
+        )}
+        <Icon className="text-muted-foreground h-4 w-4" />
+        <span className="text-muted-foreground flex-1 truncate">
+          {config.label} ×{calls.length}
+          {anyLoading && (
+            <span className="text-muted-foreground/70">
+              {" "}
+              · {doneCount}/{calls.length} done
+            </span>
+          )}
+        </span>
+        {expanded ? (
+          <ChevronDown className="text-muted-foreground h-3 w-3" />
+        ) : (
+          <ChevronRight className="text-muted-foreground h-3 w-3" />
+        )}
+      </button>
+      {expanded && (
+        <div className="border-border border-t px-2 pb-1 pt-0.5">
+          {calls.map(({ toolCallId, ...call }) => (
+            <ToolCallCard key={toolCallId} {...call} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/email-skills/swipe-recipient.ts
+++ b/src/lib/email-skills/swipe-recipient.ts
@@ -29,7 +29,9 @@ export interface ContactRow {
 }
 
 export const CONTACT_SELECT =
-  "person_id, person:people(name, title, enrichment_data, organization:organizations(name))";
+  // !organization_id disambiguates: people carries a second FK to
+  // organizations (affiliation_detached_from), so unhinted embeds error.
+  "person_id, person:people(name, title, enrichment_data, organization:organizations!organization_id(name))";
 
 export interface ResolvedRecipient {
   personId: string;

--- a/src/lib/services/claim-extractor.ts
+++ b/src/lib/services/claim-extractor.ts
@@ -84,7 +84,11 @@ export async function extractClaims(
               .string()
               .nullable()
               .describe("Date of the underlying fact if the source states one"),
-            confidence: z.number().min(0).max(1),
+            // No .min/.max here: Zod range checks compile to JSON Schema
+            // minimum/maximum, which Anthropic structured outputs reject
+            // with a 400 for number types. Range lives in prose; the value
+            // is clamped after parsing.
+            confidence: z.number().describe("Confidence in the claim, 0 to 1"),
           }),
         ),
       }),
@@ -126,7 +130,7 @@ ${wrapUntrusted(sourceBlocks.join("\n\n"))}`,
         statement: c.statement,
         sourceUrl: sources[c.sourceIndex].url,
         publishedDate: c.publishedDate ?? sources[c.sourceIndex].publishedDate,
-        confidence: c.confidence,
+        confidence: Math.min(1, Math.max(0, c.confidence)),
         extractedAt,
         status: "unverified" as const,
       }));

--- a/src/lib/services/person-enrichment.ts
+++ b/src/lib/services/person-enrichment.ts
@@ -26,7 +26,9 @@ export interface PersonEnrichmentResult {
 
 /** The columns enrichment reads. Exported so callers can select exactly these. */
 export const PERSON_ENRICH_COLUMNS =
-  "name, title, linkedin_url, twitter_url, organization:organizations(name)";
+  // !organization_id disambiguates: people carries a second FK to
+  // organizations (affiliation_detached_from), so unhinted embeds error.
+  "name, title, linkedin_url, twitter_url, organization:organizations!organization_id(name)";
 
 export interface PersonForEnrichment {
   name: string;

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -485,6 +485,30 @@ async function enrichContactById(
 }> {
   const supabase = await createClient();
 
+  // Agents routinely pass the campaign_people link ID here instead of the
+  // person ID. That used to "enrich" a person that doesn't exist: no name,
+  // no socials, nothing to search, ending in status "failed" that the batch
+  // tool then filed under `succeeded`. Resolve link IDs; reject the rest.
+  const { data: personExists } = await supabase
+    .from("people")
+    .select("id")
+    .eq("id", personId)
+    .maybeSingle();
+  if (!personExists) {
+    const { data: link } = await supabase
+      .from("campaign_people")
+      .select("person_id")
+      .eq("id", personId)
+      .maybeSingle();
+    if (!link) {
+      throw new Error(
+        `No person found for ID ${personId}. Pass the person ID ` +
+          `(people.id, the person_id field on getContacts rows), not a campaign-people link ID.`,
+      );
+    }
+    personId = link.person_id;
+  }
+
   // Check recency -- skip if recently enriched
   const recent = await isRecentlyEnriched("people", personId);
   if (recent) {
@@ -506,7 +530,10 @@ async function enrichContactById(
   const { data: person } = await supabase
     .from("people")
     .select(
-      "name, title, linkedin_url, twitter_url, organization:organizations(name)",
+      // The !organization_id hint is load-bearing: people has a second FK to
+      // organizations (affiliation_detached_from), so an unhinted embed is
+      // ambiguous and PostgREST rejects the whole query.
+      "name, title, linkedin_url, twitter_url, organization:organizations!organization_id(name)",
     )
     .eq("id", personId)
     .single();
@@ -785,7 +812,12 @@ export const enrichContact = tool({
   description:
     "Enrich a single contact and write results to the DB. Returns a THIN summary (counts of news/articles, has-linkedin flags) -- NOT the full enrichment payload. If you need to read the enriched content (e.g. to personalize an email), call getContactDetail(personId). For multiple contacts, use enrichContacts (parallel). Skips if recently enriched (<7 days).",
   inputSchema: z.object({
-    contactId: z.string().uuid().describe("Person ID to enrich"),
+    contactId: z
+      .string()
+      .uuid()
+      .describe(
+        "Person ID (people.id, the person_id field on getContacts rows), NOT the campaign-people link ID",
+      ),
     linkedinUrl: z
       .string()
       .optional()
@@ -811,7 +843,9 @@ export const enrichContacts = tool({
       .array(z.string().uuid())
       .min(1)
       .max(10)
-      .describe("Array of person IDs to enrich (max 10)"),
+      .describe(
+        "Array of person IDs (people.id, the person_id field on getContacts rows, NOT campaign-people link IDs). Max 10.",
+      ),
   }),
   execute: async (input, { experimental_context }) => {
     const deadlineAt = deadlineFrom(experimental_context);
@@ -842,11 +876,23 @@ export const enrichContacts = tool({
 
       results.forEach((result, j) => {
         if (result.status === "fulfilled") {
-          succeeded.push({
-            contactId: result.value.contactId,
-            status: result.value.status,
-            skipped: result.value.skipped,
-          });
+          // A fulfilled promise whose enrichment ended in status "failed" is
+          // a failure. Filing it under `succeeded` made the summary read
+          // "succeeded: N, failed: 0" while every row said failed.
+          if (result.value.status === "failed") {
+            failed.push({
+              contactId: result.value.contactId,
+              error:
+                result.value.errors?.join("; ") ||
+                "All enrichment sources failed",
+            });
+          } else {
+            succeeded.push({
+              contactId: result.value.contactId,
+              status: result.value.status,
+              skipped: result.value.skipped,
+            });
+          }
         } else {
           failed.push({
             contactId: chunk[j],
@@ -1481,6 +1527,12 @@ export const enrichCompany = tool({
       .string()
       .uuid()
       .describe("Organization ID or campaign-organization link ID to enrich"),
+    companyName: z
+      .string()
+      .optional()
+      .describe(
+        "Company name for the UI. Display-only: the lookup always uses companyId. Always pass when known.",
+      ),
     campaignId: z
       .string()
       .uuid()
@@ -1501,6 +1553,12 @@ export const enrichCompanies = tool({
       .max(10)
       .describe(
         "Array of organization IDs or campaign-organization link IDs to enrich (max 10)",
+      ),
+    companyNames: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Company names matching companyIds, in the same order. Display-only: shown in the UI while the batch runs; lookups always use the IDs. Always pass when known.",
       ),
     campaignId: z
       .string()
@@ -1698,19 +1756,33 @@ export const findContacts = tool({
     }
 
     // Resolve the organization — either via the campaign link or directly.
+    // Agents regularly cross the two ID kinds, so a miss on the link table
+    // falls back to treating the ID as an organization ID before failing.
+    // The old path surfaced PostgREST's "Cannot coerce the result to a
+    // single JSON object", which tells the agent nothing actionable.
     let orgId: string;
     if (input.companyId) {
-      const { data: link, error: linkError } = await supabase
+      const { data: link } = await supabase
         .from("campaign_organizations")
         .select("organization_id")
         .eq("id", input.companyId)
-        .single();
-      if (linkError || !link) {
-        throw new Error(
-          `Company not found: ${linkError?.message || "Unknown"}`,
-        );
+        .maybeSingle();
+      if (link) {
+        orgId = link.organization_id;
+      } else {
+        const { data: org } = await supabase
+          .from("organizations")
+          .select("id")
+          .eq("id", input.companyId)
+          .maybeSingle();
+        if (!org) {
+          throw new Error(
+            `No campaign-organization link or organization found for ID ${input.companyId}. ` +
+              `Use the "id" of a row from getCompanies as companyId, or pass an organization ID as organizationId.`,
+          );
+        }
+        orgId = org.id;
       }
-      orgId = link.organization_id;
     } else {
       orgId = input.organizationId!;
     }
@@ -1778,7 +1850,7 @@ export const getContacts = tool({
     const query = supabase
       .from("campaign_people")
       .select(
-        "id, person_id, campaign_id, outreach_status, priority_score, score_reason, created_at, updated_at, person:people(name, title, work_email, personal_email, linkedin_url, twitter_url, enrichment_status, source, organization_id, organization:organizations(name, domain, industry))",
+        "id, person_id, campaign_id, outreach_status, priority_score, score_reason, created_at, updated_at, person:people(name, title, work_email, personal_email, linkedin_url, twitter_url, enrichment_status, source, organization_id, organization:organizations!organization_id(name, domain, industry))",
       )
       .eq("campaign_id", input.campaignId)
       .order("priority_score", { ascending: false, nullsFirst: false })
@@ -1799,22 +1871,37 @@ export const getContacts = tool({
       );
     }
 
-    // Filter by company (campaign_organizations link)
+    // Filter by company (campaign_organizations link). A bad ID used to be
+    // silently ignored, returning the unfiltered list as if it were the
+    // company's contacts — fail loudly instead, accepting either ID kind.
     if (input.companyId) {
-      // Get the organization_id for this campaign_organizations link
       const { data: link } = await supabase
         .from("campaign_organizations")
         .select("organization_id")
         .eq("id", input.companyId)
-        .single();
+        .maybeSingle();
 
-      if (link) {
-        results = results.filter(
-          (r) =>
-            (r.person as unknown as { organization_id: string | null } | null)
-              ?.organization_id === link.organization_id,
+      let filterOrgId = link?.organization_id;
+      if (!filterOrgId) {
+        const { data: org } = await supabase
+          .from("organizations")
+          .select("id")
+          .eq("id", input.companyId)
+          .maybeSingle();
+        filterOrgId = org?.id;
+      }
+      if (!filterOrgId) {
+        throw new Error(
+          `No campaign-organization link or organization found for companyId ${input.companyId}. ` +
+            `Use the "id" of a row from getCompanies, or omit companyId for all contacts.`,
         );
       }
+
+      results = results.filter(
+        (r) =>
+          (r.person as unknown as { organization_id: string | null } | null)
+            ?.organization_id === filterOrgId,
+      );
     }
 
     // Flatten for backwards compat
@@ -1875,7 +1962,7 @@ export const getContactDetail = tool({
     const { data, error } = await supabase
       .from("people")
       .select(
-        "id, name, title, work_email, personal_email, linkedin_url, twitter_url, enrichment_status, enrichment_data, organization:organizations(id, name, domain, industry, location, description, enrichment_data, enrichment_status)",
+        "id, name, title, work_email, personal_email, linkedin_url, twitter_url, enrichment_status, enrichment_data, organization:organizations!organization_id(id, name, domain, industry, location, description, enrichment_data, enrichment_status)",
       )
       .eq("id", personId)
       .single();
@@ -1985,6 +2072,12 @@ export const scoreCompany = tool({
       .string()
       .uuid()
       .describe("Campaign-organization link ID to score"),
+    companyName: z
+      .string()
+      .optional()
+      .describe(
+        "Company name for the UI. Display-only: the lookup always uses companyId. Always pass when known.",
+      ),
     score: z
       .number()
       .min(1)


### PR DESCRIPTION
## Why

A campaign run surfaced three prod failures, and the chat/settings UI had a set of agreed polish items. Full write-up with root causes in `docs/plans/2026-08-03-ui-fixes.md`.

## Prod fixes

- **Ambiguous `people`→`organizations` embeds.** The `affiliation_detach` migration (Aug 2) added a second FK from `people` to `organizations`, so every unhinted PostgREST embed between them started erroring with PGRST201. Nine sites now hint through `!organization_id`: the campaign detail page (which swallowed the error and showed **0 contacts / 105 companies without leads** over a fully linked campaign), `getContacts`, `getContactDetail`, `enrichContactById` (silently lost its company anchor, feeding the namesake-merge problem), person enrichment, voice-swipe recipient, the outreach page, and refresh-scores. The campaign page also surfaces sub-query errors now instead of rendering them as an empty campaign.
- **Claim extractor 400 on every call.** `z.number().min(0).max(1)` compiles to JSON Schema `minimum`/`maximum`, which Anthropic structured outputs reject for numbers, so every extraction failed open to zero claims. Range moved to prose, value clamped after parse.
- **Wrong-ID-kind tool failures.** `findContacts`/`getContacts` auto-resolve an organization ID passed as a link ID and otherwise fail with an actionable message instead of a raw PostgREST coerce error; `enrichContactById` resolves campaign-people link IDs and rejects unknown IDs instead of "enriching" nobody; batch `enrichContacts` no longer counts failed enrichments as `succeeded`.

## UI

- `/chat` shows 8 recent chats with a "Show all (N)" toggle, titles stripped of raw markdown.
- Composer grows to ~6 lines (one shared 160px constant) before scrolling.
- Tool-call cards: user-facing labels for all 64 tools, runs of ≥3 same-tool calls collapse into one expandable row with live progress, and cards show their subject (query/URL/company names). Enrich/score tools grew display-only `companyName(s)` fields so the UI can name companies while a batch runs.
- Settings loses the Usage tab; `CostCenter` + `/api/settings/costs` remain for a future admin-only view (that view should add a role check on the route).

## Verification

- Typecheck, ESLint (0 errors), and all 697 unit tests pass.
- The supabase test fake now parses FK-column hints and validates them against the registered relation, so a hint naming the wrong column fails in tests the way PostgREST would in prod.
- Verified against real local PostgREST: the unhinted embed reproduces the exact PGRST201 prod error; the hinted form resolves.

## Deploy note

Prod deploys are manual from the prod Vercel account; no migrations involved. The claims pipeline and campaign contact lists stay broken in prod until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)