### PR TITLE
fix(outreach): stop emailing people who replied

### DIFF
--- a/src/__tests__/email-classify.test.ts
+++ b/src/__tests__/email-classify.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: vi.fn(),
+}));
+vi.mock("@/lib/services/reply-intent", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/services/reply-intent")>();
+  // shouldSuppress/suppressionReason stay real: they are pure and the
+  // stamp-vs-suppress ordering under test depends on their verdicts.
+  return { ...actual, classifyReplyIntent: vi.fn() };
+});
+
+import { classifyReplies } from "@/lib/jobs/executors/email-classify";
+import { classifyReplyIntent } from "@/lib/services/reply-intent";
+import { getAdminClient } from "@/lib/supabase/admin";
+
+const classifyMock = vi.mocked(classifyReplyIntent);
+const adminMock = vi.mocked(getAdminClient);
+
+interface RecordedCall {
+  table: string;
+  ops: Array<{ name: string; args: unknown[] }>;
+}
+
+function fakeSupabase(responses: Array<{ data?: unknown; error?: unknown }>) {
+  let i = 0;
+  const calls: RecordedCall[] = [];
+  const from = (table: string) => {
+    const call: RecordedCall = { table, ops: [] };
+    calls.push(call);
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "is",
+      "not",
+      "order",
+      "limit",
+      "update",
+      "upsert",
+    ]) {
+      builder[name] = (...args: unknown[]) => {
+        call.ops.push({ name, args });
+        return builder;
+      };
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+        resolve,
+        reject,
+      );
+    return builder;
+  };
+  return { calls, client: { from } as never };
+}
+
+const replyRow = {
+  id: "reply_1",
+  user_id: "user_1",
+  person_id: "per_1",
+  subject: "Re: quick note",
+  body_text: "unsubscribe me please",
+  sent_email_id: "se_1",
+  sent_emails: { subject: "quick note", to_email: "Sam@Acme.com" },
+};
+
+describe("classifyReplies suppression ordering", () => {
+  it("upserts the suppression before stamping intent", async () => {
+    // The intent stamp is what removes the row from the scan window
+    // (.is("intent", null)), so it must be the LAST write: stamping before
+    // a failed suppression upsert dropped the unsubscribe forever.
+    classifyMock.mockResolvedValueOnce({
+      intent: "unsubscribe",
+      confidence: 0.99,
+      reasoning: "explicit unsubscribe request",
+    });
+    const { client, calls } = fakeSupabase([
+      { data: [replyRow] }, // scan
+      {}, // suppression upsert
+      {}, // intent stamp
+    ]);
+    adminMock.mockReturnValue(client as never);
+
+    const result = await classifyReplies();
+
+    expect(result).toMatchObject({ classified: 1, suppressed: 1 });
+    const writes = calls.filter((c) =>
+      c.ops.some((op) => op.name === "update" || op.name === "upsert"),
+    );
+    expect(writes.map((c) => c.table)).toEqual([
+      "outreach_suppressions",
+      "email_replies",
+    ]);
+    // Suppresses the address we sent to, lowercased.
+    const upsert = writes[0].ops.find((op) => op.name === "upsert");
+    expect(upsert?.args[0]).toMatchObject({ email: "sam@acme.com" });
+  });
+
+  it("leaves the row unclassified when the suppression upsert fails", async () => {
+    classifyMock.mockResolvedValueOnce({
+      intent: "unsubscribe",
+      confidence: 0.99,
+      reasoning: "explicit unsubscribe request",
+    });
+    const { client, calls } = fakeSupabase([
+      { data: [replyRow] }, // scan
+      { error: { message: "connection reset" } }, // suppression upsert fails
+    ]);
+    adminMock.mockReturnValue(client as never);
+
+    const result = await classifyReplies();
+
+    // No intent stamp: the row stays in the scan window and the next run
+    // retries both writes.
+    expect(result).toMatchObject({ classified: 0, suppressed: 0 });
+    expect(
+      calls.some(
+        (c) =>
+          c.table === "email_replies" &&
+          c.ops.some((op) => op.name === "update"),
+      ),
+    ).toBe(false);
+  });
+
+  it("stamps intent directly for non-suppressing verdicts", async () => {
+    classifyMock.mockResolvedValueOnce({
+      intent: "interested",
+      confidence: 0.9,
+      reasoning: "asked for a call",
+    });
+    const { client, calls } = fakeSupabase([
+      { data: [replyRow] }, // scan
+      {}, // intent stamp
+    ]);
+    adminMock.mockReturnValue(client as never);
+
+    const result = await classifyReplies();
+
+    expect(result).toMatchObject({ classified: 1, suppressed: 0 });
+    expect(calls.some((c) => c.table === "outreach_suppressions")).toBe(false);
+  });
+});

--- a/src/__tests__/email-feedback-loop.test.ts
+++ b/src/__tests__/email-feedback-loop.test.ts
@@ -59,6 +59,7 @@ function fakeSupabase(
       "select",
       "eq",
       "in",
+      "not",
       "gte",
       "update",
       "insert",
@@ -138,6 +139,7 @@ function sendResponses(personId: string | null): FakeResponse[] {
     { data: draftWith(personId) }, // draft select
     { data: settings() }, // sender config
     { data: null }, // suppression check: not suppressed
+    { data: { outreach_status: "sent" } }, // recipient status: no reply
     gatePasses(), // send-gate person read
     { data: { id: "draft_1" } }, // claim won
     { count: 0 }, // daily cap
@@ -184,6 +186,7 @@ describe("send_confirmed", () => {
     await claimAndSendDraft(
       fakeSupabase([
         { data: null }, // suppression check: not suppressed
+        { data: { outreach_status: "sent" } }, // recipient status: no reply
         { data: { id: "draft_1" } }, // claim won
         { count: 0 }, // daily cap
         {}, // sent_emails insert
@@ -224,7 +227,7 @@ describe("send_confirmed", () => {
       },
     };
     const responses = sendResponses("per_1");
-    responses[4] = blocked; // the send-gate person read
+    responses[5] = blocked; // the send-gate person read
 
     const result = await sendApprovedDraft(fakeSupabase(responses), enrollment);
 
@@ -244,7 +247,7 @@ describe("send_confirmed", () => {
       },
     };
     const responses = sendResponses("per_1");
-    responses[4] = blocked;
+    responses[5] = blocked;
 
     const result = await sendApprovedDraft(fakeSupabase(responses), enrollment);
 
@@ -258,7 +261,7 @@ describe("send_confirmed", () => {
     // for no rows, so treating null as "carry on" let a DB hiccup disable the
     // one gate that cannot otherwise be bypassed.
     const responses = sendResponses("per_1");
-    responses[4] = { data: null, error: { message: "connection reset" } };
+    responses[5] = { data: null, error: { message: "connection reset" } };
 
     const result = await sendApprovedDraft(fakeSupabase(responses), enrollment);
 
@@ -272,7 +275,7 @@ describe("send_confirmed", () => {
     // the old one — without this check the gate approved on the new address's
     // verdict and delivered to the very address that just hard-bounced.
     const responses = sendResponses("per_1");
-    responses[4] = {
+    responses[5] = {
       data: {
         work_email: "corrected@example.com", // person was fixed…
         work_email_source: "user_entered",
@@ -343,6 +346,7 @@ describe("send failure recording", () => {
         "select",
         "eq",
         "in",
+        "not",
         "gte",
         "insert",
         "single",
@@ -374,7 +378,7 @@ describe("send failure recording", () => {
 
   it("classifies the daily cap as deferred, not failed", async () => {
     const responses = sendResponses("per_1");
-    responses[6] = { count: 999 }; // over the cap
+    responses[7] = { count: 999 }; // over the cap
 
     const { client, updates } = observingSupabase(responses);
     const result = await sendApprovedDraft(client, enrollment);
@@ -391,7 +395,7 @@ describe("send failure recording", () => {
 
   it("classifies a stale address as blocked, with the reason kept verbatim", async () => {
     const responses = sendResponses("per_1");
-    responses[4] = {
+    responses[5] = {
       data: {
         work_email: "corrected@example.com",
         work_email_source: "user_entered",

--- a/src/__tests__/email-feedback-loop.test.ts
+++ b/src/__tests__/email-feedback-loop.test.ts
@@ -465,6 +465,78 @@ describe("bounce feedback", () => {
     ...over,
   });
 
+  it("writes campaign_people before stamping sent_emails", async () => {
+    // The re-poll ladder compares against sent_emails.status, so the stamp
+    // is the dedupe marker. Stamping it first meant a crash between the two
+    // writes lost the reply forever: the next poll saw replied -> replied
+    // and skipped, while campaign_people still said "sent".
+    const order: string[] = [];
+    let i = 0;
+    const responses: FakeResponse[] = [{}, {}];
+    const client = {
+      from: (table: string) => {
+        const builder: Record<string, unknown> = {};
+        for (const name of ["select", "eq", "in", "not", "single"]) {
+          builder[name] = () => builder;
+        }
+        builder.update = () => {
+          order.push(table);
+          return builder;
+        };
+        builder.then = (
+          resolve: (v: unknown) => unknown,
+          reject: (e: unknown) => unknown,
+        ) =>
+          Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+            resolve,
+            reject,
+          );
+        return builder;
+      },
+    } as never;
+
+    const changed = await applyInboundStatus(client, tracked(), "replied");
+
+    expect(changed).toBe(true);
+    expect(order).toEqual(["campaign_people", "sent_emails"]);
+  });
+
+  it("does not stamp sent_emails when the campaign_people write fails", async () => {
+    const order: string[] = [];
+    let i = 0;
+    const responses: FakeResponse[] = [
+      { error: { message: "connection reset" } },
+    ];
+    const client = {
+      from: (table: string) => {
+        const builder: Record<string, unknown> = {};
+        for (const name of ["select", "eq", "in", "not", "single"]) {
+          builder[name] = () => builder;
+        }
+        builder.update = () => {
+          order.push(table);
+          return builder;
+        };
+        builder.then = (
+          resolve: (v: unknown) => unknown,
+          reject: (e: unknown) => unknown,
+        ) =>
+          Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+            resolve,
+            reject,
+          );
+        return builder;
+      },
+    } as never;
+
+    const changed = await applyInboundStatus(client, tracked(), "replied");
+
+    // Not stamped: the next poll's ladder still sees the old status and
+    // retries both writes.
+    expect(changed).toBe(false);
+    expect(order).toEqual(["campaign_people"]);
+  });
+
   it("calls recordBounce when a send bounces", async () => {
     const changed = await applyInboundStatus(
       fakeSupabase([{}, {}]),

--- a/src/__tests__/email-tools-send.test.ts
+++ b/src/__tests__/email-tools-send.test.ts
@@ -55,6 +55,7 @@ function fakeSupabase(
       "select",
       "eq",
       "in",
+      "not",
       "gte",
       "update",
       "insert",
@@ -188,6 +189,7 @@ describe("sendEmail review gating", () => {
       { data: { ...baseDraft, review_status: "approved" } }, // draft select
       settingsResponse(), // resolveSenderConfig
       { data: null }, // suppression check: not suppressed
+      { data: { outreach_status: "sent" } }, // recipient status: no reply
       gatePasses(), // send-gate person read
       { data: { id: baseDraft.id } }, // claim won
       { count: 0 }, // daily-cap count
@@ -208,7 +210,7 @@ describe("sendEmail review gating", () => {
     });
     expect(sendGmailMock).toHaveBeenCalledTimes(1);
 
-    const claim = calls[4]; // 2 suppression check, 3 send-gate person read
+    const claim = calls[5]; // 2 suppression, 3 recipient status, 4 gate read
     expect(claim.table).toBe("email_drafts");
     expect(claim.ops).toContainEqual({
       name: "update",
@@ -222,6 +224,7 @@ describe("sendEmail review gating", () => {
       { data: { ...baseDraft, review_status: "approved" } },
       settingsResponse(),
       { data: null }, // suppression check: not suppressed
+      { data: { outreach_status: "sent" } }, // recipient status: no reply
       gatePasses(), // send-gate person read
       { data: null }, // claim lost
     ]);
@@ -250,6 +253,7 @@ describe("sendBulkEmails review gating", () => {
       { data: [{ ...baseDraft, id: "d_ok", review_status: "approved" }] },
       settingsResponse(),
       { data: null }, // suppression check: not suppressed
+      { data: { outreach_status: "sent" } }, // recipient status: no reply
       gatePasses(), // send-gate person read
       { data: { id: "d_ok" } }, // claim won
       { count: 0 }, // daily-cap count

--- a/src/__tests__/job-scan-errors.test.ts
+++ b/src/__tests__/job-scan-errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: vi.fn(),
+}));
+
+import { trackEmailReplies } from "@/lib/jobs/executors/email-track";
+import { backfillReplyBodies } from "@/lib/jobs/executors/reply-backfill";
+import { getAdminClient } from "@/lib/supabase/admin";
+
+const adminMock = vi.mocked(getAdminClient);
+
+function failingSupabase(message: string) {
+  const from = () => {
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "not",
+      "gte",
+      "order",
+      "limit",
+    ]) {
+      builder[name] = () => builder;
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve({ data: null, error: { message } }).then(resolve, reject);
+    return builder;
+  };
+  return { from } as never;
+}
+
+// A failed scan must fail the job run (execute.ts catches the throw and
+// calls failJob), never read as "nothing to check" and complete clean:
+// that is how replies went unseen while the job history stayed green.
+describe("job executors fail on scan errors", () => {
+  it("email.track throws when the sent_emails scan fails", async () => {
+    adminMock.mockReturnValue(failingSupabase("connection reset"));
+    await expect(trackEmailReplies()).rejects.toThrow(
+      /sent_emails load: connection reset/,
+    );
+  });
+
+  it("reply backfill throws when the sent_emails scan fails", async () => {
+    adminMock.mockReturnValue(failingSupabase("connection reset"));
+    await expect(backfillReplyBodies()).rejects.toThrow(
+      /sent_emails load: connection reset/,
+    );
+  });
+});

--- a/src/__tests__/outreach-sender.test.ts
+++ b/src/__tests__/outreach-sender.test.ts
@@ -99,8 +99,8 @@ function settingsRow(overrides: Record<string, unknown> = {}) {
 
 // Await order inside sendApprovedDraft:
 // 0 step select · 1 draft select · 2 settings select (resolveSenderConfig) ·
-// 3 suppression select · 4 send-gate person select · 5 claim update ·
-// 6 daily-cap count
+// 3 suppression select · 4 recipient-status select (campaign_people) ·
+// 5 send-gate person select · 6 claim update · 7 daily-cap count
 // then send, then bookkeeping (insert, updates, next-step select, enrollment)
 /** A contact the data-quality gate lets through: verified email, known employer. */
 function gatePasses() {
@@ -122,6 +122,7 @@ function preSendResponses(settings: Record<string, unknown> = settingsRow()) {
     { data: draft },
     { data: settings },
     { data: null }, // suppression check: not suppressed
+    { data: { outreach_status: "sent" } }, // recipient status: no reply yet
     // The send gate reads the contact before claiming the draft.
     gatePasses(),
   ];
@@ -246,7 +247,7 @@ describe("sendApprovedDraft claim semantics", () => {
       }),
     );
 
-    const claim = calls[5]; // 3 suppression check, 4 send-gate person read
+    const claim = calls[6]; // 3 suppression, 4 recipient status, 5 gate read
     expect(claim.table).toBe("email_drafts");
     expect(claim.ops).toContainEqual({
       name: "update",
@@ -259,7 +260,7 @@ describe("sendApprovedDraft claim semantics", () => {
     });
 
     // The sent_emails row records the RFC Message-ID and the real address.
-    const insert = calls[7]; // 4 gate read, 6 cap count (also sent_emails)
+    const insert = calls[8]; // 5 gate read, 7 cap count (also sent_emails)
     expect(insert.table).toBe("sent_emails");
     expect(insert.ops).toContainEqual({
       name: "insert",
@@ -270,6 +271,63 @@ describe("sendApprovedDraft claim semantics", () => {
         }),
       ],
     });
+  });
+
+  it("refuses to send when the recipient already replied", async () => {
+    // The followups cron checks replied status before calling in, but
+    // send-now, the hero's Send all, and the agent tools did not: a reply
+    // landing between approval and click kept the follow-up going out.
+    const { client, calls } = fakeSupabase([
+      { data: { id: "step_1" } },
+      { data: draft },
+      { data: settingsRow() },
+      { data: null }, // not suppressed
+      { data: { outreach_status: "replied" } }, // recipient status
+      {}, // refuse() bookkeeping
+    ]);
+
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("replied"),
+    });
+    expect(sendGmailMock).not.toHaveBeenCalled();
+    // Refused before the gate read and the claim: no verification credits
+    // spent, and the only write is the refusal record on the draft.
+    expect(calls.map((c) => c.table)).toEqual([
+      "sequence_steps",
+      "email_drafts",
+      "user_settings",
+      "outreach_suppressions",
+      "campaign_people",
+      "email_drafts",
+    ]);
+    expect(calls[5].ops).toContainEqual({
+      name: "update",
+      args: [expect.objectContaining({ last_error_kind: "blocked" })],
+    });
+  });
+
+  it("defers when the recipient status cannot be checked", async () => {
+    // Fail closed, same contract as the suppression list: "could not check
+    // whether they replied" must never become "send anyway".
+    const { client } = fakeSupabase([
+      { data: { id: "step_1" } },
+      { data: draft },
+      { data: settingsRow() },
+      { data: null },
+      { data: null, error: { message: "connection reset" } },
+      {}, // refuse() bookkeeping
+    ]);
+
+    const result = await sendApprovedDraft(client, enrollment);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("recipient"),
+    });
+    expect(sendGmailMock).not.toHaveBeenCalled();
   });
 
   it("never downgrades a terminal outreach_status when stamping the send", async () => {
@@ -292,7 +350,13 @@ describe("sendApprovedDraft claim semantics", () => {
 
     await sendApprovedDraft(client, enrollment);
 
-    const cpUpdate = calls.find((c) => c.table === "campaign_people");
+    // The pre-send recipient-status read also hits campaign_people; assert
+    // on the call that carries the update.
+    const cpUpdate = calls.find(
+      (c) =>
+        c.table === "campaign_people" &&
+        c.ops.some((op) => op.name === "update"),
+    );
     expect(cpUpdate).toBeDefined();
     expect(cpUpdate!.ops).toContainEqual({
       name: "update",
@@ -339,6 +403,7 @@ describe("sendApprovedDraft claim semantics", () => {
         }),
       },
       { data: null }, // suppression check: not suppressed
+      { data: { outreach_status: "sent" } }, // recipient status
       gatePasses(), // send-gate person read
       { data: { id: draft.id } }, // claim won
       { count: 5 }, // already sent 5 today
@@ -353,7 +418,7 @@ describe("sendApprovedDraft claim semantics", () => {
     });
     expect(sendGmailMock).not.toHaveBeenCalled();
     // The capped draft must go back to "draft" so tomorrow's cron sends it.
-    const release = calls[7];
+    const release = calls[8];
     expect(release.table).toBe("email_drafts");
     expect(release.ops).toContainEqual({
       name: "update",
@@ -422,7 +487,7 @@ describe("sendApprovedDraft claim semantics", () => {
       ok: false,
       reason: "SMTP 421 try again later",
     });
-    const release = calls[7];
+    const release = calls[8];
     expect(release.table).toBe("email_drafts");
     expect(release.ops).toContainEqual({
       name: "update",

--- a/src/__tests__/outreach-sender.test.ts
+++ b/src/__tests__/outreach-sender.test.ts
@@ -40,6 +40,7 @@ function fakeSupabase(
       "select",
       "eq",
       "in",
+      "not",
       "gte",
       "update",
       "insert",
@@ -267,6 +268,42 @@ describe("sendApprovedDraft claim semantics", () => {
           message_id: "<m1@sahnan.co>",
           from_email: "jay@sahnan.co",
         }),
+      ],
+    });
+  });
+
+  it("never downgrades a terminal outreach_status when stamping the send", async () => {
+    // A reply or bounce recorded between draft and send must survive the
+    // send bookkeeping. The unconditional update used to write "sent" over
+    // "replied", and applyInboundStatus's ladder compares against the
+    // sent_emails row (already "replied"), so nothing ever restored it:
+    // follow-ups kept going to a live conversation.
+    const { client, calls } = fakeSupabase([
+      ...preSendResponses(),
+      { data: { id: draft.id } }, // claim won
+      { count: 0 },
+      {}, // sent_emails insert
+      {}, // draft → sent
+      {}, // campaign_people → sent (guarded)
+      { data: null }, // no next step
+      {}, // enrollment → completed
+    ]);
+    sendGmailMock.mockResolvedValue({ messageId: "<m3@sahnan.co>" });
+
+    await sendApprovedDraft(client, enrollment);
+
+    const cpUpdate = calls.find((c) => c.table === "campaign_people");
+    expect(cpUpdate).toBeDefined();
+    expect(cpUpdate!.ops).toContainEqual({
+      name: "update",
+      args: [expect.objectContaining({ outreach_status: "sent" })],
+    });
+    expect(cpUpdate!.ops).toContainEqual({
+      name: "not",
+      args: [
+        "outreach_status",
+        "in",
+        '("replied","bounced","complained","unsubscribed")',
       ],
     });
   });

--- a/src/lib/jobs/executors/email-classify.ts
+++ b/src/lib/jobs/executors/email-classify.ts
@@ -64,6 +64,53 @@ export async function classifyReplies(): Promise<{
     // later run retries, matching how email.track treats a failed body fetch.
     if (!verdict) continue;
 
+    // The suppression upsert comes BEFORE the intent stamp. The stamp is
+    // what removes the row from the scan window (.is("intent", null)), so
+    // stamping first meant a failed upsert dropped the unsubscribe forever:
+    // the row never came back into scan. In this order a failed upsert
+    // leaves the row unclassified and the next run retries both writes;
+    // the upsert itself is idempotent, so a failed stamp after a
+    // successful upsert just re-upserts next run.
+    if (shouldSuppress(verdict.intent, verdict.confidence)) {
+      // Suppress the address we SENT to, not the reply's From: a colleague
+      // answering "please stop emailing Sam" must block sam@, and a referral
+      // target must never be suppressed for being mentioned.
+      const address = sent?.to_email?.toLowerCase();
+      if (address) {
+        const { error: suppressError } = await supabase
+          .from("outreach_suppressions")
+          .upsert(
+            {
+              user_id: row.user_id,
+              person_id: row.person_id,
+              email: address,
+              reason: suppressionReason(verdict.intent) ?? "not_interested",
+              source: "classifier",
+              // Sliced to the column's check constraint: a rambling
+              // classifier must never fail the insert and silently drop an
+              // unsubscribe.
+              detail: verdict.reasoning.slice(0, 1000),
+            },
+            {
+              onConflict: "user_id,email",
+              // An unsubscribe upgrades an existing softer row
+              // (not_interested, user) so the strongest opt-out evidence is
+              // what's on record; anything weaker never overwrites what's
+              // already there.
+              ignoreDuplicates: verdict.intent !== "unsubscribe",
+            },
+          );
+        if (suppressError) {
+          console.error(
+            "[email-classify] suppression upsert failed:",
+            suppressError,
+          );
+          continue;
+        }
+        suppressed++;
+      }
+    }
+
     const { error: updateError } = await supabase
       .from("email_replies")
       .update({
@@ -78,44 +125,6 @@ export async function classifyReplies(): Promise<{
       continue;
     }
     classified++;
-
-    if (!shouldSuppress(verdict.intent, verdict.confidence)) continue;
-
-    // Suppress the address we SENT to, not the reply's From: a colleague
-    // answering "please stop emailing Sam" must block sam@, and a referral
-    // target must never be suppressed for being mentioned.
-    const address = sent?.to_email?.toLowerCase();
-    if (!address) continue;
-
-    const { error: suppressError } = await supabase
-      .from("outreach_suppressions")
-      .upsert(
-        {
-          user_id: row.user_id,
-          person_id: row.person_id,
-          email: address,
-          reason: suppressionReason(verdict.intent) ?? "not_interested",
-          source: "classifier",
-          // Sliced to the column's check constraint: a rambling classifier
-          // must never fail the insert and silently drop an unsubscribe.
-          detail: verdict.reasoning.slice(0, 1000),
-        },
-        {
-          onConflict: "user_id,email",
-          // An unsubscribe upgrades an existing softer row (not_interested,
-          // user) so the strongest opt-out evidence is what's on record;
-          // anything weaker never overwrites what's already there.
-          ignoreDuplicates: verdict.intent !== "unsubscribe",
-        },
-      );
-    if (suppressError) {
-      console.error(
-        "[email-classify] suppression upsert failed:",
-        suppressError,
-      );
-      continue;
-    }
-    suppressed++;
   }
 
   return { scanned: rows.length, classified, suppressed };

--- a/src/lib/jobs/executors/email-track.ts
+++ b/src/lib/jobs/executors/email-track.ts
@@ -73,7 +73,11 @@ export async function trackEmailReplies(): Promise<{
     .order("sent_at", { ascending: false })
     .limit(MAX_OUTSTANDING);
 
-  if (error || !emails || emails.length === 0) {
+  // A failed scan is not an empty inbox: reporting {checked: 0} on error
+  // made the job complete clean while replies went unseen. Throwing lets
+  // execute.ts mark the run failed and retry.
+  if (error) throw new Error(`sent_emails load: ${error.message}`);
+  if (!emails || emails.length === 0) {
     return { checked: 0, updated: 0, captured: 0 };
   }
 
@@ -85,10 +89,14 @@ export async function trackEmailReplies(): Promise<{
 
   // Load gmail credentials for the affected users
   const userIds = [...new Set(emails.map((e) => e.user_id))];
-  const { data: settingsRows } = await supabase
+  const { data: settingsRows, error: settingsError } = await supabase
     .from("user_settings")
     .select("user_id, gmail_address, gmail_app_password_enc")
     .in("user_id", userIds);
+  // Same contract as the scan: no credentials loaded is a failed run, not a
+  // run where every user happened to be unconfigured.
+  if (settingsError)
+    throw new Error(`user_settings load: ${settingsError.message}`);
 
   const credsByUser = new Map<
     string,

--- a/src/lib/jobs/executors/reply-backfill.ts
+++ b/src/lib/jobs/executors/reply-backfill.ts
@@ -70,7 +70,7 @@ export async function backfillReplyBodies(
 
   // Candidates: a send that reached a terminal state, whose reply we either
   // never stored or stored without a body.
-  const { data: emails } = await supabase
+  const { data: emails, error: scanError } = await supabase
     .from("sent_emails")
     .select(
       "id, message_id, campaign_people_id, user_id, status, sent_at, person_id, to_email, campaign_id, " +
@@ -80,6 +80,10 @@ export async function backfillReplyBodies(
     .gte("sent_at", windowStart)
     .order("sent_at", { ascending: false })
     .limit(500);
+
+  // A failed scan must fail the run (execute.ts -> failJob), not read as
+  // "no bodies missing" and report clean.
+  if (scanError) throw new Error(`sent_emails load: ${scanError.message}`);
 
   // Typed by hand: PostgREST's inference gives up on the embed and widens the
   // whole result to an error type.
@@ -108,10 +112,12 @@ export async function backfillReplyBodies(
   }
 
   const userIds = [...byUser.keys()].slice(0, USERS_PER_PASS);
-  const { data: settingsRows } = await supabase
+  const { data: settingsRows, error: settingsError } = await supabase
     .from("user_settings")
     .select("user_id, gmail_address, gmail_app_password_enc")
     .in("user_id", userIds);
+  if (settingsError)
+    throw new Error(`user_settings load: ${settingsError.message}`);
 
   const credsByUser = new Map<
     string,

--- a/src/lib/services/email-tracking.ts
+++ b/src/lib/services/email-tracking.ts
@@ -65,15 +65,41 @@ export async function applyInboundStatus(
   const newPriority = STATUS_PRIORITY[newStatus] ?? 0;
   if (newPriority <= currentPriority) return false;
 
+  // campaign_people first, sent_emails last. The re-poll ladder above
+  // compares against sent_emails.status, so that stamp is the dedupe
+  // marker: writing it first meant a crash (or a failed campaign_people
+  // write) between the two lost the reply forever. The next poll saw
+  // replied -> replied and skipped while campaign_people still said
+  // "sent" and follow-ups kept going.
+  let cpQuery = supabase
+    .from("campaign_people")
+    .update({ outreach_status: newStatus })
+    .eq("id", email.campaign_people_id);
+  if (newPriority < 6) {
+    // Sub-terminal signals (delivered/opened/clicked) must not walk a
+    // terminal campaign_people status backwards when the two tables have
+    // diverged (e.g. after a data repair).
+    cpQuery = cpQuery.not(
+      "outreach_status",
+      "in",
+      '("replied","bounced","complained","unsubscribed")',
+    );
+  }
+  const { error: cpError } = await cpQuery;
+  if (cpError) {
+    // Not stamped: the next poll's ladder still sees the old sent_emails
+    // status and retries both writes.
+    console.error(
+      "[email-tracking] campaign_people status write failed:",
+      cpError,
+    );
+    return false;
+  }
+
   await supabase
     .from("sent_emails")
     .update({ status: newStatus })
     .eq("id", email.id);
-
-  await supabase
-    .from("campaign_people")
-    .update({ outreach_status: newStatus })
-    .eq("id", email.campaign_people_id);
 
   // A bounce is the only ground truth we ever get about an address we guessed.
   // Feeding it back clears the contact's verification and, when the address was

--- a/src/lib/services/outreach-sender.ts
+++ b/src/lib/services/outreach-sender.ts
@@ -256,6 +256,43 @@ export async function claimAndSendDraft(
     }
   }
 
+  // Recipient status: a prospect who replied, bounced, complained, or
+  // unsubscribed is out of the pipeline, whatever path the send came from.
+  // The followups cron checks this before calling in, but send-now, the
+  // hero's Send all, and the agent tools did not: a reply landing between
+  // approval and click kept the follow-up going out mid-conversation.
+  // Checked before the claim and the gate read so it spends nothing.
+  if (draft.campaign_people_id) {
+    const { data: cp, error: cpError } = await supabase
+      .from("campaign_people")
+      .select("outreach_status")
+      .eq("id", draft.campaign_people_id)
+      .maybeSingle();
+    // Fail closed, same contract as the suppression list: "could not check
+    // whether they replied" must not become "send anyway".
+    if (cpError) {
+      return refuse(
+        supabase,
+        draft.id,
+        "deferred",
+        "Could not check the recipient's status; will retry.",
+      );
+    }
+    const terminal = ["replied", "bounced", "complained", "unsubscribed"];
+    if (cp && terminal.includes(cp.outreach_status as string)) {
+      const why =
+        cp.outreach_status === "replied"
+          ? "they replied: this conversation is live, follow-ups stop"
+          : `their status is ${cp.outreach_status}`;
+      return refuse(
+        supabase,
+        draft.id,
+        "blocked",
+        `Not sending to ${draft.to_email}: ${why}.`,
+      );
+    }
+  }
+
   // Send window: cron-driven paths wait for the window; interactive paths
   // (send-now click, agent send confirmed in chat) pass bypassSendWindow —
   // an explicit human "send" beats a schedule preference.

--- a/src/lib/services/outreach-sender.ts
+++ b/src/lib/services/outreach-sender.ts
@@ -595,10 +595,20 @@ export async function claimAndSendDraft(
     .eq("id", draft.id);
 
   if (draft.campaign_people_id) {
+    // "sent" may only overwrite pre-send states. A reply or bounce recorded
+    // between draft and send must survive this bookkeeping: the tracking
+    // ladder compares against sent_emails (already terminal there), so a
+    // downgrade written here was permanent and follow-ups kept going to
+    // people mid-conversation.
     await supabase
       .from("campaign_people")
       .update({ outreach_status: "sent" })
-      .eq("id", draft.campaign_people_id);
+      .eq("id", draft.campaign_people_id)
+      .not(
+        "outreach_status",
+        "in",
+        '("replied","bounced","complained","unsubscribed")',
+      );
   }
 
   trackUsage({


### PR DESCRIPTION
PR-1 of the hardening plan (Wave 0): the reply/bounce pipeline. Fixes K3, K20, and the email-tracking/classify/backfill ordering findings.

## What was broken

- **`claimAndSendDraft` unconditionally wrote `outreach_status='sent'`**, permanently downgrading `replied`: the tracking ladder dedupes against `sent_emails` (already terminal there), so nothing ever restored it and follow-ups kept going to live conversations.
- **No send path checked whether the recipient had replied.** The followups cron did, but send-now, the hero's Send all, and both agent tools did not.
- **`applyInboundStatus` stamped `sent_emails` (its dedupe marker) before `campaign_people`**: a crash between the writes lost the reply forever.
- **`email-classify` stamped intent (which removes the row from the scan window) before upserting the suppression**: a failed upsert silently dropped an unsubscribe (compliance risk).
- **`email.track` and the reply backfill folded scan errors into "nothing to check"** and completed clean.

## Fixes (each its own commit, test-first)

1. The post-send status write is monotonic: `sent` never overwrites `replied`/`bounced`/`complained`/`unsubscribed`.
2. New recipient-status gate in `claimAndSendDraft` (the choke point all four send paths funnel through): refuses terminal-status recipients before the claim, fail-closed when the status cannot be read.
3. `applyInboundStatus` writes `campaign_people` first, `sent_emails` last; a failed first write leaves the ladder retryable. Sub-terminal signals cannot walk a terminal `campaign_people` status backwards.
4. `email-classify` upserts the suppression first, stamps intent last; both writes retry on next run if either fails.
5. Both scan loaders throw on error so `execute.ts` marks the run failed.

## After deploy

Data repairs 3 and 7 from the runbook become safe to run (restore downgraded `replied` rows; rescan classified replies for lost suppressions).

Tests: 883 passed (9 new); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)