### PR TITLE
fix(cleanup): stop re-sending delivered emails; finish recovery bookkeeping

### DIFF
--- a/src/__tests__/email-cleanup.test.ts
+++ b/src/__tests__/email-cleanup.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: vi.fn(),
+}));
+
+import { cleanupEmails } from "@/lib/jobs/executors/email-cleanup";
+import { getAdminClient } from "@/lib/supabase/admin";
+
+const adminMock = vi.mocked(getAdminClient);
+
+interface RecordedCall {
+  table: string;
+  ops: Array<{ name: string; args: unknown[] }>;
+}
+
+function fakeSupabase(
+  responses: Array<{ data?: unknown; error?: unknown; count?: number }>,
+) {
+  let i = 0;
+  const calls: RecordedCall[] = [];
+  const from = (table: string) => {
+    const call: RecordedCall = { table, ops: [] };
+    calls.push(call);
+    const builder: Record<string, unknown> = {};
+    for (const name of [
+      "select",
+      "eq",
+      "in",
+      "not",
+      "is",
+      "or",
+      "lt",
+      "update",
+      "delete",
+      "single",
+      "maybeSingle",
+    ]) {
+      builder[name] = (...args: unknown[]) => {
+        call.ops.push({ name, args });
+        return builder;
+      };
+    }
+    builder.then = (
+      resolve: (v: unknown) => unknown,
+      reject: (e: unknown) => unknown,
+    ) =>
+      Promise.resolve(responses[i++] ?? { data: null, error: null }).then(
+        resolve,
+        reject,
+      );
+    return builder;
+  };
+  return { calls, client: { from } as never };
+}
+
+const stuckDraft = {
+  id: "d1",
+  enrollment_id: "enr_1",
+  campaign_people_id: "cp_1",
+  sequence_step_id: "s1",
+};
+
+describe("cleanupEmails stranded-queued recovery", () => {
+  it("marks a delivered draft sent AND finishes the enrollment bookkeeping", async () => {
+    // K5: marking the draft "sent" while leaving the enrollment pinned to
+    // that step made every followups run fail "No approved draft ready for
+    // this step" forever. Recovery now advances the enrollment (here: to
+    // completed, no next step) and syncs campaign_people, monotonically.
+    const { client, calls } = fakeSupabase([
+      { data: [stuckDraft] }, // stuck scan
+      { data: [{ draft_id: "d1" }] }, // sent_emails lookup: it was delivered
+      {}, // drafts -> sent
+      { data: { sequence_id: "seq_1", current_step: 1 } }, // step check: enrollment
+      { data: { id: "s1" } }, // step check: current step row
+      { data: { id: "enr_1", sequence_id: "seq_1", current_step: 1 } }, // advance: enrollment
+      { data: null }, // advance: no next step
+      {}, // enrollment -> completed
+      {}, // campaign_people -> sent (guarded)
+      { count: 0 }, // discarded delete
+      { count: 0 }, // stale delete
+    ]);
+    adminMock.mockReturnValue(client as never);
+
+    const result = await cleanupEmails();
+
+    expect(result.recovered).toEqual({ markedSent: 1, returnedToDraft: 0 });
+    const enrollmentWrite = calls.find(
+      (c) =>
+        c.table === "sequence_enrollments" &&
+        c.ops.some((op) => op.name === "update"),
+    );
+    expect(enrollmentWrite?.ops).toContainEqual({
+      name: "update",
+      args: [expect.objectContaining({ status: "completed" })],
+    });
+    const cpWrite = calls.find(
+      (c) =>
+        c.table === "campaign_people" &&
+        c.ops.some((op) => op.name === "update"),
+    );
+    expect(cpWrite?.ops).toContainEqual({
+      name: "not",
+      args: [
+        "outreach_status",
+        "in",
+        '("replied","bounced","complained","unsubscribed")',
+      ],
+    });
+  });
+
+  it("fails the run when the sent_emails lookup fails, touching nothing", async () => {
+    // Regression: a failed lookup used to read as "no sent rows", so every
+    // stuck draft was classified never-sent and reset to "draft": the next
+    // cron re-sent emails that had already been delivered.
+    const { client, calls } = fakeSupabase([
+      { data: [stuckDraft] }, // stuck scan
+      { data: null, error: { message: "connection reset" } }, // lookup fails
+    ]);
+    adminMock.mockReturnValue(client as never);
+
+    await expect(cleanupEmails()).rejects.toThrow(/sent_emails lookup/);
+    expect(
+      calls.some(
+        (c) =>
+          c.table === "email_drafts" &&
+          c.ops.some(
+            (op) =>
+              op.name === "update" &&
+              (op.args[0] as { status?: string }).status === "draft",
+          ),
+      ),
+    ).toBe(false);
+  });
+
+  it("still releases genuinely never-sent drafts back to draft", async () => {
+    const { client, calls } = fakeSupabase([
+      { data: [stuckDraft] }, // stuck scan
+      { data: [] }, // no sent_emails row: the send never happened
+      {}, // drafts -> draft
+      { count: 0 },
+      { count: 0 },
+    ]);
+    adminMock.mockReturnValue(client as never);
+
+    const result = await cleanupEmails();
+
+    expect(result.recovered).toEqual({ markedSent: 0, returnedToDraft: 1 });
+    // No enrollment/campaign_people writes on this path.
+    expect(calls.some((c) => c.table === "sequence_enrollments")).toBe(false);
+    expect(calls.some((c) => c.table === "campaign_people")).toBe(false);
+  });
+});

--- a/src/__tests__/outreach-sender.test.ts
+++ b/src/__tests__/outreach-sender.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { encryptSecret } from "@/lib/crypto";
-import { sendApprovedDraft } from "@/lib/services/outreach-sender";
+import {
+  advanceEnrollmentAfterSend,
+  sendApprovedDraft,
+} from "@/lib/services/outreach-sender";
 import { sendGmailMessage } from "@/lib/services/gmail-service";
 
 vi.mock("@/lib/services/gmail-service", async (importOriginal) => {
@@ -129,6 +132,26 @@ function preSendResponses(settings: Record<string, unknown> = settingsRow()) {
 }
 
 let savedKey: string | undefined;
+
+describe("advanceEnrollmentAfterSend", () => {
+  it("leaves the enrollment untouched when the step lookup fails", async () => {
+    // "The query failed" is not "there is no next step": completing the
+    // enrollment on a transient error silently ended the whole sequence.
+    const { client, calls } = fakeSupabase([
+      { data: null, error: { message: "connection reset" } },
+    ]);
+
+    await advanceEnrollmentAfterSend(client, {
+      id: "enr_1",
+      sequence_id: "seq_1",
+      current_step: 2,
+    });
+
+    expect(
+      calls.filter((c) => c.table === "sequence_enrollments"),
+    ).toHaveLength(0);
+  });
+});
 
 describe("sendApprovedDraft claim semantics", () => {
   beforeEach(() => {

--- a/src/lib/jobs/executors/email-cleanup.ts
+++ b/src/lib/jobs/executors/email-cleanup.ts
@@ -1,4 +1,8 @@
 import { getAdminClient } from "@/lib/supabase/admin";
+import {
+  advanceEnrollmentForDraft,
+  draftIsCurrentStep,
+} from "@/lib/services/outreach-sender";
 
 /**
  * Draft cleanup (recurring job, daily).
@@ -31,37 +35,78 @@ export async function cleanupEmails(): Promise<{
   let recoveredSent = 0;
   let recoveredDraft = 0;
 
-  const { data: stuck } = await supabase
+  const { data: stuck, error: stuckError } = await supabase
     .from("email_drafts")
-    .select("id")
+    .select("id, enrollment_id, campaign_people_id, sequence_step_id")
     .eq("status", "queued")
     .lt("updated_at", dayAgo);
+  if (stuckError) throw new Error(`stuck-draft scan: ${stuckError.message}`);
 
   if (stuck && stuck.length > 0) {
     const ids = stuck.map((d) => d.id);
-    const { data: sentRows } = await supabase
+    const { data: sentRows, error: sentError } = await supabase
       .from("sent_emails")
       .select("draft_id")
       .in("draft_id", ids);
+    // Fail loudly. A failed lookup used to read as "no sent_emails rows",
+    // classifying EVERY stuck draft as never-sent and resetting it to
+    // "draft": the next cron then re-sent emails that had already been
+    // delivered to real prospects.
+    if (sentError) throw new Error(`sent_emails lookup: ${sentError.message}`);
     const sentIds = new Set((sentRows ?? []).map((r) => r.draft_id));
 
-    const wasSent = ids.filter((id) => sentIds.has(id));
-    const neverSent = ids.filter((id) => !sentIds.has(id));
+    const wasSent = stuck.filter((d) => sentIds.has(d.id));
+    const neverSent = stuck.filter((d) => !sentIds.has(d.id));
     const now = new Date().toISOString();
 
     if (wasSent.length > 0) {
       await supabase
         .from("email_drafts")
         .update({ status: "sent", updated_at: now })
-        .in("id", wasSent)
+        .in(
+          "id",
+          wasSent.map((d) => d.id),
+        )
         .eq("status", "queued");
       recoveredSent = wasSent.length;
+
+      // Finishing the bookkeeping means finishing ALL of it. Marking the
+      // draft sent while leaving the enrollment pinned to that step made
+      // every 15-minute followups run fail "No approved draft ready for
+      // this step" forever, and the contact's status never left "queued".
+      for (const d of wasSent) {
+        // Only advance an enrollment still waiting on THIS draft's step:
+        // if it moved on already, the send's own bookkeeping won the race.
+        const stepCheck = await draftIsCurrentStep(supabase, d);
+        if (stepCheck.current) {
+          await advanceEnrollmentForDraft(
+            supabase,
+            d.enrollment_id as string | null,
+          );
+        }
+        if (d.campaign_people_id) {
+          await supabase
+            .from("campaign_people")
+            .update({ outreach_status: "sent" })
+            .eq("id", d.campaign_people_id)
+            // Same monotonic rule as the sender: a reply or bounce recorded
+            // since the crash must survive this late bookkeeping.
+            .not(
+              "outreach_status",
+              "in",
+              '("replied","bounced","complained","unsubscribed")',
+            );
+        }
+      }
     }
     if (neverSent.length > 0) {
       await supabase
         .from("email_drafts")
         .update({ status: "draft", updated_at: now })
-        .in("id", neverSent)
+        .in(
+          "id",
+          neverSent.map((d) => d.id),
+        )
         .eq("status", "queued");
       recoveredDraft = neverSent.length;
     }

--- a/src/lib/services/outreach-sender.ts
+++ b/src/lib/services/outreach-sender.ts
@@ -682,12 +682,23 @@ export async function advanceEnrollmentAfterSend(
   const now = new Date().toISOString();
   const nextStep = enrollment.current_step + 1;
 
-  const { data: nextStepRow } = await supabase
+  const { data: nextStepRow, error: nextStepError } = await supabase
     .from("sequence_steps")
     .select("delay_days, delay_hours")
     .eq("sequence_id", enrollment.sequence_id)
     .eq("step_number", nextStep)
-    .single();
+    .maybeSingle();
+
+  // "The query failed" is not "there is no next step". Completing the
+  // enrollment on a transient error silently ended the sequence; leaving it
+  // untouched lets the next cron run retry the advance.
+  if (nextStepError) {
+    console.error(
+      "[outreach-sender] next-step lookup failed; enrollment left for retry:",
+      nextStepError,
+    );
+    return;
+  }
 
   if (!nextStepRow) {
     await supabase


### PR DESCRIPTION
PR-2 of the hardening plan: the last Wave-0 item (built on main after #78 merged, since both touch outreach-sender.ts).

## What was broken

- **Duplicate sends (deliverability):** in the stranded-`queued` recovery, a failed `sent_emails` lookup read as "no sent rows", so every stuck draft was classified never-sent and reset to `draft`: the next cron **re-sent emails that had already been delivered** to real prospects.
- **K5, stranded enrollments:** recovery marked the draft `sent` but never advanced the enrollment or `campaign_people.outreach_status`, so the enrollment stayed pinned to a step whose draft no longer exists as `draft`: every 15-minute followups run failed "No approved draft ready for this step" forever.
- **`advanceEnrollmentAfterSend` conflated "no next step" with "step query failed"** (`.single()` + null check), silently completing enrollments on transient errors.

## Fixes

1. The `sent_emails` lookup (and the stuck scan) throw on error, failing the job run instead of misclassifying.
2. Recovered delivered drafts get full bookkeeping: enrollment advanced via `advanceEnrollmentForDraft` (guarded by `draftIsCurrentStep` so an enrollment that already moved on is untouched) and `campaign_people` synced under the same monotonic never-downgrade-replied rule as the sender.
3. `advanceEnrollmentAfterSend` uses `.maybeSingle()` and leaves the enrollment for retry on lookup errors.

## After deploy

Wave 0 is complete. Data repairs 2 and 5 from the runbook become safe (5 is the urgent one: re-mark drafts wrongly reset to `draft` that already have `sent_emails` rows, before their next send window).

Tests: 887 passed (4 new); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)