### PR TITLE
fix(jobs): durable side-effects + same-batch singleton dedupe (carries a migration)

### DIFF
--- a/src/__tests__/job-execute.test.ts
+++ b/src/__tests__/job-execute.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { flushMock, completeJobMock, failJobMock, testExecutor } = vi.hoisted(
+  () => ({
+    flushMock: vi.fn().mockResolvedValue(undefined),
+    completeJobMock: vi.fn(),
+    failJobMock: vi.fn(),
+    testExecutor: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: async () => ({
+              data: {
+                id: "job_1",
+                type: "test.job",
+                status: "running",
+                payload: {},
+                attempts: 1,
+                max_attempts: 1,
+                recurring_interval_seconds: null,
+              },
+            }),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+vi.mock("@/lib/services/jobs", () => ({
+  completeJob: completeJobMock,
+  failJob: failJobMock,
+}));
+vi.mock("@/lib/jobs/executors", () => ({
+  executors: { "test.job": testExecutor },
+}));
+vi.mock("@/lib/posthog-server", () => ({
+  getPostHogClient: () => ({ flush: flushMock }),
+}));
+
+import { executeClaimedJob } from "@/lib/jobs/execute";
+
+beforeEach(() => {
+  flushMock.mockClear();
+  completeJobMock.mockClear();
+  failJobMock.mockClear();
+  testExecutor.mockReset();
+});
+
+// Serverless: anything not awaited before the function returns may be
+// dropped when Vercel freezes the instance. The flush is what guarantees
+// executor-captured events (sends, fires) actually leave the process.
+describe("executeClaimedJob posthog flush", () => {
+  it("flushes after a successful run", async () => {
+    testExecutor.mockResolvedValue(undefined);
+
+    await executeClaimedJob("job_1");
+
+    expect(completeJobMock).toHaveBeenCalledTimes(1);
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes even when the executor fails", async () => {
+    testExecutor.mockRejectedValue(new Error("boom"));
+
+    await executeClaimedJob("job_1");
+
+    expect(failJobMock).toHaveBeenCalledTimes(1);
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failing flush never fails the job run", async () => {
+    testExecutor.mockResolvedValue(undefined);
+    flushMock.mockRejectedValueOnce(new Error("network"));
+
+    await expect(executeClaimedJob("job_1")).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/jobs/execute.ts
+++ b/src/lib/jobs/execute.ts
@@ -1,6 +1,7 @@
 import { getAdminClient } from "@/lib/supabase/admin";
 import { completeJob, failJob, type JobRow } from "@/lib/services/jobs";
 import { executors } from "@/lib/jobs/executors";
+import { getPostHogClient } from "@/lib/posthog-server";
 
 /**
  * Runs one claimed job to completion. Only ever called by /api/jobs/run
@@ -34,5 +35,12 @@ export async function executeClaimedJob(jobId: string): Promise<void> {
   } catch (err) {
     console.error(`[jobs] ${row.type} (${row.id}) failed:`, err);
     await failJob(row, err);
+  } finally {
+    // Serverless: anything not awaited before the function returns may be
+    // dropped when Vercel freezes the instance, and executors capture
+    // events (sends, fires) that must not vanish.
+    await getPostHogClient()
+      .flush()
+      .catch((err) => console.error("[jobs] posthog flush failed:", err));
   }
 }

--- a/src/lib/jobs/executors/tracking-run.ts
+++ b/src/lib/jobs/executors/tracking-run.ts
@@ -315,8 +315,13 @@ export async function runTrackingConfig(trackingConfigId: string) {
         Boolean(typedConfig.auto_send) && verdict.confidence === "high";
 
       // Enqueue the outreach job; /api/jobs/* auth guards the outbox path.
-      // Fire-and-forget: don't block the tracking run on the dispatch.
-      void enqueueJob({
+      // AWAITED: this insert is the entire product promise of a threshold
+      // crossing. Fire-and-forget inside a serverless function let Vercel
+      // freeze the instance before the insert reached Supabase, so the
+      // company was stamped ready-to-contact and the outreach silently
+      // never happened. If the enqueue fails the run fails loudly and the
+      // job system retries.
+      await enqueueJob({
         type: "outreach.process",
         payload: {
           type: "signal",
@@ -331,8 +336,6 @@ export async function runTrackingConfig(trackingConfigId: string) {
         // Queue fairness: attribute the outreach job to the campaign owner
         // instead of the shared '<system>' partition.
         userId: typedConfig.campaign.user_id ?? null,
-      }).catch((err) => {
-        console.error("[tracking] Failed to enqueue outreach:", err);
       });
     }
 

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -1,10 +1,11 @@
 import { PostHog } from "posthog-node";
 
-type PostHogLike = Pick<PostHog, "capture" | "identify" | "shutdown">;
+type PostHogLike = Pick<PostHog, "capture" | "identify" | "flush" | "shutdown">;
 
 const noop: PostHogLike = {
   capture: () => {},
   identify: () => {},
+  flush: async () => {},
   shutdown: async () => {},
 };
 

--- a/src/lib/services/jobs.ts
+++ b/src/lib/services/jobs.ts
@@ -98,7 +98,20 @@ export async function completeJob(job: JobRow): Promise<void> {
         completed_at: new Date().toISOString(),
         locked_until: null,
       };
-  await getAdminClient().from("jobs").update(values).eq("id", job.id);
+  // Logged, not thrown: a throw here would route through the caller's
+  // failJob and re-arm a job that actually finished, guaranteeing a
+  // duplicate execution. A stuck 'running' row is reaped by the next
+  // claim_jobs lease sweep, so visibility is what matters.
+  const { error } = await getAdminClient()
+    .from("jobs")
+    .update(values)
+    .eq("id", job.id);
+  if (error) {
+    console.error(
+      `[jobs] completeJob write failed for ${job.type} (${job.id}); the lease sweep will reap it:`,
+      error,
+    );
+  }
 }
 
 export async function failJob(job: JobRow, err: unknown): Promise<void> {
@@ -126,5 +139,15 @@ export async function failJob(job: JobRow, err: unknown): Promise<void> {
       last_error: message,
     };
   }
-  await getAdminClient().from("jobs").update(values).eq("id", job.id);
+  // Same contract as completeJob: log, never throw, lease sweep recovers.
+  const { error } = await getAdminClient()
+    .from("jobs")
+    .update(values)
+    .eq("id", job.id);
+  if (error) {
+    console.error(
+      `[jobs] failJob write failed for ${job.type} (${job.id}); the lease sweep will reap it:`,
+      error,
+    );
+  }
 }

--- a/supabase/migrations/20260807000000_claim_jobs_singleton_batch.sql
+++ b/supabase/migrations/20260807000000_claim_jobs_singleton_batch.sql
@@ -1,0 +1,92 @@
+-- Same-batch singleton dedupe for claim_jobs.
+-- 2026-08-07
+--
+-- The singleton guard only excluded keys with a RUNNING row, so two PENDING
+-- jobs sharing a singleton_key could be claimed in the same batch and run
+-- concurrently: exactly what the key exists to prevent (mailbox:<user_id>
+-- serializes one inbox's sends; tracking-run:<config> serializes a config's
+-- runs). key_rank picks one pending job per key per batch; the loser stays
+-- pending and is claimable next tick once the winner finishes.
+--
+-- Signature unchanged, so either version of the app code tolerates either
+-- version of this function (deploy order is still code first, per repo rule).
+
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '60s';
+
+create or replace function claim_jobs(
+    batch_size int default 25,
+    lease_seconds int default 330,
+    per_user_cap int default 5
+) returns setof jobs
+language plpgsql
+as $$
+begin
+    -- Reap expired leases. Recurring jobs always re-arm; one-offs go dead
+    -- once attempts are exhausted (attempts was already incremented when
+    -- the job was claimed).
+    update jobs
+    set status = case
+            when recurring_interval_seconds is null and attempts >= max_attempts
+                then 'dead'
+            else 'pending'
+        end,
+        run_at = case
+            when recurring_interval_seconds is not null
+                then now() + make_interval(secs => recurring_interval_seconds)
+            else now()
+        end,
+        locked_until = null,
+        last_error = coalesce(last_error, 'lease expired (runner crashed or timed out)')
+    where status = 'running' and locked_until < now();
+
+    return query
+    with ranked as (
+        select j.id, j.priority, j.run_at,
+               row_number() over (
+                   partition by coalesce(j.user_id, '<system>')
+                   order by j.priority asc, j.run_at asc
+               ) as user_rank,
+               -- At most one pending job per singleton key per batch. The
+               -- running-row check below covers cross-batch serialization;
+               -- this covers two pending rows sharing a key in ONE batch.
+               -- Null keys partition by their own id, so key_rank is 1.
+               row_number() over (
+                   partition by coalesce(j.singleton_key, j.id::text)
+                   order by j.priority asc, j.run_at asc
+               ) as key_rank
+        from jobs j
+        where j.status = 'pending'
+          and j.run_at <= now()
+          and (j.singleton_key is null or not exists (
+              select 1 from jobs r
+              where r.status = 'running'
+                and r.singleton_key = j.singleton_key
+          ))
+    ),
+    picked as (
+        select id from ranked
+        where user_rank <= per_user_cap
+          and key_rank = 1
+        order by priority asc, run_at asc
+        limit batch_size
+    )
+    update jobs
+    set status = 'running',
+        attempts = attempts + 1,
+        locked_until = now() + make_interval(secs => lease_seconds)
+    where id in (
+        -- SKIP LOCKED here is what makes overlapping ticks (or a future
+        -- persistent worker running alongside the cron) safe: a second
+        -- claimer just skips rows the first one is mid-claim on.
+        select jobs.id from jobs
+        where jobs.id in (select picked.id from picked)
+        for update skip locked
+    )
+    returning *;
+end;
+$$;
+
+commit;


### PR DESCRIPTION
Wave 3, PR-7 of the hardening plan (K9 + the jobs-queue cluster). **This PR carries the plan's only new migration** — after merging and the Vercel deploy, run `supabase db push` (it will offer `20260807000000_claim_jobs_singleton_batch.sql`).

## What was broken

- **K9 (plausible-confirmed):** the `outreach.process` enqueue after a threshold crossing was `void`/fire-and-forget inside a serverless function. Vercel can freeze the instance the moment the handler returns, so the jobs insert could silently never land: company stamped ready-to-contact, timeline shows the crossing, and the promised end-to-end outreach just never happens, with no error anywhere.
- `completeJob`/`failJob` never read their update errors: a failed completion write left the job `running` until the lease sweep, invisibly.
- PostHog events captured inside job executors could be dropped on instance freeze (nothing flushed the client).
- `claim_jobs` only excluded singleton keys with a **running** row: two **pending** jobs sharing a key could be claimed in one batch and run concurrently — defeating exactly what `mailbox:<user>` (one inbox never sends twice concurrently) and `tracking-run:<config>` exist to serialize.

## Fixes

1. The enqueue is awaited; a failure fails the tracking run loudly and the job system retries.
2. `completeJob`/`failJob` log their write errors (never throw: a throw would re-arm a finished job and guarantee a duplicate execution; the lease sweep recovers either way).
3. `executeClaimedJob` flushes PostHog in a `finally`, and a failing flush never fails the run.
4. Migration: `claim_jobs` ranks pending jobs per singleton key and picks one per batch; the loser stays pending for the next tick. Signature unchanged, so either code version tolerates either RPC version.

## Merge order

Independent of the other Wave-3+ PRs (disjoint files); merge any time. **Then: `supabase db push`.**

Tests: 906 passed (3 new); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)