### PR TITLE
fix(auth): apply the Clerk-load wait to apiFetch too

### DIFF
--- a/src/lib/api-fetch.ts
+++ b/src/lib/api-fetch.ts
@@ -3,11 +3,19 @@
 import { toast } from "sonner";
 
 interface ClerkWindow {
-  Clerk?: { session?: { getToken: () => Promise<string | null> } };
+  Clerk?: {
+    loaded?: boolean;
+    session?: { getToken: () => Promise<string | null> };
+  };
 }
 
 /**
  * A freshly-minted Clerk session token, or null when signed out.
+ *
+ * Waits for the Clerk script to finish initializing first — pages fetch in
+ * mount effects, which on a hard load race Clerk's async bootstrap, and a
+ * token read before it lands sends the request unauthenticated. Bounded so a
+ * broken Clerk script degrades to an anonymous request instead of hanging.
  *
  * `getToken()` returns the cached token and transparently refreshes it when it
  * is close to expiring, so calling this per request is the point — not waste.
@@ -15,11 +23,13 @@ interface ClerkWindow {
 export async function getSessionToken(): Promise<string | null> {
   if (typeof window === "undefined") return null;
 
-  const token = await (
-    window as unknown as ClerkWindow
-  ).Clerk?.session?.getToken();
+  const w = window as unknown as ClerkWindow;
+  const deadline = Date.now() + 10_000;
+  while (!w.Clerk?.loaded && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
 
-  return token ?? null;
+  return (await w.Clerk?.session?.getToken()) ?? null;
 }
 
 // Several calls can fail together (e.g. Send All fires one request per draft).

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -2,50 +2,26 @@
 
 import { createBrowserClient } from "@supabase/ssr";
 
+import { getSessionToken } from "@/lib/api-fetch";
+
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
-
-interface ClerkWindow {
-  Clerk?: {
-    loaded?: boolean;
-    session?: { getToken: () => Promise<string | null> };
-  };
-}
-
-/**
- * Waits for the Clerk script to finish initializing, then returns the session
- * token (null when signed out).
- *
- * The wait is load-bearing: pages fetch in mount effects, which on a hard
- * load race Clerk's async bootstrap. Reading the token too early sends the
- * request anonymously, RLS matches nothing, and the page renders empty with
- * no error. Bounded so a broken Clerk script degrades to today's behavior
- * (anonymous request) instead of hanging every query forever.
- */
-async function getClerkToken(): Promise<string | null> {
-  const w = window as unknown as ClerkWindow;
-  const deadline = Date.now() + 10_000;
-  while (!w.Clerk?.loaded && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-  return (await w.Clerk?.session?.getToken()) ?? null;
-}
 
 /**
  * Browser Supabase client that forwards the Clerk session token as a Bearer
  * header on every request. Supabase's third-party auth integration validates
  * the JWT and exposes the Clerk user id as `auth.jwt() ->> 'sub'` for RLS.
  *
- * Reads the token from `window.Clerk.session` (initialized by ClerkProvider)
- * so callers don't need a hook context — works inside callbacks, effects,
- * imperative service functions.
+ * `getSessionToken` waits for Clerk's async bootstrap before reading the
+ * token — the wait is load-bearing here. Pages query in mount effects, which
+ * on a hard load race the Clerk script; a query sent early goes out
+ * anonymously, RLS matches nothing, and the page renders empty with no error.
  */
 export const createClient = () =>
   createBrowserClient(supabaseUrl!, supabaseKey!, {
     global: {
       fetch: async (input, init = {}) => {
-        const token =
-          typeof window !== "undefined" ? await getClerkToken() : null;
+        const token = await getSessionToken();
         const headers = new Headers(init.headers);
         if (token) headers.set("Authorization", `Bearer ${token}`);
         return fetch(input, { ...init, headers });


### PR DESCRIPTION
Follow-up to #67, which merged before this commit landed on the branch.

`getSessionToken` in `api-fetch.ts` had the same race #67 fixed in the Supabase client: mount-time `apiFetch` callers (dashboard, integrations status, learnings, email settings, outreach) could read `window.Clerk` before it loaded and send requests with no Bearer token. The `__session` cookie fallback usually covers it, but a stale cookie on a fresh visit means a spurious 401 and an "expired session" toast on first paint.

## Changes

- `src/lib/api-fetch.ts`: `getSessionToken` waits (bounded at 10s) for `window.Clerk.loaded` before reading the token.
- `src/lib/supabase/client.ts`: drops its own copy of the wait and reuses `getSessionToken`, one source of truth for both paths.

## Testing

- `pnpm typecheck` clean, `pnpm test` 844 passed, prettier clean (verified on this exact diff before #67 was merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)