### PR TITLE
fix(outreach): give ad-hoc drafts a review path

### DIFF
--- a/src/__tests__/outreach-drafts-panel.test.tsx
+++ b/src/__tests__/outreach-drafts-panel.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The panel writes through supabase and apiFetch on user actions; this file
+// only renders the list, so both are stubbed out.
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+vi.mock("@/lib/api-fetch", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import {
+  OutreachDraftsPanel,
+  type DraftRow,
+} from "@/components/outreach/outreach-drafts-panel";
+
+// vitest runs without `globals`, so Testing Library's automatic teardown never
+// registers and renders would stack up across tests.
+afterEach(cleanup);
+
+function draft(over: Partial<DraftRow> = {}): DraftRow {
+  return {
+    id: "d_1",
+    subject: "AI in the post-sales stack",
+    to_email: "mark@trig.test",
+    review_status: "pending",
+    status: "draft",
+    person_name: "Mark Ryan",
+    person_title: "Head of Marketing",
+    company_name: "Trig",
+    sequence_id: null,
+    sequence_name: null,
+    next_send_at: null,
+    step_number: 1,
+    total_steps: 1,
+    enrollment_id: null,
+    has_inbox: true,
+    ...over,
+  };
+}
+
+describe("<OutreachDraftsPanel> review buttons", () => {
+  it("links sequence drafts to their sequence review queue", () => {
+    render(
+      <OutreachDraftsPanel
+        drafts={[draft({ sequence_id: "seq-1", enrollment_id: "en-1" })]}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Review" })).toHaveAttribute(
+      "href",
+      "/outreach/review?sequence=seq-1",
+    );
+  });
+
+  it("links ad-hoc drafts (no sequence) to the ad-hoc review queue", () => {
+    // Regression: the button used to render only when the group had a
+    // sequence_id, so agent-written one-off drafts sat in "Needs review"
+    // with nothing to click and no way to ever approve them.
+    render(<OutreachDraftsPanel drafts={[draft()]} onRefresh={vi.fn()} />);
+    expect(screen.getByRole("link", { name: "Review" })).toHaveAttribute(
+      "href",
+      "/outreach/review",
+    );
+  });
+});

--- a/src/__tests__/review-page-adhoc.test.tsx
+++ b/src/__tests__/review-page-adhoc.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ── Router: which mode the page runs in comes from the URL ────────────────
+let search = "";
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(search),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("posthog-js", () => ({ default: { capture: vi.fn() } }));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/api-fetch", () => ({ apiFetch: vi.fn() }));
+// Enrichment sidebar pulls in a deep component tree; the queue logic under
+// test never touches it.
+vi.mock("@/components/campaign/contact-detail", () => ({
+  ContactDetail: () => <div data-testid="contact-detail" />,
+}));
+
+// ── Supabase: one chainable, awaitable query builder per .from() call ─────
+interface BuilderCall {
+  table: string;
+  filters: Array<[string, string, unknown]>;
+}
+let builderCalls: BuilderCall[] = [];
+let draftRows: unknown[] = [];
+
+function makeBuilder(table: string) {
+  const call: BuilderCall = { table, filters: [] };
+  builderCalls.push(call);
+  const rows = table === "email_drafts" ? draftRows : [];
+  const builder = {
+    select: () => builder,
+    order: () => builder,
+    eq: (col: string, val: unknown) => {
+      call.filters.push([table, col, val]);
+      return builder;
+    },
+    is: (col: string, val: unknown) => {
+      call.filters.push([table, col, val]);
+      return builder;
+    },
+    then: (resolve: (v: { data: unknown[]; error: null }) => void) =>
+      Promise.resolve({ data: rows, error: null }).then(resolve),
+  };
+  return builder;
+}
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ from: (table: string) => makeBuilder(table) }),
+}));
+
+import ReviewPage from "@/app/outreach/review/page";
+
+afterEach(() => {
+  cleanup();
+  builderCalls = [];
+  draftRows = [];
+});
+
+function adhocDraft(id: string, personId: string, name: string) {
+  return {
+    id,
+    to_email: `${personId}@example.test`,
+    subject: `Subject for ${name}`,
+    body_html: "<p>Hi</p>",
+    body_text: "Hi",
+    ai_reasoning: null,
+    review_status: "pending",
+    status: "draft",
+    sequence_step_id: null,
+    enrollment_id: null,
+    person_id: personId,
+    people: {
+      name,
+      title: null,
+      bio_summary: null,
+      organization_id: null,
+      enrichment_data: {},
+      enrichment_status: "pending",
+      last_enriched_at: null,
+      work_email: null,
+      work_email_confidence: null,
+      work_email_source: null,
+      work_email_verification: null,
+      affiliation_source: null,
+      affiliation_confidence: null,
+      affiliation_evidence: null,
+      personal_email: null,
+      linkedin_url: null,
+      twitter_url: null,
+      organizations: null,
+    },
+    campaign_people: null,
+    sequence_enrollments: null,
+    sequence_steps: null,
+  };
+}
+
+describe("review page ad-hoc mode", () => {
+  it("without a sequence param, loads pending drafts with a null sequence", async () => {
+    // Regression: this used to dead-end at "No sequence specified.", which
+    // made agent-written one-off drafts unreviewable anywhere in the app.
+    search = "";
+    draftRows = [adhocDraft("d1", "p1", "Mark Ryan")];
+
+    render(<ReviewPage />);
+
+    // Main pane h2 and sidebar h3 both carry the contact's name.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Mark Ryan", level: 2 }),
+      ).toBeVisible(),
+    );
+
+    const draftsCall = builderCalls.find((c) => c.table === "email_drafts");
+    expect(draftsCall?.filters).toContainEqual([
+      "email_drafts",
+      "sequence_id",
+      null,
+    ]);
+    // No sequence, no steps to count.
+    expect(builderCalls.some((c) => c.table === "sequence_steps")).toBe(false);
+
+    // A one-off draft is not "Step 1 of 1" of anything.
+    expect(screen.getByText("One-off email")).toBeVisible();
+    expect(screen.queryByText(/Step 1 of/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve all" })).toBeEnabled();
+  });
+
+  it("with a sequence param, still scopes to that sequence", async () => {
+    search = "sequence=seq-1";
+    draftRows = [];
+
+    render(<ReviewPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No drafts to review.")).toBeVisible(),
+    );
+
+    const draftsCall = builderCalls.find((c) => c.table === "email_drafts");
+    expect(draftsCall?.filters).toContainEqual([
+      "email_drafts",
+      "sequence_id",
+      "seq-1",
+    ]);
+    expect(builderCalls.some((c) => c.table === "sequence_steps")).toBe(true);
+  });
+});

--- a/src/app/outreach/page.tsx
+++ b/src/app/outreach/page.tsx
@@ -89,7 +89,7 @@ export default function OutreachPage() {
         .select(
           `
             id, subject, to_email, review_status, status, sent_at,
-            enrollment_id, sequence_step_id,
+            enrollment_id, sequence_id, sequence_step_id,
             sequence_enrollments(next_send_at, sequence_id),
             sequence_steps(step_number),
             sequences(name),
@@ -215,7 +215,10 @@ export default function OutreachPage() {
         step_number: number;
       } | null;
       const seq = d.sequences as unknown as { name: string } | null;
-      const sequenceId = enrollment?.sequence_id ?? null;
+      // The draft's own column, not just the enrollment embed: a draft
+      // written into a sequence before (or without) enrollment still
+      // belongs to that sequence's review queue.
+      const sequenceId = d.sequence_id ?? enrollment?.sequence_id ?? null;
       return {
         id: d.id,
         subject: d.subject ?? "",

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -120,7 +120,7 @@ function ReviewPageInner() {
   const [drafts, setDrafts] = useState<DraftForReview[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [currentPersonIndex, setCurrentPersonIndex] = useState(0);
-  const [loading, setLoading] = useState(!!sequenceId);
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [edits, setEdits] = useState<Record<string, EditState>>({});
   const [enrichingPersonIds, setEnrichingPersonIds] = useState<Set<string>>(
@@ -137,15 +137,13 @@ function ReviewPageInner() {
 
   useEffect(() => {
     mountedRef.current = true;
-    if (!sequenceId) return;
 
     const load = async () => {
       const supabase = createClient();
-      const [draftsRes, stepsRes] = await Promise.all([
-        supabase
-          .from("email_drafts")
-          .select(
-            `
+      const baseQuery = supabase
+        .from("email_drafts")
+        .select(
+          `
           id, to_email, subject, body_html, body_text, ai_reasoning,
           review_status, status, sequence_step_id, enrollment_id, person_id,
           people(
@@ -161,15 +159,23 @@ function ReviewPageInner() {
           sequence_enrollments(current_step),
           sequence_steps(step_number, delay_days, delay_hours)
         `,
-          )
-          .eq("sequence_id", sequenceId)
-          .eq("review_status", "pending")
-          .order("person_id")
-          .order("sequence_step_id"),
-        supabase
-          .from("sequence_steps")
-          .select("id")
-          .eq("sequence_id", sequenceId),
+        )
+        .eq("review_status", "pending")
+        .order("person_id")
+        .order("sequence_step_id");
+      const [draftsRes, stepsRes] = await Promise.all([
+        // Without a sequence param this is the ad-hoc queue: drafts the
+        // agent wrote outside any sequence. They are born pending like
+        // everything else, so they need a review surface too.
+        sequenceId
+          ? baseQuery.eq("sequence_id", sequenceId)
+          : baseQuery.is("sequence_id", null),
+        sequenceId
+          ? supabase
+              .from("sequence_steps")
+              .select("id")
+              .eq("sequence_id", sequenceId)
+          : null,
       ]);
 
       if (!mountedRef.current) return;
@@ -184,8 +190,8 @@ function ReviewPageInner() {
       }
 
       const rawDrafts = draftsRes.data;
-      const steps = stepsRes.data;
-      const totalSteps = steps?.length ?? 1;
+      // Ad-hoc drafts have no steps; stepsRes is null and every card is 1/1.
+      const totalSteps = stepsRes ? (stepsRes.data?.length ?? 1) : 1;
 
       const mapped: DraftForReview[] = (rawDrafts ?? []).map((d) => {
         const person = d.people as unknown as {
@@ -820,14 +826,6 @@ function ReviewPageInner() {
     );
   }
 
-  if (!sequenceId) {
-    return (
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-muted-foreground text-sm">No sequence specified.</p>
-      </div>
-    );
-  }
-
   if (loadError) {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -1138,14 +1136,20 @@ function EmailCard({
   return (
     <div className="border-border bg-background rounded-lg border p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className="bg-primary/10 text-primary inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold tabular-nums">
-            {draft.step_number}
-          </span>
+        {draft.sequence_step_id !== null ? (
+          <div className="flex items-center gap-2">
+            <span className="bg-primary/10 text-primary inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold tabular-nums">
+              {draft.step_number}
+            </span>
+            <span className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+              Step {draft.step_number} of {draft.total_steps}
+            </span>
+          </div>
+        ) : (
           <span className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Step {draft.step_number} of {draft.total_steps}
+            One-off email
           </span>
-        </div>
+        )}
         <div className="flex items-center gap-2">
           {isSent ? (
             <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">

--- a/src/components/outreach/outreach-drafts-panel.tsx
+++ b/src/components/outreach/outreach-drafts-panel.tsx
@@ -301,7 +301,12 @@ export function OutreachDraftsPanel({
                               </span>
                             )}
 
-                          {key === "needs_review" && group.sequence_id && (
+                          {/* No sequence_id guard: ad-hoc drafts (agent
+                              writeEmail with no enrollment) review at
+                              /outreach/review without a sequence param.
+                              Guarding here left them pending with no UI
+                              anywhere able to approve them. */}
+                          {key === "needs_review" && (
                             <ReviewButton sequenceId={group.sequence_id} />
                           )}
 

--- a/src/components/outreach/review-button.tsx
+++ b/src/components/outreach/review-button.tsx
@@ -4,7 +4,8 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface ReviewButtonProps {
-  sequenceId: string;
+  /** Without a sequence, links to the ad-hoc review queue. */
+  sequenceId?: string | null;
   variant?: "default" | "outline" | "ghost";
   size?: "sm" | "default";
   label?: string;
@@ -20,7 +21,11 @@ export function ReviewButton({
 }: ReviewButtonProps) {
   return (
     <Link
-      href={`/outreach/review?sequence=${sequenceId}`}
+      href={
+        sequenceId
+          ? `/outreach/review?sequence=${sequenceId}`
+          : "/outreach/review"
+      }
       className={cn(buttonVariants({ variant, size }), className)}
     >
       {label}


### PR DESCRIPTION
## Problem

Drafts the agent writes with `writeEmail` outside a sequence are born `review_status: pending`, but:

- The "Needs review" panel only rendered its Review button when the group had a `sequence_id` (derived solely from the enrollment embed).
- The review page required a `?sequence=` param and filtered `.eq("sequence_id", ...)`, dead-ending at "No sequence specified." otherwise.

So ad-hoc drafts sat in "Needs review" with nothing to click and no UI anywhere able to approve them, while `sendEmail`'s gate refused to send anything unapproved: stuck forever. (This is the "why can't I click review" queue of 8 currently in prod.)

## Fix

- `/outreach/review` without a sequence param is now the ad-hoc queue: pending drafts with a null `sequence_id`. Cards show "One-off email" instead of "Step 1 of 1".
- The panel always renders Review for needs-review groups; without a sequence it links to the ad-hoc queue.
- The outreach page reads the draft's own `sequence_id` column instead of only the enrollment embed, so a sequence draft that predates its enrollment still reaches its sequence queue.

"Send now" stays hidden for ad-hoc drafts: `/api/outreach/send-now` resolves the send through the enrollment and rejects drafts without one, so approval hands them to `sendEmail` as before.

## Tests

- New: panel renders Review linking to `?sequence=` for sequence drafts and to the bare queue for ad-hoc drafts (regression for the missing button).
- New: review page queries `.is("sequence_id", null)` without a param, still scopes `.eq(...)` with one, and skips the steps query in ad-hoc mode.
- Full suite: 870 passed. tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)