### PR TITLE
feat(chat): getEmailVoices tool so the agent can check saved voices

### DIFF
--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -162,6 +162,7 @@ Every contact carries evidence for *why* we believe they work where we say they 
 - Never use generic templates -- each email should reference something specific about the recipient
 
 ### Email Voice Profile
+- Use \`getEmailVoices\` to check what voices exist (campaign-scoped and the user default) BEFORE telling the user they have no voice or sending them to build one. Never assert a voice is missing without calling it
 - An email voice profile is built on the swipe deck at /email-skills: you write real drafts, the user keeps or passes them, and the run converges into rules. The run itself starts on that page (it opens with a paste-your-own-writing step); you cannot start one from chat, so when a user wants a voice, send them there
 - Voice is **per campaign**: each campaign gets its own, built against that campaign's ICP and offering, because which signal to open on and which credibility framing lands differ by audience. A user-level default also exists and is used for any campaign without its own
 - **During an active voice run** (short "Voice run:" messages arrive automatically while the user swipes):

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -83,6 +83,7 @@ import {
   rewriteVoiceDrafts,
   saveVoiceProfile,
   refineEmailVoice,
+  getEmailVoices,
 } from "./voice-tools";
 import {
   listEmailLearnings,
@@ -162,6 +163,7 @@ const rawTools = {
   rewriteVoiceDrafts,
   saveVoiceProfile,
   refineEmailVoice,
+  getEmailVoices,
   listEmailLearnings,
   addEmailLearning,
   setEmailLearningStatus,

--- a/src/lib/tools/voice-tools.ts
+++ b/src/lib/tools/voice-tools.ts
@@ -290,3 +290,42 @@ export const refineEmailVoice = tool({
     };
   },
 });
+
+export const getEmailVoices = tool({
+  description:
+    "List the user's saved email voice profiles: campaign-scoped voices and " +
+    "the user-level default. ALWAYS call this before claiming a voice does or " +
+    "does not exist (e.g. before sending the user to /email-skills to build " +
+    "one). A campaign without its own voice falls back to the default; drafts " +
+    "use generic base rules only when neither exists.",
+  inputSchema: z.object({}),
+  execute: async () => {
+    const auth = await getSupabaseAndUser();
+    if (!auth) return { error: "No authenticated session in tool context." };
+
+    // RLS scopes rows to the signed-in user; campaign name rides along so the
+    // model can answer "which campaigns have a voice" without a second call.
+    const { data, error } = await auth.supabase
+      .from("email_voice_profiles")
+      .select("campaign_id, summary, updated_at, campaign:campaigns(name)")
+      .order("updated_at", { ascending: false });
+    if (error) return { error: error.message };
+
+    const voices = (data ?? []).map((v) => ({
+      scope: v.campaign_id ? "campaign" : "default",
+      campaignId: (v.campaign_id as string | null) ?? null,
+      campaignName:
+        ((v.campaign as { name?: string } | null)?.name as string | null) ??
+        null,
+      summary: (v.summary as string | null) ?? null,
+      updatedAt: v.updated_at as string,
+    }));
+    return {
+      voices,
+      note:
+        voices.length === 0
+          ? "No email voices saved yet, at any scope."
+          : "A campaign without its own voice falls back to the default (scope: default).",
+    };
+  },
+});


### PR DESCRIPTION
Fixes the agent flatly asserting "No email voice has been built for this campaign" while the campaign page showed "Email voice set".

Root cause: the chat agent has four voice write tools (`startVoiceRun`, `rewriteVoiceDrafts`, `saveVoiceProfile`, `refineEmailVoice`) but no read tool over `email_voice_profiles`. It admitted as much mid-conversation ("The tools I have access to don't expose a direct list email voices endpoint") and then asserted the voice was missing anyway, repeatedly steering the user to rebuild a voice they already had.

## Changes

- **`getEmailVoices` tool**: lists the user's saved voices (RLS-scoped) with scope (campaign vs default), campaign name, one-line summary, and updated-at. One call answers "do I have a voice, and which campaigns have their own".
- **System prompt**: the voice section now requires calling `getEmailVoices` before claiming a voice is missing or sending the user to build one.

## Testing

- `pnpm typecheck` clean, `pnpm lint` clean, `pnpm test` 852/852, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)