### PR TITLE
fix(voice): pass profile notes to the swipe drafter; widen draft body cap

### DIFF
--- a/src/lib/email-skills/swipe-prompts.ts
+++ b/src/lib/email-skills/swipe-prompts.ts
@@ -42,11 +42,16 @@ export const DraftAxesSchema = z.object({
   signoff: z.enum(["name", "none", "best", "regards"]),
 });
 
+// Body cap matches the transcript's JudgedSchema bound (4,000), so any draft
+// the model produces can always round-trip onto the deck and back. The bound
+// no longer reaches the model (the wire schema cannot carry it), so one
+// long-winded draft must not sink the whole batch: keep it generous and let
+// the user steer length through feedback instead.
 export const DraftSchema = z.object({
   subject: z.string().max(200),
   body: z
     .string()
-    .max(2_000)
+    .max(4_000)
     .describe("Plain text. Real line breaks, no HTML."),
   axes: DraftAxesSchema,
 });
@@ -275,6 +280,9 @@ export interface SwipeSender {
   roleTitle?: string | null;
   companyName?: string | null;
   offeringSummary?: string | null;
+  /** Free-form profile notes: constraints and corrections the user wrote for
+   * the drafter ("solo consultant", "do not use company name in sign-off"). */
+  notes?: string | null;
   /** The rendered SENDER FACT BANK block, already fenced by renderFactBank.
    * Null when the user has no facts, which renders nothing. */
   factBank?: string | null;
@@ -304,6 +312,7 @@ function renderSender(sender: SwipeSender | null | undefined): string {
         field("Role", sender.roleTitle),
         field("Company", sender.companyName),
         field("What they sell", sender.offeringSummary),
+        field("Sender notes (follow these)", sender.notes),
       ].filter(Boolean) as string[])
     : [];
 

--- a/src/lib/email-skills/swipe-service.ts
+++ b/src/lib/email-skills/swipe-service.ts
@@ -157,6 +157,7 @@ async function loadPromptContext(
           roleTitle: profile.role_title,
           companyName: profile.company_name,
           offeringSummary: profile.offering_summary,
+          notes: profile.notes,
           factBank,
         }
       : null,


### PR DESCRIPTION
Follow-up to #69, which merged before this commit landed on the branch (same race as #67/#68).

Two live failures from the voice drafting session:

- **Profile notes never reached the swipe drafter.** It passed only name, role, company, and offering to the model; the Additional Notes field (where constraints like "solo consultant", "do not use company name in sign-off", and role corrections live) was dropped, so drafts contradicted the profile. Notes now render in the sender block. The chat agent and the real outreach composer already included notes; this brings the swipe deck in line.
- **"No object generated: response did not match schema" on rewrites.** Draft bodies were capped at 2,000 chars in the model-output schema. Since #69, length bounds no longer reach the model, so a request for longer emails made one draft overrun and client-side validation killed the whole batch. The cap now matches the transcript's own 4,000-char JudgedSchema bound, so any generated draft can round-trip onto the deck; length is steered by user feedback instead of a hidden ceiling.

## Testing

- `pnpm typecheck` clean, `pnpm lint` clean, `pnpm test` 852/852, prettier clean (verified on this exact diff before #69 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)