### PR TITLE
fix(email): read the test-send credential through the admin client

### DIFF
--- a/src/app/api/settings/email/test/route.ts
+++ b/src/app/api/settings/email/test/route.ts
@@ -14,6 +14,7 @@ import {
   sendGmailMessage,
 } from "@/lib/services/gmail-service";
 import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { getAdminClient } from "@/lib/supabase/admin";
 
 // The IMAP socket timeout is 60s, so the settings route's 30 is not enough
 // for a check that has to connect, fetch and log out.
@@ -60,7 +61,11 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { supabase, user } = ctx;
 
-  const { data } = await supabase
+  // Admin client: SELECT names gmail_app_password_enc, which the
+  // `authenticated` role may not read, and PostgREST refuses the whole
+  // statement rather than the one column. The row is still pinned by the
+  // user_id getSupabaseAndUser established.
+  const { data } = await getAdminClient()
     .from("user_settings")
     .select(SELECT)
     .eq("user_id", user.id)
@@ -91,7 +96,8 @@ export async function POST(request: Request) {
   const { supabase, user } = ctx;
   const body = await request.json();
 
-  const { data } = await supabase
+  // Admin client, same reason as the GET above.
+  const { data } = await getAdminClient()
     .from("user_settings")
     .select(SELECT)
     .eq("user_id", user.id)


### PR DESCRIPTION
Second and final blocker for the production migration, same shape as #62 one route further along.

`/api/settings/email/test` selects `gmail_app_password_enc` through the RLS-scoped client. After `20260804000000` the `authenticated` role cannot read that column, and PostgREST refuses the **whole statement** rather than the single column, so Settings > Email would report "not connected" for a connected mailbox and both send-test and check-reply would refuse.

Verified empirically against a hardened local database, both directions:

| client | result |
| --- | --- |
| RLS-scoped (before) | `connected=null` for a fully connected mailbox |
| admin (after) | `connected="probe@example.com"` |

Worth stating plainly: **no test covers this route handler** — only the pure helpers in `email-test.ts` — so the green unit suite was not evidence here, which is why I probed the running endpoint instead.

I have now swept every reader of that column. Six files touch it: this one and `email-tools.ts` (#62) needed fixing; `settings/email/route.ts` only writes it (the revoke was SELECT-only and its upserts do not chain `.select()`); `email-track.ts` and `reply-backfill.ts` already use the admin client; and `email-transport.ts` takes a client whose three callers all now pass admin. That closes this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)