### PR TITLE
fix(voice): real-recipient swipe path finally works, prompts stop lying about it

### DIFF
--- a/src/__tests__/swipe-recipient-rotation.test.ts
+++ b/src/__tests__/swipe-recipient-rotation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadRecipientCandidates,
+  pickRecipient,
+  recipientLabel,
+  type RealRecipient,
+} from "@/lib/email-skills/swipe-recipient";
+import { buildSkillSystem } from "@/lib/email-skills/swipe-prompts";
+
+function candidate(name: string, enriched = true): RealRecipient {
+  return {
+    personId: name,
+    name,
+    title: "VP Marketing",
+    company: "Acme",
+    headline: null,
+    signals: [],
+    enriched,
+  };
+}
+
+describe("pickRecipient wrap-around", () => {
+  it("rotates on the second pass instead of pinning the first candidate", () => {
+    // Regression: once every label had been judged, `?? ordered[0]` returned
+    // the same first candidate for every subsequent batch forever.
+    const candidates = [candidate("Ana"), candidate("Ben"), candidate("Cyd")];
+    const labels = candidates.map(recipientLabel);
+
+    // Everyone judged once, Ana judged twice: Ben is least-drafted-to next.
+    const judged = [labels[0], labels[1], labels[2], labels[0]];
+    expect(pickRecipient(candidates, judged)?.name).toBe("Ben");
+
+    // Full second pass done: back to Ana, not stuck anywhere.
+    const twoFull = [...labels, ...labels];
+    expect(pickRecipient(candidates, twoFull)?.name).toBe("Ana");
+  });
+});
+
+describe("loadRecipientCandidates query", () => {
+  it("filters on outreach_status, never the dropped status column", async () => {
+    // Regression: .neq("status","rejected") referenced a column dropped by
+    // migration 20260420; the query errored on EVERY call, the error was
+    // swallowed, and the real-recipient path never activated once.
+    const filters: Array<[string, ...unknown[]]> = [];
+    const builder: Record<string, unknown> = {};
+    for (const name of ["select", "eq", "neq", "not", "limit"]) {
+      builder[name] = (...args: unknown[]) => {
+        filters.push([name, ...args]);
+        return builder;
+      };
+    }
+    builder.then = (resolve: (v: unknown) => unknown) =>
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    const supabase = { from: () => builder } as never;
+
+    await loadRecipientCandidates(supabase, "camp_1");
+
+    const columns = filters
+      .filter(([op]) => op === "eq" || op === "neq" || op === "not")
+      .map(([, col]) => col);
+    expect(columns).not.toContain("status");
+    expect(columns).toContain("outreach_status");
+  });
+
+  it("logs a failed load instead of silently returning []", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const builder: Record<string, unknown> = {};
+    for (const name of ["select", "eq", "neq", "not", "limit"]) {
+      builder[name] = () => builder;
+    }
+    builder.then = (resolve: (v: unknown) => unknown) =>
+      Promise.resolve({
+        data: null,
+        error: { message: "column does not exist" },
+      }).then(resolve);
+    const supabase = { from: () => builder } as never;
+
+    const out = await loadRecipientCandidates(supabase, "camp_1");
+
+    expect(out).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("buildSkillSystem recipients note", () => {
+  it("does not claim real contacts were fictional", () => {
+    const withReal = buildSkillSystem(null, {}, true);
+    expect(withReal).toContain("REAL campaign contacts");
+    expect(withReal).not.toContain(
+      "The recipients in the judged drafts were fictional personas",
+    );
+
+    const invented = buildSkillSystem(null, {}, false);
+    expect(invented).toContain("fictional personas invented for practice");
+  });
+});

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -85,7 +85,6 @@ function getSuggestions(pathname: string, campaignId: string | null): string[] {
   if (pathname === "/settings") {
     return [
       "Help me configure my email settings",
-      "Show me my API usage costs",
       "Connect my Gmail for outreach",
       "What's my current sending setup?",
     ];
@@ -214,6 +213,10 @@ function AgentPanelInner({
         if (autoContinuesRef.current < MAX_AUTO_CONTINUES) {
           autoContinuesRef.current += 1;
           setContinueTick((tick) => tick + 1);
+          // The continuation is about to stream: telling the deck the turn
+          // is done here flashed a retryable "came back without drafts"
+          // error while the drafts were still on their way.
+          return;
         }
       }
       // After the turn settles: if the deck was waiting on drafts that never

--- a/src/components/email-skills/voice-swipe.tsx
+++ b/src/components/email-skills/voice-swipe.tsx
@@ -204,9 +204,12 @@ export function VoiceSwipe({
             body: card.body,
             axes: card.axes,
             kept: liked,
-            // Which invented persona this judgement was against, so the next
-            // batch never reuses it and no persona detail reads as a rule.
+            // Which persona this judgement was against, so the next batch
+            // never reuses it and no persona detail reads as a rule.
             personaLabel: card.personaLabel ?? undefined,
+            // Real-contact judgements must stay distinguishable: the skill
+            // prompt asserts personas were fictional unless told otherwise.
+            personaReal: card.personaReal ?? undefined,
           },
         ],
         queue: r.queue.filter((d) => d.id !== card.id),

--- a/src/lib/email-skills/swipe-prompts.ts
+++ b/src/lib/email-skills/swipe-prompts.ts
@@ -115,9 +115,12 @@ export interface JudgedDraft {
   body: string;
   axes: DraftAxes;
   kept: boolean;
-  /** The fictional persona this draft addressed, as the deck labelled it.
+  /** The persona this draft addressed, as the deck labelled it.
    * Optional: runs recorded before personas existed have none. */
   personaLabel?: string;
+  /** True when the recipient was a REAL campaign contact, not an invented
+   * persona. Optional: older runs never recorded it. */
+  personaReal?: boolean;
   /** Phrases the user highlighted on this draft, with what they said. */
   notes?: { phrase: string; note: string }[];
 }
@@ -201,7 +204,9 @@ function renderTranscript(t: SwipeTranscript): string {
     for (const d of judged) {
       // Which persona each judgement was against, so the model can avoid
       // reusing personas and never mistakes a persona detail for a voice rule.
-      const to = d.personaLabel ? ` (to ${d.personaLabel})` : "";
+      const to = d.personaLabel
+        ? ` (to ${d.personaLabel}${d.personaReal ? ", a REAL campaign contact" : ""})`
+        : "";
       lines.push(
         `- [${d.kept ? "KEPT" : "PASSED"}]${to} ${JSON.stringify(d.axes)} subject: ${d.subject}`,
       );
@@ -416,7 +421,7 @@ A highlighted phrase with a note is the strongest signal available: they pointed
 ## Writing the emails themselves
 
 - 30-90 words. These are cold emails; the user is judging voice, not admiring length.
-- Reference the campaign's real offering and audience, and ground each draft in the invented persona's situation and signals.
+- Reference the campaign's real offering and audience, and ground each draft in the recipient's situation and signals AS GIVEN in the recipient block. When the recipient is REAL, the no-fabrication rule in their block outranks every variation and grounding instruction here: a detail not listed for them does not exist.
 - Plain text with real line breaks. No HTML, no markdown, no placeholders like [Name]. Write it as it would send.
 - No emojis.
 
@@ -456,7 +461,7 @@ You have four kinds, and they are not equally reliable:
 3. **What they kept**: strong on aggregate, weak individually. Four kept drafts that all open on the signal is a rule. One kept draft that happens to be 40 words is not.
 4. **What they passed**: the weakest. A pass means something in it was wrong, not that everything in it was. Only write a "never" rule when the same trait was rejected repeatedly AND never appears in anything they kept.
 
-The recipients in the judged drafts were fictional personas invented for practice. Write rules about the user's voice only; never a rule about any persona, their company, or their situation.
+__RECIPIENTS_NOTE__
 
 That ranking is about evidence, not about intent. What they pasted is the truest picture of how they write today; what they typed is the truest picture of what they want changed. So where a typed instruction contradicts everything else, follow the instruction: they are correcting themselves, not describing themselves. Someone who keeps three warm drafts and then types "stop being so friendly" has told you the drafts were the best of a bad set.
 
@@ -477,8 +482,15 @@ If a block of rules they are already writing with appears, this is a change and 
 export function buildSkillSystem(
   campaign: SwipeCampaign | null,
   context: SwipeSenderContext = {},
+  hadRealRecipients = false,
 ): string {
-  return `${SKILL_SYSTEM}\n\n---\n${UNTRUSTED_NOTICE}\n\n${renderSender(
+  // The old static sentence flatly asserted every judged recipient was
+  // fictional, which was untrue for runs addressed to real campaign
+  // contacts and licensed the model to treat real details as inventions.
+  const recipientsNote = hadRealRecipients
+    ? "Some or all recipients in the judged drafts were REAL campaign contacts (marked in the transcript); the rest were fictional practice personas. Either way, write rules about the user's voice only; never a rule about any recipient, their company, or their situation."
+    : "The recipients in the judged drafts were fictional personas invented for practice. Write rules about the user's voice only; never a rule about any persona, their company, or their situation.";
+  return `${SKILL_SYSTEM.replace("__RECIPIENTS_NOTE__", recipientsNote)}\n\n---\n${UNTRUSTED_NOTICE}\n\n${renderSender(
     context.sender,
   )}\n\n${campaignBlock(campaign)}`;
 }

--- a/src/lib/email-skills/swipe-recipient.ts
+++ b/src/lib/email-skills/swipe-recipient.ts
@@ -38,11 +38,27 @@ export function pickRecipient(
   judgedLabels: string[],
 ): RealRecipient | null {
   if (candidates.length === 0) return null;
-  const seen = new Set(judgedLabels);
   const ordered = [...candidates].sort(
     (a, b) => Number(b.enriched) - Number(a.enriched),
   );
-  return ordered.find((c) => !seen.has(recipientLabel(c))) ?? ordered[0]!;
+  // Occurrence counts, not a seen-set: with a set, once every label had
+  // appeared the fallback pinned the SAME first candidate for every later
+  // batch instead of wrapping around. Fewest-drafted-to wins each time.
+  const counts = new Map<string, number>();
+  for (const label of judgedLabels) {
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  let best = ordered[0]!;
+  let bestCount = Number.POSITIVE_INFINITY;
+  for (const c of ordered) {
+    const n = counts.get(recipientLabel(c)) ?? 0;
+    if (n < bestCount) {
+      best = c;
+      bestCount = n;
+      if (n === 0) break;
+    }
+  }
+  return best;
 }
 
 interface SignalSource {
@@ -119,9 +135,20 @@ export async function loadRecipientCandidates(
         "person:people(id, name, title, enrichment_status, enrichment_data, organization:organizations!organization_id(name))",
       )
       .eq("campaign_id", campaignId)
-      .neq("status", "rejected")
+      // campaign_people.status was dropped in the 20260420 migration; the
+      // old .neq("status","rejected") filter errored on every call and the
+      // swallowed error meant this path NEVER activated: every "real
+      // recipient" batch was silently an invented persona. Opt-outs are
+      // the surviving exclusion that matches the intent.
+      .not("outreach_status", "in", '("unsubscribed","complained","bounced")')
       .limit(200);
-    if (error || !data) return [];
+    if (error) {
+      // Still fall back to invented personas, but never silently: the
+      // silent [] is exactly how the dropped-column bug hid for weeks.
+      console.error("[swipe] recipient candidates load failed:", error);
+      return [];
+    }
+    if (!data) return [];
     return data
       .map((row) =>
         candidateFromRow(row as Parameters<typeof candidateFromRow>[0]),

--- a/src/lib/email-skills/swipe-service.ts
+++ b/src/lib/email-skills/swipe-service.ts
@@ -249,6 +249,16 @@ export async function generateVoiceBatch(
   }
   // Real recipient: the server stamps the label so the model cannot misname
   // anyone. Invented: the label comes from the returned persona as before.
+  // The schema keeps persona optional for the real-recipient path, so the
+  // invented path has to enforce it here: a batch without its persona
+  // renders unlabeled cards whose judgements can't be rotated against.
+  if (!recipient && !result.value.persona) {
+    return {
+      ok: false,
+      error:
+        "The model returned drafts without the invented persona; try another batch.",
+    };
+  }
   const label = recipient
     ? recipientLabel(recipient)
     : result.value.persona
@@ -285,7 +295,11 @@ async function writeSkill(
         abortSignal: llmTimeout(),
         model: anthropic(MODELS.EMAIL),
         schema: apiSafeSchema(SkillSchema),
-        system: buildSkillSystem(campaign, senderContext),
+        system: buildSkillSystem(
+          campaign,
+          senderContext,
+          input.transcript.judged.some((d) => d.personaReal === true),
+        ),
         prompt: buildSkillPrompt(input.transcript),
         providerOptions: { anthropic: { effort: "medium" } },
         maxRetries: 0,
@@ -364,11 +378,20 @@ export async function refineVoiceProfile(
   // RLS scopes the table to the signed-in user, so scope is the only filter
   // needed. `.is` rather than `.eq`, because the default voice's campaign_id
   // is NULL and `eq(null)` matches nothing.
-  const { data } = await (
+  const { data, error: savedError } = await (
     input.campaignId
       ? saved.eq("campaign_id", input.campaignId)
       : saved.is("campaign_id", null)
   ).maybeSingle();
+
+  // A failed read is not "no saved voice": that false claim sent the agent
+  // off to rebuild a voice the user already has.
+  if (savedError) {
+    return {
+      ok: false,
+      error: `Could not load the saved voice: ${savedError.message}. Try again.`,
+    };
+  }
 
   const existing = data as SavedVoice | null;
   if (!existing?.instructions?.trim()) {

--- a/src/lib/tools/voice-tools.ts
+++ b/src/lib/tools/voice-tools.ts
@@ -59,6 +59,10 @@ function emitDrafts(
     mode: "opening" | "append" | "replace";
     drafts: unknown[];
     persona: { label: string; real?: boolean } | null;
+    /** The run scope these drafts were generated for. The client refuses
+     * parts whose scope doesn't match the active run, so an in-flight batch
+     * can't append to a different scope's deck. */
+    campaignId?: string | null;
   },
 ) {
   writer?.write({ type: "data-voice-drafts", data, transient: true });
@@ -106,6 +110,7 @@ export const startVoiceRun = tool({
       mode: "opening",
       drafts: result.drafts,
       persona: result.persona,
+      campaignId: ctx.voiceRun.campaignId ?? null,
     });
     return {
       ok: true,
@@ -194,6 +199,7 @@ export const rewriteVoiceDrafts = tool({
       mode: instruction ? "replace" : "append",
       drafts: result.drafts,
       persona: result.persona,
+      campaignId: ctx.voiceRun.campaignId ?? null,
     });
     return {
       ok: true,

--- a/src/lib/voice-run-context.tsx
+++ b/src/lib/voice-run-context.tsx
@@ -88,6 +88,7 @@ const VoiceRunContext = createContext<VoiceRunContextValue>({
 });
 
 interface DraftsPart {
+  campaignId?: string | null;
   mode: "opening" | "append" | "replace";
   drafts: Omit<RunDraft, "id" | "personaLabel">[];
   /** Who the batch is written to: a real campaign contact, or an invented
@@ -248,6 +249,15 @@ export function VoiceRunProvider({ children }: { children: ReactNode }) {
       if (part.type === "data-voice-drafts") {
         const data = part.data as DraftsPart | undefined;
         if (!current || !data?.drafts?.length) return;
+        // Same scope check as data-voice-skill: an in-flight batch generated
+        // for one scope must not append to whichever run is active when it
+        // lands. Parts without a campaignId (older emitters) pass through.
+        if (
+          data.campaignId !== undefined &&
+          (current.campaignId ?? null) !== (data.campaignId ?? null)
+        ) {
+          return;
+        }
         // Stamped per draft, not per run: the persona rotates every batch,
         // and a queue holding two batches must label each card with the
         // persona its drafts were actually written to.


### PR DESCRIPTION
Wave 4, PR-10 of the hardening plan (K6, K12 + the voice-swipe cluster: 10 findings). Branched off main, independent of the other open PRs: merge any time.

## The headline

**The real-recipient swipe feature (PR #72) has never actually run in production.** `loadRecipientCandidates` filters on `campaign_people.status`, a column dropped by the 20260420 migration, so the query errored on every call; the error was swallowed into `[]`; and `generateVoiceBatch` silently fell back to inventing personas. Every batch the deck ever labeled "in this campaign" was written to a fictional person.

## Why this is one PR, not two

Fixing the query alone would have *activated* a path whose prompts still invite fabrication about real people (K6): the batch writing-rules told the model to "ground each draft in the invented persona's situation and signals" unconditionally, and the skill prompt flatly asserted "the recipients in the judged drafts were fictional personas". The map flagged this coupling explicitly, so the query fix and the prompt-truthfulness fixes land together:

- Batch rules ground drafts in "the recipient's situation AS GIVEN"; for real recipients the no-fabrication rule in their block explicitly outranks variation/grounding.
- `personaReal` now survives the whole loop (queue → judgement → transcript → skill prompt): real-contact judgements are marked in the transcript, and the skill prompt only claims recipients were fictional when they actually were.
- K12: the invented path enforces the persona the schema leaves optional (it's optional for the real-recipient path).

## Also in the cluster

`pickRecipient` truly wraps around instead of pinning the first candidate forever; draft stream parts are scope-checked so an in-flight batch can't append to a different run's deck; `refineVoiceProfile` distinguishes query failure from "no saved voice"; the agent panel stops flashing a retryable deck error mid-auto-continue and drops a suggestion no chat tool can answer.

Tests: 907 passed (4 new: rotation, dropped-column regression, skill-note truthfulness); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)