### PR TITLE
fix(review): disambiguate organizations embed; surface draft load errors

### DIFF
--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -118,6 +118,7 @@ function ReviewPageInner() {
   const sequenceId = searchParams.get("sequence");
 
   const [drafts, setDrafts] = useState<DraftForReview[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [currentPersonIndex, setCurrentPersonIndex] = useState(0);
   const [loading, setLoading] = useState(!!sequenceId);
   const [saving, setSaving] = useState(false);
@@ -154,7 +155,7 @@ function ReviewPageInner() {
             work_email_verification, affiliation_source,
             affiliation_confidence, affiliation_evidence,
             personal_email, linkedin_url, twitter_url,
-            organizations(name, domain, industry)
+            organizations!organization_id(name, domain, industry)
           ),
           campaign_people(priority_score),
           sequence_enrollments(current_step),
@@ -172,6 +173,15 @@ function ReviewPageInner() {
       ]);
 
       if (!mountedRef.current) return;
+
+      // A failed query must never render as an empty queue: that is how a
+      // broken embed hid eight pending drafts behind "No drafts to review".
+      if (draftsRes.error) {
+        console.error("[outreach/review] drafts load failed:", draftsRes.error);
+        setLoadError(draftsRes.error.message);
+        setLoading(false);
+        return;
+      }
 
       const rawDrafts = draftsRes.data;
       const steps = stepsRes.data;
@@ -814,6 +824,16 @@ function ReviewPageInner() {
     return (
       <div className="flex flex-1 items-center justify-center">
         <p className="text-muted-foreground text-sm">No sequence specified.</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-destructive text-sm" role="alert">
+          Could not load drafts: {loadError}
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
Fixes the review page showing "No drafts to review" while the outreach list correctly showed 8 drafts pending review.

## Root cause

The affiliation-detach migration (20260802) added a second foreign key from `people` to `organizations` (`affiliation_detached_from`). PostgREST now rejects unhinted `organizations(...)` embeds through `people` as ambiguous — the codebase already documents this in `PERSON_ENRICH_COLUMNS` and hints every other query, but the review page's big draft select still had a bare `organizations(name, domain, industry)` inside its `people(...)` embed. The whole query 400'd, the page never checked `draftsRes.error`, and the failure rendered as an empty review queue.

The outreach list page was unaffected because it doesn't embed organizations through people, which is why the two surfaces disagreed.

## Changes

- The embed is now `organizations!organization_id(name, domain, industry)`, matching the convention everywhere else.
- The page surfaces a failed drafts query as a visible "Could not load drafts: ..." error (and logs it) instead of silently rendering the empty state — same silent-empty lesson as the Clerk RLS bug.
- Audited every other `organizations(` embed in the repo: all others go through `campaign_organizations` or `tracking_configs` (single FK), so this was the only broken one.

## Testing

- `pnpm typecheck` clean, `pnpm lint` clean, `pnpm test` 866/866, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)