### PR TITLE
fix(email): resolve the sender through the admin client (blocks the prod migration)

### DIFF
--- a/src/__tests__/email-tools-send.test.ts
+++ b/src/__tests__/email-tools-send.test.ts
@@ -6,11 +6,20 @@ import { sendGmailMessage } from "@/lib/services/gmail-service";
 const h = vi.hoisted(() => ({
   createClient: vi.fn(),
   getSupabaseAndUser: vi.fn(),
+  // getAdminClient is synchronous, unlike createClient, so it needs its own
+  // handle rather than reusing the resolved one.
+  adminClient: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: h.createClient,
   getSupabaseAndUser: h.getSupabaseAndUser,
+}));
+// The send tools resolve the sender through the admin client, because
+// gmail_app_password_enc is not readable by the `authenticated` role. Same
+// fake, so the ordered responses below still describe the whole conversation.
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: () => h.adminClient(),
 }));
 vi.mock("@/lib/services/gmail-service", async (importOriginal) => {
   const actual =
@@ -104,6 +113,7 @@ beforeEach(() => {
   process.env.EMAIL_CREDENTIALS_KEY = Buffer.alloc(32, 7).toString("base64");
   sendGmailMock.mockReset();
   h.createClient.mockReset();
+  h.adminClient.mockReset();
 });
 
 afterEach(() => {
@@ -130,6 +140,7 @@ describe("sendEmail review gating", () => {
   ) {
     const fake = fakeSupabase(responses);
     h.createClient.mockResolvedValue(fake.client);
+    h.adminClient.mockReturnValue(fake.client);
     return fake;
   }
 
@@ -244,6 +255,7 @@ describe("sendBulkEmails review gating", () => {
       {}, // campaign_people → sent
     ]);
     h.createClient.mockResolvedValue(fake.client);
+    h.adminClient.mockReturnValue(fake.client);
     sendGmailMock.mockResolvedValue({ messageId: "<m1@sahnan.co>" });
 
     const result = (await sendBulkEmails.execute!(
@@ -280,6 +292,7 @@ describe("sendBulkEmails review gating", () => {
       },
     ]);
     h.createClient.mockResolvedValue(fake.client);
+    h.adminClient.mockReturnValue(fake.client);
 
     const result = (await sendBulkEmails.execute!(
       { campaignId: "camp_1" },

--- a/src/lib/tools/email-tools.ts
+++ b/src/lib/tools/email-tools.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { createClient, getSupabaseAndUser } from "@/lib/supabase/server";
+import { getAdminClient } from "@/lib/supabase/admin";
 import { callerHoldsPerson, toolSession } from "@/lib/tools/ownership";
 import { ExaService } from "@/lib/services/exa-service";
 import { trackUsage } from "@/lib/services/cost-tracker";
@@ -931,7 +932,16 @@ export const sendEmail = tool({
       return { error: stepCheck.reason };
     }
 
-    const sender = await resolveSenderConfig(supabase, draft.user_id);
+    // The credential read has to go through the admin client.
+    //
+    // gmail_app_password_enc is not selectable by the `authenticated` role --
+    // only server code needs the ciphertext, so the browser's grant was
+    // removed rather than left to RLS. Handing resolveSenderConfig this
+    // request's RLS-scoped client makes PostgREST refuse the whole select with
+    // "permission denied for table user_settings", which reads here as an
+    // unconfigured mailbox: every agent-initiated send would refuse with
+    // "Email is not configured" while the cron path kept working.
+    const sender = await resolveSenderConfig(getAdminClient(), draft.user_id);
     if ("error" in sender) {
       return { error: sender.error };
     }
@@ -1096,7 +1106,8 @@ export const sendBulkEmails = tool({
 
       // Re-resolved per draft rather than once up front: the pause switch has
       // to bite mid-batch, which is exactly when someone reaches for it.
-      const sender = await resolveSenderConfig(supabase, draft.user_id);
+      // Admin client for the same reason as sendEmail above.
+      const sender = await resolveSenderConfig(getAdminClient(), draft.user_id);
       if ("error" in sender) {
         results.push({
           draftId: draft.id,


### PR DESCRIPTION
**Blocks the production migration.** Found while checking `20260804000000_tenant_policy_hardening.sql` against deployed code before running `supabase db push`.

That migration removes the `authenticated` role's grant on `user_settings.gmail_app_password_enc` — only server code needs the ciphertext, so it is not left to RLS. But `sendEmail` and `sendBulkEmails` hand `resolveSenderConfig` the request's RLS-scoped client, and its select names that column. PostgREST refuses the whole statement:

```
ERROR:  permission denied for table user_settings
```

`resolveSenderConfig` reads that as no row and returns `"Email is not configured"`. So applying the migration against today's `main` would have made **every agent-initiated send refuse**, while the cron path — which already uses the admin client — kept working. That asymmetry would have been unpleasant to diagnose.

Reading as admin is not a widening: the row is pinned by the `user_id` the caller has already established, and the decrypted password goes straight to nodemailer without leaving the server. `service_role` keeps the column privilege and bypasses RLS, so this is exactly the path the revoke was designed to leave open.

Kept narrow deliberately: `resolveSenderConfig` still takes a client, and the cron path still passes its own. Only the two agent tools changed. An earlier attempt moved the read inside `resolveSenderConfig`, which broke the positional fakes in three test files and made those tests say less than they do now.

## Verification

`pnpm typecheck` clean, `pnpm lint` 0 errors, `pnpm test` 749 passing. Confirmed against the hardened local database: `has_column_privilege('authenticated', ...)` is `false` and `service_role` is `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
