### PR TITLE
fix(compose): stop drafting breakup emails for first contact

### DIFF
--- a/src/__tests__/email-composition-skill.test.ts
+++ b/src/__tests__/email-composition-skill.test.ts
@@ -59,6 +59,46 @@ describe("buildEmailSystemPrompt with a fact bank", () => {
   });
 });
 
+describe("buildComposeUserPrompt breakup framing", () => {
+  it("never frames step 1 as a breakup, even when the caller flags it final", () => {
+    // Regression: 1-step sequences (and regenerate's ad-hoc default) passed
+    // isFinal for step 1 of 1, so the model was told "FINAL: breakup email"
+    // and invented a prior thread ("nothing back from my last note") for
+    // contacts who had never been emailed.
+    const prompt = buildComposeUserPrompt({
+      ...baseInput,
+      step: {
+        stepNumber: 1,
+        totalSteps: 1,
+        condition: "always",
+        isFinal: true,
+      },
+    });
+    expect(prompt).toContain("STEP 1 of 1");
+    expect(prompt).not.toContain("breakup");
+  });
+
+  it("keeps breakup framing for the last of several steps", () => {
+    const prompt = buildComposeUserPrompt({
+      ...baseInput,
+      step: {
+        stepNumber: 3,
+        totalSteps: 3,
+        condition: "no_reply",
+        isFinal: true,
+      },
+    });
+    expect(prompt).toContain("STEP 3 of 3 (FINAL: breakup email)");
+  });
+});
+
+describe("email skill system prompt", () => {
+  it("forbids implying prior emails without a previous subject in context", () => {
+    const sys = buildEmailSystemPrompt(null, null);
+    expect(sys).toContain("unless PREVIOUS EMAIL SUBJECT appears");
+  });
+});
+
 describe("buildComposeUserPrompt sender fields", () => {
   it("carries offering summary and notes that were previously dropped", () => {
     const prompt = buildComposeUserPrompt(baseInput);

--- a/src/app/api/outreach/regenerate/route.ts
+++ b/src/app/api/outreach/regenerate/route.ts
@@ -118,7 +118,9 @@ export async function POST(request: Request) {
   let stepNumber = 1;
   let totalSteps = 1;
   let condition = "always";
-  let isFinal = true;
+  // Ad-hoc drafts (no sequence) are first contact. The old default of true
+  // regenerated them as breakup emails for threads that never existed.
+  let isFinal = false;
   let previousSubject: string | null = null;
 
   if (draft.sequence_step_id && draft.sequence_id) {
@@ -137,7 +139,9 @@ export async function POST(request: Request) {
       .select("*", { count: "exact", head: true })
       .eq("sequence_id", draft.sequence_id);
     totalSteps = count ?? 1;
-    isFinal = stepNumber === totalSteps;
+    // Only a step with real predecessors is a breakup; the sole step of a
+    // 1-step sequence is first contact.
+    isFinal = totalSteps > 1 && stepNumber === totalSteps;
 
     // A follow-up regenerates with the subject it actually follows up on.
     if (stepNumber > 1 && draft.enrollment_id) {

--- a/src/lib/email-composition/skill.ts
+++ b/src/lib/email-composition/skill.ts
@@ -72,6 +72,7 @@ Step-specific guidance:
 - Step 1 (initial cold): lead with the person-specific signal, connect it to the offering in one move, close with the reasoned ask.
 - Step 2-N (follow-up, condition=no_reply or opened_no_reply): follow-ups carry 42% of all replies, so each one earns its place with ONE genuinely new angle: a different proof point, a different consequence, a question you haven't asked yet. Never "just bumping this". Shorter than the email before it.
 - Final step (breakup): one or two sentences. Acknowledge the silence without guilt-tripping, leave the door open, shortest of the sequence.
+- Never reference or imply an earlier email from the sender (a "last note", "closing the loop", going quiet, or any prior thread) unless PREVIOUS EMAIL SUBJECT appears in the context. If it is absent, nothing has been sent to this person: write as first contact, whatever the step framing says.
 
 Output format:
 - \`subject\`: 4-5 words, under ~45 chars, no caps, no special characters.
@@ -172,9 +173,16 @@ export function buildComposeUserPrompt(input: {
 }): string {
   const sections: string[] = [];
 
+  // A breakup presupposes earlier emails in the same sequence. Callers have
+  // shipped step 1 flagged final (1-step sequences; regenerate's ad-hoc
+  // default), and the model obeyed the flag over reality: it wrote "nothing
+  // back from my last note" to people who had never been emailed. Whatever
+  // the caller says, step 1 is first contact.
+  const isBreakup = input.step.isFinal && input.step.stepNumber > 1;
+
   sections.push(
     `STEP ${input.step.stepNumber} of ${input.step.totalSteps}${
-      input.step.isFinal ? " (FINAL: breakup email)" : ""
+      isBreakup ? " (FINAL: breakup email)" : ""
     }, condition: ${input.step.condition}`,
   );
 

--- a/src/lib/jobs/executors/outreach-process.ts
+++ b/src/lib/jobs/executors/outreach-process.ts
@@ -419,7 +419,10 @@ async function pickAndDraft(
           stepNumber: 1,
           totalSteps: totalSteps ?? 1,
           condition: (step1.condition as string) ?? "always",
-          isFinal: (totalSteps ?? 1) === 1,
+          // This path only ever drafts step 1, and step 1 is first contact
+          // even when it is the sequence's only step. The old `totalSteps
+          // === 1` flag produced breakup emails for people never emailed.
+          isFinal: false,
         },
         campaign: {
           name: (campaign?.name as string) ?? "Campaign",

--- a/src/lib/tools/sequence-tools.ts
+++ b/src/lib/tools/sequence-tools.ts
@@ -496,7 +496,10 @@ export const draftEmailsForSequence = tool({
               stepNumber: step.step_number,
               totalSteps,
               condition: step.condition,
-              isFinal: step.step_number === totalSteps,
+              // Last of SEVERAL steps. In a 1-step sequence the only email
+              // is first contact, and flagging it final made the composer
+              // write a breakup for a thread that never existed.
+              isFinal: totalSteps > 1 && step.step_number === totalSteps,
             },
             campaign: {
               name: campaign.name,


### PR DESCRIPTION
## Problem

The 9 "closing the loop" / "last note from me" drafts in review: every one is a breakup email to a contact who was never sent an initial email, each inventing a prior thread ("Nothing back from my last note").

Root cause: every drafting path computed "final step" as `step_number === totalSteps`, so in a **1-step sequence the only email is flagged `(FINAL: breakup email)`**, and the email skill instructs the final step to "acknowledge the silence". Ordered to write a breakup with no thread in context, the model fabricated one. `/api/outreach/regenerate` was worse: its ad-hoc defaults were `stepNumber = 1, totalSteps = 1, isFinal = true`, so regenerating any ad-hoc draft also produced a breakup.

## Fix (four layers, so no single caller can reproduce it)

1. `sequence-tools.ts`: `isFinal: totalSteps > 1 && step.step_number === totalSteps`
2. `outreach-process.ts`: this path only drafts step 1, so `isFinal: false`
3. `regenerate/route.ts`: ad-hoc default `false`; in-sequence requires `totalSteps > 1`
4. `skill.ts`: `buildComposeUserPrompt` refuses breakup framing on step 1 regardless of what the caller passed, and the system prompt now forbids referencing/implying any earlier email unless `PREVIOUS EMAIL SUBJECT` is present in the context (which threaded multi-step drafting always provides)

Layer 4 is the "agent should be smarter" part: the composer no longer trusts step framing over the ground truth it can see.

## After deploy

Reject the current 9 drafts, then re-draft (or regenerate) them: they'll come out as proper first-contact emails.

## Tests

- New: step 1 of 1 with `isFinal: true` renders without breakup framing; step 3 of 3 keeps it; system prompt carries the no-implied-thread rule.
- Full suite: 873 passed. tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)