### PR TITLE
fix(review): stop draft edits silently destroying links

### DIFF
--- a/src/__tests__/html-to-plain-roundtrip.test.ts
+++ b/src/__tests__/html-to-plain-roundtrip.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { htmlToPlain, plainToHtml } from "@/lib/email/html-to-plain";
+
+describe("editor round-trip (htmlToPlain -> plainToHtml)", () => {
+  it("escapes what htmlToPlain decoded, so the trip is symmetric", () => {
+    // htmlToPlain decodes entities into the textarea; plainToHtml used to
+    // re-serialise without encoding, so "&lt;10ms" came back as a raw
+    // "<10ms" that mail clients parse as a tag open and swallow.
+    const original = "<p>we cut latency to &lt;10ms &amp; kept costs flat</p>";
+    const text = htmlToPlain(original);
+    expect(text).toBe("we cut latency to <10ms & kept costs flat");
+
+    const back = plainToHtml(text);
+    expect(back).toBe(
+      "<p>we cut latency to &lt;10ms &amp; kept costs flat</p>",
+    );
+    // And it survives a second pass unchanged.
+    expect(plainToHtml(htmlToPlain(back))).toBe(back);
+  });
+
+  it("escapes characters the user types directly", () => {
+    expect(plainToHtml("a < b & c > d")).toBe("<p>a &lt; b &amp; c &gt; d</p>");
+  });
+
+  it("keeps paragraph and line-break structure", () => {
+    expect(plainToHtml("one\ntwo\n\nthree")).toBe(
+      "<p>one<br>two</p><p>three</p>",
+    );
+  });
+});

--- a/src/__tests__/review-page-adhoc.test.tsx
+++ b/src/__tests__/review-page-adhoc.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ── Router: which mode the page runs in comes from the URL ────────────────
@@ -23,6 +29,7 @@ vi.mock("@/components/campaign/contact-detail", () => ({
 interface BuilderCall {
   table: string;
   filters: Array<[string, string, unknown]>;
+  updatePayload?: Record<string, unknown>;
 }
 let builderCalls: BuilderCall[] = [];
 let draftRows: unknown[] = [];
@@ -30,10 +37,14 @@ let draftRows: unknown[] = [];
 function makeBuilder(table: string) {
   const call: BuilderCall = { table, filters: [] };
   builderCalls.push(call);
-  const rows = table === "email_drafts" ? draftRows : [];
   const builder = {
     select: () => builder,
     order: () => builder,
+    in: () => builder,
+    update: (payload: Record<string, unknown>) => {
+      call.updatePayload = payload;
+      return builder;
+    },
     eq: (col: string, val: unknown) => {
       call.filters.push([table, col, val]);
       return builder;
@@ -42,8 +53,17 @@ function makeBuilder(table: string) {
       call.filters.push([table, col, val]);
       return builder;
     },
-    then: (resolve: (v: { data: unknown[]; error: null }) => void) =>
-      Promise.resolve({ data: rows, error: null }).then(resolve),
+    then: (resolve: (v: { data: unknown[]; error: null }) => void) => {
+      // Reads return the seeded drafts; the review_status write echoes ids
+      // back (the page verifies the updated row count); other writes are {}.
+      const rows =
+        table === "email_drafts" && !call.updatePayload
+          ? draftRows
+          : call.updatePayload && "review_status" in call.updatePayload
+            ? draftRows.map((d) => ({ id: (d as { id: string }).id }))
+            : [];
+      return Promise.resolve({ data: rows, error: null }).then(resolve);
+    },
   };
   return builder;
 }
@@ -128,6 +148,39 @@ describe("review page ad-hoc mode", () => {
     expect(screen.getByText("One-off email")).toBeVisible();
     expect(screen.queryByText(/Step 1 of/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Approve all" })).toBeEnabled();
+  });
+
+  it("a subject-only edit never rewrites the body", async () => {
+    // Regression: the save payload used to include body_html/body_text
+    // unconditionally, so tweaking just the subject pushed the untouched
+    // body through the lossy htmlToPlain -> plainToHtml round-trip and
+    // silently stripped every link the composer had written.
+    search = "";
+    draftRows = [adhocDraft("d1", "p1", "Mark Ryan")];
+
+    render(<ReviewPage />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Mark Ryan", level: 2 }),
+      ).toBeVisible(),
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Subject..."), {
+      target: { value: "A sharper subject" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Approve all" }));
+
+    await waitFor(() => {
+      const editWrite = builderCalls.find(
+        (c) =>
+          c.table === "email_drafts" &&
+          c.updatePayload &&
+          "subject" in c.updatePayload,
+      );
+      expect(editWrite).toBeDefined();
+      expect(editWrite!.updatePayload).not.toHaveProperty("body_html");
+      expect(editWrite!.updatePayload).not.toHaveProperty("body_text");
+    });
   });
 
   it("with a sequence param, still scopes to that sequence", async () => {

--- a/src/app/outreach/review/page.tsx
+++ b/src/app/outreach/review/page.tsx
@@ -22,20 +22,12 @@ import {
 import { createClient } from "@/lib/supabase/client";
 import type { CampaignContact, EnrichmentData } from "@/lib/types/campaign";
 import { apiFetch } from "@/lib/api-fetch";
-import { htmlToPlain } from "@/lib/email/html-to-plain";
+import { htmlToPlain, plainToHtml } from "@/lib/email/html-to-plain";
 
-// Moved to src/lib/email/html-to-plain.ts so the read-only activity view can
-// share it. Deliberately the LOSSY variant: this feeds a textarea that
+// Both halves of the editor round-trip live in src/lib/email/html-to-plain.ts.
+// htmlToPlain is deliberately the LOSSY variant: this feeds a textarea that
 // plainToHtml re-serialises on save, so a link-preserving version here would
 // write "text (url)" back into the body as literal text.
-
-function plainToHtml(text: string): string {
-  const paragraphs = text
-    .split(/\n\s*\n/)
-    .map((p) => p.trim())
-    .filter(Boolean);
-  return paragraphs.map((p) => `<p>${p.replace(/\n/g, "<br>")}</p>`).join("");
-}
 
 interface DraftForReview {
   id: string;
@@ -366,14 +358,20 @@ function ReviewPageInner() {
           const subjectChanged = edit.subject !== d.subject;
           const bodyChanged = edit.bodyText !== baseBody;
           if (!subjectChanged && !bodyChanged) return;
+          // Only what actually changed is written. The payload used to
+          // include the body unconditionally, so a subject-only tweak
+          // pushed the untouched body through the lossy htmlToPlain ->
+          // plainToHtml round-trip and silently stripped every link the
+          // composer had written.
+          const patch: Record<string, string> = { updated_at: now };
+          if (subjectChanged) patch.subject = edit.subject;
+          if (bodyChanged) {
+            patch.body_html = plainToHtml(edit.bodyText);
+            patch.body_text = edit.bodyText;
+          }
           const { error } = await supabase
             .from("email_drafts")
-            .update({
-              subject: edit.subject,
-              body_html: plainToHtml(edit.bodyText),
-              body_text: edit.bodyText,
-              updated_at: now,
-            })
+            .update(patch)
             .eq("id", d.id);
           if (error)
             throw new Error(`Could not save your edit: ${error.message}`);
@@ -554,14 +552,17 @@ function ReviewPageInner() {
           const subjectChanged = edit.subject !== draft.subject;
           const bodyChanged = edit.bodyText !== baseBody;
           if (subjectChanged || bodyChanged) {
+            // Same partial-payload rule as the approve path: an untouched
+            // body must never round-trip through the lossy serialiser.
+            const patch: Record<string, string> = { updated_at: now };
+            if (subjectChanged) patch.subject = edit.subject;
+            if (bodyChanged) {
+              patch.body_html = plainToHtml(edit.bodyText);
+              patch.body_text = edit.bodyText;
+            }
             const { error: editErr } = await supabase
               .from("email_drafts")
-              .update({
-                subject: edit.subject,
-                body_html: plainToHtml(edit.bodyText),
-                body_text: edit.bodyText,
-                updated_at: now,
-              })
+              .update(patch)
               .eq("id", draftId);
             if (editErr) {
               toast.error(editErr.message);

--- a/src/components/campaign/companies-list.tsx
+++ b/src/components/campaign/companies-list.tsx
@@ -481,12 +481,20 @@ export function CompaniesList({
     if (error) throw new Error(error.message);
 
     if (oldEmail) {
-      await supabase
+      // Surfaced, not fire-and-forget: a silently failed retarget leaves
+      // pending drafts addressed to the old email, and the send gate then
+      // refuses them with "regenerate the draft" for an address the user
+      // believes they already fixed.
+      const { error: draftsError } = await supabase
         .from("email_drafts")
         .update({ to_email: next, updated_at: now })
         .eq("person_id", contact.person_id)
         .eq("status", "draft")
         .eq("to_email", oldEmail);
+      if (draftsError)
+        throw new Error(
+          `Saved the contact, but pending drafts still use ${oldEmail}: ${draftsError.message}`,
+        );
     }
 
     onDataChanged();

--- a/src/lib/email/html-to-plain.ts
+++ b/src/lib/email/html-to-plain.ts
@@ -80,6 +80,29 @@ export function htmlToPlain(html: string): string {
 }
 
 /**
+ * The editor's serialiser: the other half of htmlToPlain's round-trip.
+ *
+ * Escapes &, < and > before wrapping, because htmlToPlain DECODES entities
+ * on the way into the textarea: without the matching encode on the way back
+ * the round trip was asymmetric, and a body containing "&lt;10ms" came back
+ * as a raw "<10ms" that mail clients parse as a tag open and swallow.
+ *
+ * Moved out of outreach/review/page.tsx so it can be tested against
+ * htmlToPlain directly.
+ */
+export function plainToHtml(text: string): string {
+  const escaped = text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+  const paragraphs = escaped
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return paragraphs.map((p) => `<p>${p.replace(/\n/g, "<br>")}</p>`).join("");
+}
+
+/**
  * Read-only conversion that keeps link targets.
  *
  * The composer is allowed to emit anchors (skill.ts permits <p>, <br> and <a>),


### PR DESCRIPTION
PR-4 of the hardening plan (Wave 0): the draft-editing round-trip.

## What was broken

- **A subject-only edit rewrote `body_html`** through the lossy `htmlToPlain -> plainToHtml` round-trip (both the approve path and Send now): every link the composer wrote was silently stripped from the email that then got sent, with zero indication to the reviewer.
- **The round-trip was asymmetric:** `htmlToPlain` decodes entities into the textarea, but `plainToHtml` re-serialised without encoding, so a body containing `&lt;10ms` came back as a raw `<10ms` that HTML mail clients parse as a tag open and swallow (truncating the sentence for the recipient).
- **The email retarget in the companies list ignored its `email_drafts` update error**: on failure the UI showed success while pending drafts kept the old address, which the send gate later refuses with "regenerate the draft".

## Fixes

1. Draft saves write only the fields that changed; an untouched body never round-trips.
2. `plainToHtml` escapes `&`, `<`, `>` before wrapping, and moved to `lib/email/html-to-plain.ts` beside its inverse; the symmetry is unit-tested both directions.
3. The retarget throws on a failed drafts update so `EditableEmail` surfaces it.

## After deploy

Data repair 17 from the runbook (resync `email_drafts.to_email` for pending drafts) becomes safe to run.

Tests: 877 passed (4 new, incl. a page-level regression asserting a subject-only approve writes no body fields); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)