### PR TITLE
fix(security): signal prompt-injection gating + SSRF DNS pinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "tailwind-merge": "^3.5.0",
     "tldts": "^7.0.30",
     "tw-animate-css": "^1.4.0",
+    "undici": "^8.10.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      undici:
+        specifier: ^8.10.0
+        version: 8.10.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -6171,6 +6174,10 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -13713,6 +13720,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@7.25.0: {}
+
+  undici@8.10.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/src/__tests__/safe-fetch.test.ts
+++ b/src/__tests__/safe-fetch.test.ts
@@ -4,6 +4,7 @@ import {
   addressIsPublic,
   assertPublicUrl,
   BlockedUrlError,
+  pinnedLookup,
   readBodyCapped,
   safeFetch,
   type HostResolver,
@@ -140,6 +141,56 @@ describe("safeFetch redirects", () => {
       { resolveHost: publicDns },
     );
     expect(res.status).toBe(200);
+  });
+});
+
+describe("DNS pinning", () => {
+  it("answers the vetted addresses without consulting DNS again", () => {
+    // Rebinding TOCTOU: the guard resolves once and vets, but fetch used to
+    // re-resolve on connect, so a TTL-0 domain could answer a public IP to
+    // the guard and the metadata service to the connection. The pinned
+    // lookup ignores the hostname entirely.
+    const lookup = pinnedLookup(["93.184.216.34"]);
+
+    lookup("evil.example.com", { all: false }, (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe("93.184.216.34");
+      expect(family).toBe(4);
+    });
+    lookup("evil.example.com", { all: true }, (err, records) => {
+      expect(err).toBeNull();
+      expect(records).toEqual([{ address: "93.184.216.34", family: 4 }]);
+    });
+  });
+
+  it("carries IPv6 family through", () => {
+    pinnedLookup(["2606:4700::1111"])("x", { all: false }, (_e, a, f) => {
+      expect(a).toBe("2606:4700::1111");
+      expect(f).toBe(6);
+    });
+  });
+
+  it("hands fetch a dispatcher pinned to the guard's own resolution", async () => {
+    // Simulated rebinding: the first resolution (the guard's) is public,
+    // any later one would be the metadata service. The dispatcher's lookup
+    // must answer the first, vetted address.
+    let resolutions = 0;
+    const rebinding: HostResolver = async () => {
+      resolutions++;
+      return resolutions === 1 ? ["93.184.216.34"] : ["169.254.169.254"];
+    };
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+
+    await safeFetch("https://example.com/", {}, { resolveHost: rebinding });
+
+    const initArg = fetchMock.mock.calls[0][1] as {
+      dispatcher?: unknown;
+    };
+    expect(initArg.dispatcher).toBeDefined();
+    // The guard resolved exactly once; nothing re-consulted the resolver.
+    expect(resolutions).toBe(1);
   });
 });
 

--- a/src/__tests__/signal-detail-dialog.test.tsx
+++ b/src/__tests__/signal-detail-dialog.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SignalDetailDialog } from "@/components/signals/signal-detail-dialog";
+import type { Signal } from "@/lib/types/signal";
+
+afterEach(cleanup);
+
+function signal(over: Partial<Signal> = {}): Signal {
+  return {
+    id: "sig_1",
+    name: "Hiring for GTM roles",
+    description: "Company is hiring GTM",
+    long_description: "Watch the careers page for GTM openings.",
+    category: "hiring",
+    icon: null,
+    execution_type: "exa_search",
+    tool_key: null,
+    config: {},
+    is_builtin: false,
+    is_public: true,
+    created_by: "prof_other",
+    created_at: "",
+    updated_at: "",
+    ...over,
+  } as Signal;
+}
+
+describe("<SignalDetailDialog> edit gating", () => {
+  it("offers Edit only when the page supplies an onEdit handler", () => {
+    // The page passes onEdit only for the user's OWN signals: Edit
+    // interpolates the signal's stored text into an auto-sent agent message
+    // and the agent holds send tools, so another tenant's community signal
+    // must never take this path (cross-tenant prompt injection).
+    render(
+      <SignalDetailDialog
+        signal={signal()}
+        open
+        onOpenChange={vi.fn()}
+        onEdit={undefined}
+        onMakePublic={undefined}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /edit/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still offers Edit for an owned non-builtin signal", () => {
+    render(
+      <SignalDetailDialog
+        signal={signal({ is_public: false, created_by: "prof_mine" })}
+        open
+        onOpenChange={vi.fn()}
+        onEdit={vi.fn()}
+        onMakePublic={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -58,11 +58,16 @@ function SignalsPageContent() {
   const [activeCategory, setActiveCategory] = useState<string>("all");
   const [detailSignal, setDetailSignal] = useState<Signal | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [ownedProfileIds, setOwnedProfileIds] = useState<string[]>([]);
   const mountedRef = useRef(true);
+  // Which campaign's toggles were requested last, so a slow earlier
+  // response can never overwrite a later campaign's map.
+  const togglesRequestRef = useRef<string>("");
 
   const fetchData = useCallback(async () => {
     const supabase = createClient();
-    const [signalsRes, campaignsRes] = await Promise.all([
+    const [signalsRes, campaignsRes, profilesRes] = await Promise.all([
       supabase
         .from("signals")
         .select("*")
@@ -72,24 +77,48 @@ function SignalsPageContent() {
         .from("campaigns")
         .select("id, name, status")
         .order("updated_at", { ascending: false }),
+      // RLS scopes user_profile to the caller: these ids are what marks a
+      // signal as the user's own (created_by is a profile id).
+      supabase.from("user_profile").select("id"),
     ]);
     if (!mountedRef.current) return;
+    // A failed query must render as an error, not as a library with zero
+    // signals: the empty grid is indistinguishable from real data.
+    const firstError =
+      signalsRes.error ?? campaignsRes.error ?? profilesRes.error;
+    if (firstError) {
+      setLoadError(firstError.message);
+      setLoading(false);
+      return;
+    }
+    setLoadError(null);
     setSignals((signalsRes.data as Signal[]) ?? []);
     setCampaigns((campaignsRes.data as Campaign[]) ?? []);
+    setOwnedProfileIds((profilesRes.data ?? []).map((p) => p.id as string));
     setLoading(false);
   }, []);
 
   const fetchToggles = useCallback(async (campaignId: string) => {
+    togglesRequestRef.current = campaignId;
     if (!campaignId) {
       setEnabledMap({});
       return;
     }
     const supabase = createClient();
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from("campaign_signals")
       .select("signal_id, enabled")
       .eq("campaign_id", campaignId);
     if (!mountedRef.current) return;
+    // A stale response (user already switched campaigns) must not paint the
+    // previous campaign's toggle state under the new selection.
+    if (togglesRequestRef.current !== campaignId) return;
+    if (error) {
+      // Leave the map alone: rendering every toggle off would invite the
+      // user to "re-enable" signals that are already on.
+      toast.error(`Could not load signal toggles: ${error.message}`);
+      return;
+    }
     const map: Record<string, boolean> = {};
     for (const row of data ?? []) {
       map[(row as Record<string, unknown>).signal_id as string] = (
@@ -99,9 +128,16 @@ function SignalsPageContent() {
     setEnabledMap(map);
   }, []);
 
+  const isOwned = useCallback(
+    (signal: Signal) =>
+      !!signal.created_by && ownedProfileIds.includes(signal.created_by),
+    [ownedProfileIds],
+  );
+
   useEffect(() => {
     mountedRef.current = true;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchData();
     return () => {
       mountedRef.current = false;
@@ -154,12 +190,18 @@ function SignalsPageContent() {
 
   const handleMakePublic = async (signal: Signal) => {
     const supabase = createClient();
-    const { error } = await supabase
+    // Row count checked, not just error: the RLS-filtered update returns
+    // error null with zero matched rows (e.g. created_by nulled by a
+    // deleted profile), which used to toast success while nothing changed.
+    const { data: updated, error } = await supabase
       .from("signals")
       .update({ is_public: true })
-      .eq("id", signal.id);
-    if (error) {
-      toast.error("Failed to publish signal");
+      .eq("id", signal.id)
+      .select("id");
+    if (error || !updated || updated.length === 0) {
+      toast.error(
+        "Could not publish this signal: it does not belong to one of your profiles.",
+      );
     } else {
       toast.success("Signal published to community");
       setSignals((prev) =>
@@ -263,18 +305,40 @@ function SignalsPageContent() {
               : "animate-in fade-in-0 duration-200 grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
           }
         >
-          {filtered.map((signal) => (
-            <SignalCard
-              key={signal.id}
-              signal={signal}
-              variant="card"
-              enabled={enabledMap[signal.id] ?? false}
-              showToggle={!!selectedCampaignId}
-              onToggle={handleToggle}
-              onClick={setDetailSignal}
-            />
-          ))}
-          {filtered.length === 0 && (
+          {loadError && (
+            <div
+              role="alert"
+              className="col-span-full py-8 text-center text-sm"
+            >
+              <p className="text-destructive">
+                Could not load signals: {loadError}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={() => {
+                  setLoading(true);
+                  fetchData();
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+          {!loadError &&
+            filtered.map((signal) => (
+              <SignalCard
+                key={signal.id}
+                signal={signal}
+                variant="card"
+                enabled={enabledMap[signal.id] ?? false}
+                showToggle={!!selectedCampaignId}
+                onToggle={handleToggle}
+                onClick={setDetailSignal}
+              />
+            ))}
+          {!loadError && filtered.length === 0 && (
             <p className="text-muted-foreground col-span-full py-8 text-center text-sm">
               No signals in this category.
             </p>
@@ -288,8 +352,15 @@ function SignalsPageContent() {
         onOpenChange={(open) => {
           if (!open) setDetailSignal(null);
         }}
-        onMakePublic={handleMakePublic}
-        onEdit={handleEdit}
+        // Edit interpolates the signal's stored text into an auto-sent
+        // agent message, and the agent holds send tools: community signals
+        // are other tenants' text, so only the user's own signals may take
+        // either path. This is the same injection surface the builtin-
+        // spoofing migration closed, still open via is_public rows.
+        onMakePublic={
+          detailSignal && isOwned(detailSignal) ? handleMakePublic : undefined
+        }
+        onEdit={detailSignal && isOwned(detailSignal) ? handleEdit : undefined}
       />
     </div>
   );

--- a/src/components/signals/campaign-signals-popover.tsx
+++ b/src/components/signals/campaign-signals-popover.tsx
@@ -23,6 +23,7 @@ interface CampaignSignalsPopoverProps {
 interface SignalsData {
   signals: Signal[];
   enabled: Record<string, boolean>;
+  error?: string;
 }
 
 async function fetchSignalsData(campaignId: string): Promise<SignalsData> {
@@ -38,6 +39,13 @@ async function fetchSignalsData(campaignId: string): Promise<SignalsData> {
       .select("signal_id, enabled")
       .eq("campaign_id", campaignId),
   ]);
+
+  // A failed query must render as an error, not as "No signals defined."
+  // or as every toggle switched off: both misstate what is armed.
+  const firstError = signalsRes.error ?? togglesRes.error;
+  if (firstError) {
+    return { signals: [], enabled: {}, error: firstError.message };
+  }
 
   const enabled: Record<string, boolean> = {};
   for (const row of togglesRes.data ?? []) {
@@ -118,7 +126,7 @@ export function CampaignSignalsPopover({
           <Button variant="outline" size="sm" aria-label="Manage signals">
             <Zap className="mr-1.5 h-4 w-4" />
             Signals
-            {data && (
+            {data && !data.error && (
               <span className="text-muted-foreground ml-1.5 tabular-nums">
                 {enabledCount}/{signals.length}
               </span>
@@ -139,6 +147,13 @@ export function CampaignSignalsPopover({
         {!data ? (
           <div className="text-muted-foreground px-3 py-6 text-center text-sm">
             Loading...
+          </div>
+        ) : data.error ? (
+          <div
+            role="alert"
+            className="text-destructive px-3 py-6 text-center text-sm"
+          >
+            Could not load signals: {data.error}
           </div>
         ) : signals.length === 0 ? (
           <div className="text-muted-foreground px-3 py-6 text-center text-sm">

--- a/src/lib/safe-fetch.ts
+++ b/src/lib/safe-fetch.ts
@@ -1,5 +1,6 @@
 import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
+import { isIP, type LookupFunction } from "node:net";
+import { Agent } from "undici";
 
 /**
  * Outbound HTTP for URLs the product did not choose.
@@ -113,6 +114,18 @@ export async function assertPublicUrl(
   raw: string,
   resolveHost: HostResolver = realResolver,
 ): Promise<URL> {
+  return (await vetPublicUrl(raw, resolveHost)).url;
+}
+
+/**
+ * assertPublicUrl plus the addresses it vetted, so the connection can be
+ * pinned to exactly what was checked. Kept separate because assertPublicUrl
+ * is public API with URL-only semantics.
+ */
+async function vetPublicUrl(
+  raw: string,
+  resolveHost: HostResolver = realResolver,
+): Promise<{ url: URL; addresses: string[] }> {
   let url: URL;
   try {
     url = new URL(raw);
@@ -134,7 +147,7 @@ export async function assertPublicUrl(
         `${host} is not a publicly routable address, so it will not be fetched.`,
       );
     }
-    return url;
+    return { url, addresses: [host] };
   }
 
   // A single-label host ("localhost", "supabase-kong") is only meaningful on
@@ -164,7 +177,27 @@ export async function assertPublicUrl(
     }
   }
 
-  return url;
+  return { url, addresses };
+}
+
+/**
+ * A dns.lookup-compatible function that answers with a fixed address list
+ * and never consults DNS. This closes the rebinding TOCTOU: the guard vets
+ * the addresses it resolved, but fetch performs its OWN lookup, so a TTL-0
+ * domain could answer a public IP to the guard and 169.254.169.254 to the
+ * connection. Pinning the vetted addresses onto the connection makes the
+ * checked address the connected address, while TLS SNI and certificate
+ * validation still run against the hostname in the URL.
+ */
+export function pinnedLookup(addresses: string[]): LookupFunction {
+  return (_hostname, options, callback) => {
+    const records = addresses.map((address) => ({
+      address,
+      family: isIP(address) === 6 ? 6 : 4,
+    }));
+    if (options?.all) callback(null, records);
+    else callback(null, records[0].address, records[0].family);
+  };
 }
 
 /**
@@ -223,15 +256,22 @@ export async function safeFetch(
   const { timeoutMs, maxRedirects } = { ...DEFAULTS, ...options };
   const resolveHost = options.resolveHost ?? realResolver;
 
-  let target = await assertPublicUrl(rawUrl, resolveHost);
+  let { url: target, addresses } = await vetPublicUrl(rawUrl, resolveHost);
   const signal = init.signal ?? AbortSignal.timeout(timeoutMs);
 
   for (let hop = 0; hop <= maxRedirects; hop++) {
+    // The connection is pinned to the vetted addresses (see pinnedLookup);
+    // the short-lived Agent is not closed here because the caller may still
+    // be streaming the body, and its idle sockets time out on their own.
+    const dispatcher = new Agent({
+      connect: { lookup: pinnedLookup(addresses) },
+    });
     const response = await fetch(target, {
       ...init,
       signal,
       redirect: "manual",
-    });
+      dispatcher,
+    } as RequestInit);
 
     const location = response.headers.get("location");
     const isRedirect =
@@ -248,10 +288,12 @@ export async function safeFetch(
     // Resolved against the current URL so a relative Location works, then
     // vetted again: passing the first check buys the destination nothing.
     response.body?.cancel().catch(() => {});
-    target = await assertPublicUrl(
+    const next = await vetPublicUrl(
       new URL(location, target).toString(),
       resolveHost,
     );
+    target = next.url;
+    addresses = next.addresses;
   }
 
   throw new BlockedUrlError(

--- a/src/lib/signals.ts
+++ b/src/lib/signals.ts
@@ -14,7 +14,15 @@ export async function getActiveSignals(campaignId: string): Promise<Signal[]> {
     .eq("campaign_id", campaignId)
     .eq("enabled", true);
 
-  if (error || !data) return [];
+  // Logged rather than silently coalesced: an empty return here strips the
+  // enabled-signals block from the chat system prompt, and the prompt tells
+  // the agent to only run enrichment for listed signals, so a swallowed
+  // failure reads to the agent as "this campaign has zero signals".
+  if (error) {
+    console.error("[signals] getActiveSignals failed:", error);
+    return [];
+  }
+  if (!data) return [];
 
   return data
     .map((row: Record<string, unknown>) => row.signals as Signal | null)


### PR DESCRIPTION
PR-3 of the hardening plan (Wave 0): the two security findings plus the signals page's swallowed errors.

## Cross-tenant prompt injection (signals)

`handleEdit` interpolates a signal's `long_description` and `config` verbatim into an **auto-sent** agent message, and the dialog offered Edit on any non-builtin signal, including other tenants' community signals (`signals_select` RLS allows any `is_public` row). A hostile community signal was a prompt-injection channel into an agent holding send tools: the same surface the builtin-spoofing migration closed, still open via `is_public`.

- Edit and Make-public now require the signal's `created_by` to be one of the caller's profiles (loaded RLS-scoped in `fetchData`).
- `handleMakePublic` checks the updated row count: the RLS-filtered update returns `error: null` with zero rows (e.g. `created_by` nulled by a deleted profile), which used to toast "published" while nothing changed.
- The page and the campaign popover render query failures as errors instead of an empty library / every toggle off; a stale toggles response can no longer paint the previous campaign's state under the new selection; `getActiveSignals` logs failures instead of silently stripping the signals block from the agent's system prompt.

## SSRF: DNS rebinding TOCTOU (safe-fetch)

`assertPublicUrl` vetted the resolved addresses, but `fetch()` performs its own independent DNS lookup: a TTL-0 domain could answer a public IP to the guard and `169.254.169.254` (or the operator's own Supabase) to the connection. The vetted addresses are now pinned onto the connection via an undici `Agent` with a custom `lookup` (new `undici` dependency), per redirect hop; TLS SNI and cert validation still run against the URL hostname. `pinnedLookup` is exported and unit-tested; a rebinding-simulation test asserts the guard resolves exactly once.

Tests: 878 passed (5 new); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)