### PR TITLE
fix(voice): cap transcript sent to server; retry flaky batch generations

### DIFF
--- a/src/lib/email-skills/swipe-run.ts
+++ b/src/lib/email-skills/swipe-run.ts
@@ -1,7 +1,10 @@
-import type {
-  DraftAxes,
-  JudgedDraft,
-  SwipeTranscript,
+import {
+  MAX_INSTRUCTIONS_IN_PROMPT,
+  MAX_JUDGED_IN_PROMPT,
+  MAX_SAMPLES_IN_PROMPT,
+  type DraftAxes,
+  type JudgedDraft,
+  type SwipeTranscript,
 } from "@/lib/email-skills/swipe-prompts";
 
 /**
@@ -61,11 +64,17 @@ export function newRun(campaignId: string | null, samples: string[]): VoiceRun {
 
 /** What the agent needs to continue the run: exactly the transcript shape the
  * batch and skill prompts consume. Queue and UI state stay client-side. */
+/**
+ * Truncated to the same windows the batch prompt renders, because the server
+ * rejects anything larger. A long run judges far more than 50 drafts, and
+ * sending the full history made every request past that point fail
+ * validation: the deck could never top up again.
+ */
 export function toTranscript(run: VoiceRun): SwipeTranscript {
   return {
-    judged: run.judged,
-    instructions: run.instructions,
-    samples: run.samples,
+    judged: run.judged.slice(-MAX_JUDGED_IN_PROMPT),
+    instructions: run.instructions.slice(-MAX_INSTRUCTIONS_IN_PROMPT),
+    samples: run.samples.slice(0, MAX_SAMPLES_IN_PROMPT),
   };
 }
 

--- a/src/lib/email-skills/swipe-service.ts
+++ b/src/lib/email-skills/swipe-service.ts
@@ -5,7 +5,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { apiSafeSchema } from "@/lib/ai/api-safe-schema";
 import { MODELS } from "@/lib/ai/models";
-import { salvageObject } from "@/lib/ai/salvage-object";
+import { generateWithRetry } from "@/lib/ai/salvage-object";
 import {
   BatchSchema,
   MAX_INSTRUCTIONS_IN_PROMPT,
@@ -189,51 +189,50 @@ export async function generateVoiceBatch(
     input.campaignId,
   );
 
-  try {
-    const { object } = await generateObject({
-      abortSignal: llmTimeout(),
-      model: anthropic(MODELS.EMAIL),
-      schema: apiSafeSchema(BatchSchema),
-      system: buildBatchSystem(campaign, senderContext),
-      prompt: buildBatchPrompt(input.transcript, input.count),
-      providerOptions: {
-        anthropic: {
-          // Only the transcript changes between batches, so the rules and
-          // campaign context read from cache after the first call.
-          cacheControl: { type: "ephemeral" },
-          effort: "medium",
+  // The wrapped-payload flake hits these prompts like every other Opus 5
+  // structured call, so single-shot + salvage was not enough: a malformed
+  // wrapper surfaced straight to the deck as a failed batch. generateWithRetry
+  // salvages what it can and retries the rest.
+  const result = await generateWithRetry(
+    async () => {
+      const { object } = await generateObject({
+        abortSignal: llmTimeout(),
+        model: anthropic(MODELS.EMAIL),
+        schema: apiSafeSchema(BatchSchema),
+        system: buildBatchSystem(campaign, senderContext),
+        prompt: buildBatchPrompt(input.transcript, input.count),
+        providerOptions: {
+          anthropic: {
+            // Only the transcript changes between batches, so the rules and
+            // campaign context read from cache after the first call.
+            cacheControl: { type: "ephemeral" },
+            effort: "medium",
+          },
         },
-      },
-      // generateWithRetry owns retrying elsewhere; leaving the SDK default of
-      // 2 would stack upstream requests under a 429 storm.
-      maxRetries: 0,
-      // Opus 5 thinks by default and maxOutputTokens caps thinking plus
-      // visible output together, so a budget sized for the text alone
-      // truncates and fails generateObject outright.
-      // Sized for 8 drafts plus the invented persona object, with thinking
-      // headroom on top (Opus 5 thinks by default and this cap covers both).
-      maxOutputTokens: 10_000,
-    });
-    return {
-      ok: true,
-      drafts: object.drafts,
-      persona: { label: personaLabel(object.persona) },
-    };
-  } catch (err) {
-    const salvaged = salvageObject(err, BatchSchema);
-    if (salvaged) {
-      return {
-        ok: true,
-        drafts: salvaged.drafts,
-        persona: { label: personaLabel(salvaged.persona) },
-      };
-    }
-    return {
-      ok: false,
-      error:
-        err instanceof Error ? err.message : "Could not write the next drafts",
-    };
+        // generateWithRetry owns retrying; leaving the SDK default of 2 would
+        // stack upstream requests under a 429 storm.
+        maxRetries: 0,
+        // Opus 5 thinks by default and maxOutputTokens caps thinking plus
+        // visible output together, so a budget sized for the text alone
+        // truncates and fails generateObject outright.
+        // Sized for 8 drafts plus the invented persona object, with thinking
+        // headroom on top (Opus 5 thinks by default and this cap covers both).
+        maxOutputTokens: 10_000,
+      });
+      return object;
+    },
+    BatchSchema,
+    3,
+  );
+
+  if (!result.ok) {
+    return { ok: false, error: result.error };
   }
+  return {
+    ok: true,
+    drafts: result.value.drafts,
+    persona: { label: personaLabel(result.value.persona) },
+  };
 }
 
 /**
@@ -254,32 +253,27 @@ async function writeSkill(
     input.campaignId,
   );
 
-  let skill: { instructions: string; summary: string };
-  try {
-    const { object } = await generateObject({
-      abortSignal: llmTimeout(),
-      model: anthropic(MODELS.EMAIL),
-      schema: apiSafeSchema(SkillSchema),
-      system: buildSkillSystem(campaign, senderContext),
-      prompt: buildSkillPrompt(input.transcript),
-      providerOptions: { anthropic: { effort: "medium" } },
-      maxRetries: 0,
-      maxOutputTokens: 5_000,
-    });
-    skill = object;
-  } catch (err) {
-    const salvaged = salvageObject(err, SkillSchema);
-    if (!salvaged) {
-      return {
-        ok: false,
-        error:
-          err instanceof Error
-            ? err.message
-            : "Could not write the voice rules",
-      };
-    }
-    skill = salvaged;
+  const skillResult = await generateWithRetry(
+    async () => {
+      const { object } = await generateObject({
+        abortSignal: llmTimeout(),
+        model: anthropic(MODELS.EMAIL),
+        schema: apiSafeSchema(SkillSchema),
+        system: buildSkillSystem(campaign, senderContext),
+        prompt: buildSkillPrompt(input.transcript),
+        providerOptions: { anthropic: { effort: "medium" } },
+        maxRetries: 0,
+        maxOutputTokens: 5_000,
+      });
+      return object;
+    },
+    SkillSchema,
+    3,
+  );
+  if (!skillResult.ok) {
+    return { ok: false, error: skillResult.error };
   }
+  const skill = skillResult.value;
 
   const instructions = normaliseInstructions(skill.instructions);
   if (!instructions) {


### PR DESCRIPTION
Fixes the recurring "Ran into an issue generating the next batch" during long swipe runs. Two independent causes:

- **Hard wall after ~50 swipes.** `toTranscript` sent the entire judged history, but `VoiceRunBodySchema` rejects more than `MAX_JUDGED_IN_PROMPT + 10` (50) judged drafts, and the batch prompt only renders the last 40 anyway. Once a run crossed 50 judgements, every subsequent request failed validation and the deck could never top up again. Same trap existed for typed instructions at 50. The client now truncates to the same windows the prompt renders (last 40 judged, last 40 instructions, first 10 samples).
- **Intermittent single-shot failures.** `generateVoiceBatch` and `writeSkill` called the model once with salvage-only recovery, while the email composer already uses `generateWithRetry` for the known Opus 5 wrapped-payload flake (~20-40% of structured calls; salvage recovers well-formed wrappers, retries cover malformed ones). A malformed wrapper therefore surfaced straight to the deck as a failed batch. Both paths now use `generateWithRetry` with 3 attempts; abort/timeout still short-circuits.

## Testing

- `pnpm typecheck` clean, `pnpm lint` clean (pre-existing warnings only), `pnpm test` 852/852, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)