### PR TITLE
fix(cost): opus pricing tier, compose caching that works, attributed spend

### DIFF
--- a/src/__tests__/opus-pricing.test.ts
+++ b/src/__tests__/opus-pricing.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  estimateClaudeCost,
+  estimateClaudeCostFromUsage,
+} from "@/lib/services/cost-tracker";
+
+describe("opus pricing tier", () => {
+  it("prices claude-opus-5 usage at $5/$25 per MTok", () => {
+    // K18: the email composer runs on Opus and its spend was never
+    // trackable because the tier did not exist in PRICING.
+    const cost = estimateClaudeCost({
+      model: "opus",
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+    });
+    // 0.1 MTok * $5 + 0.01 MTok * $25
+    expect(cost).toBeCloseTo(0.75, 6);
+  });
+
+  it("prices cache reads and writes at the opus multipliers", () => {
+    const cost = estimateClaudeCostFromUsage("opus", {
+      inputTokens: 100_000,
+      outputTokens: 0,
+      inputTokenDetails: { cacheReadTokens: 80_000, cacheWriteTokens: 20_000 },
+    });
+    // 0 uncached + 0.08 MTok * $0.50 + 0.02 MTok * $6.25
+    expect(cost).toBeCloseTo(0.04 + 0.125, 6);
+  });
+});

--- a/src/app/api/companies/[id]/classify-departments/route.ts
+++ b/src/app/api/companies/[id]/classify-departments/route.ts
@@ -83,6 +83,9 @@ export async function POST(
     classifications = await withAction(
       `Classify departments: ${org.name}`,
       () => classifyPeople(org.name, inputs),
+      // Attribution, matching find-contacts/enrich-company: without it the
+      // classification spend lands with user_id NULL.
+      user.id,
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -93,6 +96,7 @@ export async function POST(
     );
   }
 
+  let failedWrites = 0;
   for (const c of classifications) {
     const { error: updErr } = await supabase
       .from("people")
@@ -103,6 +107,7 @@ export async function POST(
       })
       .eq("id", c.id);
     if (updErr) {
+      failedWrites++;
       console.error(
         `[classify-departments] update failed for ${c.id}:`,
         updErr,
@@ -110,5 +115,10 @@ export async function POST(
     }
   }
 
-  return Response.json({ classified: classifications.length });
+  // Failed writes are not classifications: reporting them as successes hid
+  // rows the user believed were classified.
+  return Response.json({
+    classified: classifications.length - failedWrites,
+    failed: failedWrites,
+  });
 }

--- a/src/app/api/enrich/bulk/route.ts
+++ b/src/app/api/enrich/bulk/route.ts
@@ -115,7 +115,12 @@ export async function POST(req: Request) {
         if (index >= targets.length) return;
         const target = targets[index];
         try {
-          const result = await enrichPerson(supabase, target.id, target.person);
+          const result = await enrichPerson(
+            supabase,
+            target.id,
+            target.person,
+            user.id,
+          );
           if (result.status === "enriched") enriched.push(target.id);
           else
             failed.push({

--- a/src/app/api/enrich/route.ts
+++ b/src/app/api/enrich/route.ts
@@ -144,7 +144,7 @@ export async function POST(request: Request) {
     });
   }
 
-  const result = await enrichPerson(supabase, personId, person);
+  const result = await enrichPerson(supabase, personId, person, user.id);
 
   return Response.json({
     contactId: personId,

--- a/src/app/api/outreach/regenerate/route.ts
+++ b/src/app/api/outreach/regenerate/route.ts
@@ -177,7 +177,7 @@ export async function POST(request: Request) {
       email:
         (person.work_email as string) ??
         (person.personal_email as string) ??
-        "unknown@example.com",
+        "", // no address on file: never render a fabricated one into the prompt
       enrichmentData:
         (person.enrichment_data as Record<string, unknown>) ?? null,
     },

--- a/src/app/api/profile/research-facts/route.ts
+++ b/src/app/api/profile/research-facts/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Profile not found" }, { status: 404 });
   }
 
-  const result = await researchSender(profile as UserProfile);
+  const result = await researchSender(profile as UserProfile, user.id);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }

--- a/src/app/api/settings/costs/route.ts
+++ b/src/app/api/settings/costs/route.ts
@@ -74,6 +74,21 @@ export async function GET(request: Request) {
     fetchRealSpend(realSpendStart, nowIso),
   ]);
 
+  // A failed query must never render as $0 spend with empty tables: that
+  // is indistinguishable from a genuinely idle account.
+  const firstError =
+    totalRes.error ??
+    byServiceRes.error ??
+    byOperationRes.error ??
+    dailyRes.error ??
+    recentRes.error;
+  if (firstError) {
+    return Response.json(
+      { error: `Could not load usage data: ${firstError.message}` },
+      { status: 500 },
+    );
+  }
+
   // Aggregate total
   const totalCost = (totalRes.data ?? []).reduce(
     (sum: number, r: { estimated_cost_usd: number }) =>

--- a/src/lib/email-composition/compose.ts
+++ b/src/lib/email-composition/compose.ts
@@ -10,6 +10,10 @@ import {
 import { apiSafeSchema } from "@/lib/ai/api-safe-schema";
 import { MODELS } from "@/lib/ai/models";
 import { generateWithRetry } from "@/lib/ai/salvage-object";
+import {
+  estimateClaudeCostFromUsage,
+  trackUsage,
+} from "@/lib/services/cost-tracker";
 import type { VoiceProfile } from "@/lib/types/email-voice";
 
 type UserPromptInput = Parameters<typeof buildComposeUserPrompt>[0];
@@ -51,20 +55,32 @@ export async function composeEmail(
   // for free; the retries cover the rest. Measured live — without both, a fifth
   // or more of every fan-out silently loses its draft.
   const attempt = await generateWithRetry(async () => {
-    const { object } = await generateObject({
+    const { object, usage } = await generateObject({
       abortSignal: llmTimeout(),
       model: anthropic(MODELS.EMAIL),
       schema: apiSafeSchema(ComposedEmailSchema),
-      system: buildEmailSystemPrompt(
-        voice ?? null,
-        factBank ?? null,
-        learnings ?? null,
-      ),
-      prompt: buildComposeUserPrompt(userPromptInput),
+      // The cache breakpoint rides ON the system message, not in call-level
+      // providerOptions: the call-level form maps to top-level auto-cache,
+      // which places the breakpoint on the LAST cacheable block — the
+      // per-contact user prompt that varies on every fan-out call. Keyed to
+      // varying content, the stable Opus system prompt never actually
+      // served from cache; every call paid the full write price.
+      messages: [
+        {
+          role: "system",
+          content: buildEmailSystemPrompt(
+            voice ?? null,
+            factBank ?? null,
+            learnings ?? null,
+          ),
+          providerOptions: {
+            anthropic: { cacheControl: { type: "ephemeral" } },
+          },
+        },
+        { role: "user", content: buildComposeUserPrompt(userPromptInput) },
+      ],
       providerOptions: {
         anthropic: {
-          // Cache the stable system prompt across the fan-out batch.
-          cacheControl: { type: "ephemeral" },
           // Opus 5 thinks by default (Opus 4.6 did not), and maxOutputTokens
           // caps thinking + visible output together — so the old 1200 budget
           // would have been eaten by reasoning and truncated the email,
@@ -81,6 +97,16 @@ export async function composeEmail(
       // would stack to 12 upstream requests per email under a 429 storm.
       maxRetries: 0,
       maxOutputTokens: 4000,
+    });
+    // K18: every composed email is an Opus call and none of it was ever
+    // cost-tracked. Attribution inherits the nearest withAction context.
+    trackUsage({
+      service: "claude",
+      operation: "compose-email",
+      tokens_input: usage.inputTokens ?? 0,
+      tokens_output: usage.outputTokens ?? 0,
+      estimated_cost_usd: estimateClaudeCostFromUsage("opus", usage),
+      metadata: { model: MODELS.EMAIL },
     });
     return object;
   }, ComposedEmailSchema);

--- a/src/lib/email-learnings.ts
+++ b/src/lib/email-learnings.ts
@@ -84,9 +84,13 @@ export async function loadActiveLearnings(
   const rows = (data ?? []) as Array<
     EmailLearning & { campaign_id: string | null }
   >;
+  // Timing learnings never render into the compose prompt
+  // (renderLearningsBlock drops them), so letting them occupy prompt-cap
+  // slots crowded real copy/targeting learnings out entirely.
+  const promptRows = rows.filter((r) => r.category !== "timing");
   // Campaign-scoped learnings outrank user-wide ones for the prompt cap.
   return [
-    ...rows.filter((r) => r.campaign_id !== null),
-    ...rows.filter((r) => r.campaign_id === null),
+    ...promptRows.filter((r) => r.campaign_id !== null),
+    ...promptRows.filter((r) => r.campaign_id === null),
   ].slice(0, MAX_LEARNINGS_IN_PROMPT);
 }

--- a/src/lib/jobs/execute.ts
+++ b/src/lib/jobs/execute.ts
@@ -2,6 +2,7 @@ import { getAdminClient } from "@/lib/supabase/admin";
 import { completeJob, failJob, type JobRow } from "@/lib/services/jobs";
 import { executors } from "@/lib/jobs/executors";
 import { getPostHogClient } from "@/lib/posthog-server";
+import { flushUsageTracking } from "@/lib/services/cost-tracker";
 
 /**
  * Runs one claimed job to completion. Only ever called by /api/jobs/run
@@ -38,7 +39,8 @@ export async function executeClaimedJob(jobId: string): Promise<void> {
   } finally {
     // Serverless: anything not awaited before the function returns may be
     // dropped when Vercel freezes the instance, and executors capture
-    // events (sends, fires) that must not vanish.
+    // events (sends, fires) and spend rows that must not vanish.
+    await flushUsageTracking();
     await getPostHogClient()
       .flush()
       .catch((err) => console.error("[jobs] posthog flush failed:", err));

--- a/src/lib/jobs/executors/outreach-process.ts
+++ b/src/lib/jobs/executors/outreach-process.ts
@@ -417,7 +417,13 @@ async function pickAndDraft(
         contact: {
           name: (person.name as string) ?? null,
           title: (person.title as string) ?? null,
-          email: (person.work_email as string) ?? "unknown@example.com", // placeholder; saveDraft re-reads from DB
+          // The prompt renders this line verbatim; a fabricated placeholder
+          // address was a lie of the class that produced the breakup-email
+          // bug. saveDraft re-reads the address from the DB for sending.
+          email:
+            (person.work_email as string) ??
+            (person.personal_email as string) ??
+            "",
           enrichmentData:
             (person.enrichment_data as Record<string, unknown>) ?? null,
         },

--- a/src/lib/jobs/executors/tracking-run.ts
+++ b/src/lib/jobs/executors/tracking-run.ts
@@ -55,322 +55,336 @@ export async function runTrackingConfig(trackingConfigId: string) {
   const orgDomain = typedConfig.organization?.domain as string | undefined;
 
   // Wrap in withAction for cost tracking
-  return withAction(`Tracking run: ${orgName}`, async () => {
-    // ── Execute signal via universal executor ────────────────────────
-    const signalRecord = typedConfig.signal as unknown as Signal;
-    let signalOutput: SignalOutput;
-    let rawOutput: Record<string, unknown>;
+  return withAction(
+    `Tracking run: ${orgName}`,
+    async () => {
+      // ── Execute signal via universal executor ────────────────────────
+      const signalRecord = typedConfig.signal as unknown as Signal;
+      let signalOutput: SignalOutput;
+      let rawOutput: Record<string, unknown>;
 
-    try {
-      signalOutput = await executeSignal(signalRecord, {
-        organizationId: config.organization_id,
-        domain: orgDomain,
-        name: orgName,
-        campaignId: config.campaign_id,
-        // Person-level configs (e.g. social-engagement) need the contact.
-        personId: config.person_id ?? undefined,
-        useAdmin: true,
-      });
-
-      rawOutput = signalOutput.data;
-
-      // If the signal executor didn't find anything meaningful, still store the result
-      if (!signalOutput.found && !rawOutput) {
-        rawOutput = { found: false, summary: signalOutput.summary };
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Unknown error";
-      throw new Error(`Signal execution failed: ${msg}`);
-    }
-
-    // ── Normalize into snapshot ────────────────────────────────────────
-    // Hiring-shaped output (the hiring-activity scraper) keeps its rich
-    // title-level diffing; everything else gets a stable generic snapshot.
-    // Detection is on output shape, not slug, so any future signal that
-    // emits { jobs: [...] } inherits the hiring pipeline.
-    const isHiring = Array.isArray(rawOutput.jobs);
-    const jobs = isHiring
-      ? (rawOutput.jobs as Array<{
-          title: string;
-          department?: string;
-          location?: string;
-          url?: string;
-        }>)
-      : [];
-    const careersUrl = (rawOutput.careersUrl as string) || null;
-    const snapshot = isHiring
-      ? normalizeHiringData(jobs, careersUrl)
-      : buildGenericSnapshot(signalRecord.execution_type, rawOutput);
-    const hash = hashSnapshot(snapshot);
-
-    // ── Compare to previous snapshot ───────────────────────────────────
-    const { data: prevSnapshots, error: prevError } = await getAdminClient()
-      .from("tracking_snapshots")
-      .select("snapshot_data, snapshot_hash")
-      .eq("tracking_config_id", trackingConfigId)
-      .order("captured_at", { ascending: false })
-      .limit(1);
-    // A failed read is not "no previous snapshot": treating it as one
-    // inserted the CURRENT snapshot as a fresh baseline and permanently
-    // swallowed whatever change actually happened. Fail the run; the job
-    // system retries.
-    if (prevError) {
-      throw new Error(`previous-snapshot read failed: ${prevError.message}`);
-    }
-
-    const prevSnapshot = prevSnapshots?.[0] ?? null;
-    const hasChanged = !prevSnapshot || prevSnapshot.snapshot_hash !== hash;
-
-    // ── Store new snapshot (always, for the timeline) ──────────────────
-    // Checked: a silently failed insert left the stale snapshot as the
-    // diff baseline, so the same change re-fired every run (duplicate
-    // timeline rows, repeat LLM spend, repeat outreach enqueues). Failing
-    // here, BEFORE any change is recorded, makes the retry clean.
-    const { error: snapshotError } = await getAdminClient()
-      .from("tracking_snapshots")
-      .insert({
-        tracking_config_id: trackingConfigId,
-        snapshot_data: snapshot,
-        snapshot_hash: hash,
-      });
-    if (snapshotError) {
-      throw new Error(`snapshot insert failed: ${snapshotError.message}`);
-    }
-
-    // ── Store signal_result with tracking_config_id ────────────────────
-    const { error: resultError } = await getAdminClient()
-      .from("signal_results")
-      .insert({
-        signal_id: config.signal_id,
-        campaign_id: config.campaign_id,
-        organization_id: config.organization_id,
-        person_id: config.person_id,
-        tracking_config_id: trackingConfigId,
-        output: rawOutput,
-        status: "success",
-      });
-    // The next run's baseline (and the recipe history step) read this row;
-    // a silent miss re-baselines the signal.
-    if (resultError) {
-      throw new Error(`signal_result insert failed: ${resultError.message}`);
-    }
-
-    // ── Update last_run_at ─────────────────────────────────────────────
-    await getAdminClient()
-      .from("tracking_configs")
-      .update({ last_run_at: new Date().toISOString() })
-      .eq("id", trackingConfigId);
-
-    if (!hasChanged) {
-      return {
-        trackingConfigId,
-        changed: false,
-        jobCount: isHiring ? (snapshot as HiringSnapshot).job_count : undefined,
-      };
-    }
-
-    // ── Compute diff ───────────────────────────────────────────────────
-    const prevData = prevSnapshot ? prevSnapshot.snapshot_data : null;
-
-    // If no previous data (first run after baseline), store as baseline
-    if (!prevData) {
-      return {
-        trackingConfigId,
-        changed: false,
-        baseline: true,
-        jobCount: isHiring ? (snapshot as HiringSnapshot).job_count : undefined,
-      };
-    }
-
-    let changeDescription: string;
-    let rawDiffForIntent: unknown;
-    let diffSummary: Record<string, unknown>;
-
-    if (isHiring) {
-      const prevHiring = prevData as HiringSnapshot;
-      const currHiring = snapshot as HiringSnapshot;
-      const diff = diffHiringSnapshots(prevHiring, currHiring);
-
-      // ── Classify new roles via Haiku ─────────────────────────────────
-      if (diff.added_jobs.length > 0) {
-        const icp = typedConfig.campaign.icp || {};
-        const offering = typedConfig.campaign.offering || {};
-        const icpContext = [
-          icp.industry && `Industry: ${icp.industry}`,
-          icp.targetTitles &&
-            `Target titles: ${(icp.targetTitles as string[]).join(", ")}`,
-          icp.painPoints &&
-            `Pain points: ${(icp.painPoints as string[]).join(", ")}`,
-          offering.description && `Offering: ${offering.description}`,
-        ]
-          .filter(Boolean)
-          .join(". ");
-
-        const classified = await classifyNewRoles(diff.added_jobs, icpContext);
-        diff.classified_added = classified;
-      }
-
-      // ── Store tracking changes ───────────────────────────────────────
-      changeDescription = describeHiringChanges(diff);
-
-      const changesToInsert: Array<Record<string, unknown>> = [];
-
-      if (diff.added_jobs.length > 0) {
-        changesToInsert.push({
-          tracking_config_id: trackingConfigId,
-          change_type: "added",
-          field_path: "jobs",
-          previous_value: null,
-          current_value: diff.added_jobs,
-          description: `+${diff.added_jobs.length} role${diff.added_jobs.length > 1 ? "s" : ""}: ${diff.added_jobs.map((j) => j.title).join(", ")}`,
+      try {
+        signalOutput = await executeSignal(signalRecord, {
+          organizationId: config.organization_id,
+          domain: orgDomain,
+          name: orgName,
+          campaignId: config.campaign_id,
+          // Person-level configs (e.g. social-engagement) need the contact.
+          personId: config.person_id ?? undefined,
+          useAdmin: true,
         });
+
+        rawOutput = signalOutput.data;
+
+        // If the signal executor didn't find anything meaningful, still store the result
+        if (!signalOutput.found && !rawOutput) {
+          rawOutput = { found: false, summary: signalOutput.summary };
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        throw new Error(`Signal execution failed: ${msg}`);
       }
 
-      if (diff.removed_jobs.length > 0) {
-        changesToInsert.push({
-          tracking_config_id: trackingConfigId,
-          change_type: "removed",
-          field_path: "jobs",
-          previous_value: diff.removed_jobs,
-          current_value: null,
-          description: `-${diff.removed_jobs.length} role${diff.removed_jobs.length > 1 ? "s" : ""}: ${diff.removed_jobs.map((j) => j.title).join(", ")}`,
-        });
+      // ── Normalize into snapshot ────────────────────────────────────────
+      // Hiring-shaped output (the hiring-activity scraper) keeps its rich
+      // title-level diffing; everything else gets a stable generic snapshot.
+      // Detection is on output shape, not slug, so any future signal that
+      // emits { jobs: [...] } inherits the hiring pipeline.
+      const isHiring = Array.isArray(rawOutput.jobs);
+      const jobs = isHiring
+        ? (rawOutput.jobs as Array<{
+            title: string;
+            department?: string;
+            location?: string;
+            url?: string;
+          }>)
+        : [];
+      const careersUrl = (rawOutput.careersUrl as string) || null;
+      const snapshot = isHiring
+        ? normalizeHiringData(jobs, careersUrl)
+        : buildGenericSnapshot(signalRecord.execution_type, rawOutput);
+      const hash = hashSnapshot(snapshot);
+
+      // ── Compare to previous snapshot ───────────────────────────────────
+      const { data: prevSnapshots, error: prevError } = await getAdminClient()
+        .from("tracking_snapshots")
+        .select("snapshot_data, snapshot_hash")
+        .eq("tracking_config_id", trackingConfigId)
+        .order("captured_at", { ascending: false })
+        .limit(1);
+      // A failed read is not "no previous snapshot": treating it as one
+      // inserted the CURRENT snapshot as a fresh baseline and permanently
+      // swallowed whatever change actually happened. Fail the run; the job
+      // system retries.
+      if (prevError) {
+        throw new Error(`previous-snapshot read failed: ${prevError.message}`);
       }
 
-      if (diff.job_count_delta !== 0 && changesToInsert.length === 0) {
-        changesToInsert.push({
-          tracking_config_id: trackingConfigId,
-          change_type: "count_change",
-          field_path: "job_count",
-          previous_value: prevHiring.job_count,
-          current_value: currHiring.job_count,
-          description: changeDescription,
-        });
-      }
+      const prevSnapshot = prevSnapshots?.[0] ?? null;
+      const hasChanged = !prevSnapshot || prevSnapshot.snapshot_hash !== hash;
 
-      if (changesToInsert.length > 0) {
-        await getAdminClient().from("tracking_changes").insert(changesToInsert);
-      }
-
-      rawDiffForIntent = diff;
-      diffSummary = {
-        addedCount: diff.added_jobs.length,
-        removedCount: diff.removed_jobs.length,
-        jobCountDelta: diff.job_count_delta,
-        description: changeDescription,
-      };
-    } else {
-      const prevGeneric = prevData as GenericSnapshot;
-      const currGeneric = snapshot as GenericSnapshot;
-      // Prefer the executor's own diff (exa_search and recipes compute one
-      // against signal_results); fall back to a structural diff of snapshots.
-      const executorDiff = signalOutput.diff;
-      const structural = structuralDiff(prevGeneric.data, currGeneric.data);
-      const meaningful = executorDiff?.changed ?? structural.changed;
-      if (!meaningful) {
-        // Hash moved but nothing semantically changed (e.g. result
-        // reordering a projection didn't catch). Don't wake the intent
-        // evaluator.
-        return { trackingConfigId, changed: false };
-      }
-
-      changeDescription =
-        executorDiff?.description ||
-        structural.description ||
-        "Signal output changed";
-      rawDiffForIntent = executorDiff ?? structural;
-
-      // ── Store tracking change ────────────────────────────────────────
-      await getAdminClient().from("tracking_changes").insert({
-        tracking_config_id: trackingConfigId,
-        change_type: "added",
-        field_path: "data",
-        previous_value: prevGeneric.data,
-        current_value: currGeneric.data,
-        description: changeDescription,
-      });
-
-      diffSummary = { description: changeDescription };
-    }
-
-    // ── Evaluate intent via LLM ────────────────────────────────────────
-    const signal = typedConfig.signal as {
-      name?: string;
-      category?: string;
-    } | null;
-    const verdict = await evaluateIntent({
-      intent: (typedConfig.intent as string) ?? "",
-      signalName: signal?.name ?? "Unknown signal",
-      signalCategory: signal?.category ?? "custom",
-      snapshotSummary: changeDescription,
-      rawDiff: rawDiffForIntent,
-      isFirstRun: false,
-    });
-
-    if (verdict.fire) {
-      await getAdminClient()
-        .from("tracking_changes")
+      // ── Store new snapshot (always, for the timeline) ──────────────────
+      // Checked: a silently failed insert left the stale snapshot as the
+      // diff baseline, so the same change re-fired every run (duplicate
+      // timeline rows, repeat LLM spend, repeat outreach enqueues). Failing
+      // here, BEFORE any change is recorded, makes the retry clean.
+      const { error: snapshotError } = await getAdminClient()
+        .from("tracking_snapshots")
         .insert({
           tracking_config_id: trackingConfigId,
-          change_type: "threshold_crossed",
-          field_path: null,
-          previous_value: null,
-          current_value: { confidence: verdict.confidence },
-          description: verdict.reason,
+          snapshot_data: snapshot,
+          snapshot_hash: hash,
+        });
+      if (snapshotError) {
+        throw new Error(`snapshot insert failed: ${snapshotError.message}`);
+      }
+
+      // ── Store signal_result with tracking_config_id ────────────────────
+      const { error: resultError } = await getAdminClient()
+        .from("signal_results")
+        .insert({
+          signal_id: config.signal_id,
+          campaign_id: config.campaign_id,
+          organization_id: config.organization_id,
+          person_id: config.person_id,
+          tracking_config_id: trackingConfigId,
+          output: rawOutput,
+          status: "success",
+        });
+      // The next run's baseline (and the recipe history step) read this row;
+      // a silent miss re-baselines the signal.
+      if (resultError) {
+        throw new Error(`signal_result insert failed: ${resultError.message}`);
+      }
+
+      // ── Update last_run_at ─────────────────────────────────────────────
+      await getAdminClient()
+        .from("tracking_configs")
+        .update({ last_run_at: new Date().toISOString() })
+        .eq("id", trackingConfigId);
+
+      if (!hasChanged) {
+        return {
+          trackingConfigId,
+          changed: false,
+          jobCount: isHiring
+            ? (snapshot as HiringSnapshot).job_count
+            : undefined,
+        };
+      }
+
+      // ── Compute diff ───────────────────────────────────────────────────
+      const prevData = prevSnapshot ? prevSnapshot.snapshot_data : null;
+
+      // If no previous data (first run after baseline), store as baseline
+      if (!prevData) {
+        return {
+          trackingConfigId,
+          changed: false,
+          baseline: true,
+          jobCount: isHiring
+            ? (snapshot as HiringSnapshot).job_count
+            : undefined,
+        };
+      }
+
+      let changeDescription: string;
+      let rawDiffForIntent: unknown;
+      let diffSummary: Record<string, unknown>;
+
+      if (isHiring) {
+        const prevHiring = prevData as HiringSnapshot;
+        const currHiring = snapshot as HiringSnapshot;
+        const diff = diffHiringSnapshots(prevHiring, currHiring);
+
+        // ── Classify new roles via Haiku ─────────────────────────────────
+        if (diff.added_jobs.length > 0) {
+          const icp = typedConfig.campaign.icp || {};
+          const offering = typedConfig.campaign.offering || {};
+          const icpContext = [
+            icp.industry && `Industry: ${icp.industry}`,
+            icp.targetTitles &&
+              `Target titles: ${(icp.targetTitles as string[]).join(", ")}`,
+            icp.painPoints &&
+              `Pain points: ${(icp.painPoints as string[]).join(", ")}`,
+            offering.description && `Offering: ${offering.description}`,
+          ]
+            .filter(Boolean)
+            .join(". ");
+
+          const classified = await classifyNewRoles(
+            diff.added_jobs,
+            icpContext,
+          );
+          diff.classified_added = classified;
+        }
+
+        // ── Store tracking changes ───────────────────────────────────────
+        changeDescription = describeHiringChanges(diff);
+
+        const changesToInsert: Array<Record<string, unknown>> = [];
+
+        if (diff.added_jobs.length > 0) {
+          changesToInsert.push({
+            tracking_config_id: trackingConfigId,
+            change_type: "added",
+            field_path: "jobs",
+            previous_value: null,
+            current_value: diff.added_jobs,
+            description: `+${diff.added_jobs.length} role${diff.added_jobs.length > 1 ? "s" : ""}: ${diff.added_jobs.map((j) => j.title).join(", ")}`,
+          });
+        }
+
+        if (diff.removed_jobs.length > 0) {
+          changesToInsert.push({
+            tracking_config_id: trackingConfigId,
+            change_type: "removed",
+            field_path: "jobs",
+            previous_value: diff.removed_jobs,
+            current_value: null,
+            description: `-${diff.removed_jobs.length} role${diff.removed_jobs.length > 1 ? "s" : ""}: ${diff.removed_jobs.map((j) => j.title).join(", ")}`,
+          });
+        }
+
+        if (diff.job_count_delta !== 0 && changesToInsert.length === 0) {
+          changesToInsert.push({
+            tracking_config_id: trackingConfigId,
+            change_type: "count_change",
+            field_path: "job_count",
+            previous_value: prevHiring.job_count,
+            current_value: currHiring.job_count,
+            description: changeDescription,
+          });
+        }
+
+        if (changesToInsert.length > 0) {
+          await getAdminClient()
+            .from("tracking_changes")
+            .insert(changesToInsert);
+        }
+
+        rawDiffForIntent = diff;
+        diffSummary = {
+          addedCount: diff.added_jobs.length,
+          removedCount: diff.removed_jobs.length,
+          jobCountDelta: diff.job_count_delta,
+          description: changeDescription,
+        };
+      } else {
+        const prevGeneric = prevData as GenericSnapshot;
+        const currGeneric = snapshot as GenericSnapshot;
+        // Prefer the executor's own diff (exa_search and recipes compute one
+        // against signal_results); fall back to a structural diff of snapshots.
+        const executorDiff = signalOutput.diff;
+        const structural = structuralDiff(prevGeneric.data, currGeneric.data);
+        const meaningful = executorDiff?.changed ?? structural.changed;
+        if (!meaningful) {
+          // Hash moved but nothing semantically changed (e.g. result
+          // reordering a projection didn't catch). Don't wake the intent
+          // evaluator.
+          return { trackingConfigId, changed: false };
+        }
+
+        changeDescription =
+          executorDiff?.description ||
+          structural.description ||
+          "Signal output changed";
+        rawDiffForIntent = executorDiff ?? structural;
+
+        // ── Store tracking change ────────────────────────────────────────
+        await getAdminClient().from("tracking_changes").insert({
+          tracking_config_id: trackingConfigId,
+          change_type: "added",
+          field_path: "data",
+          previous_value: prevGeneric.data,
+          current_value: currGeneric.data,
+          description: changeDescription,
         });
 
-      const junctionTable = config.organization_id
-        ? "campaign_organizations"
-        : "campaign_people";
-      const entityField = config.organization_id
-        ? "organization_id"
-        : "person_id";
-      const entityId = config.organization_id || config.person_id;
+        diffSummary = { description: changeDescription };
+      }
 
-      await getAdminClient()
-        .from(junctionTable)
-        .update({ readiness_tag: "ready_to_contact" })
-        .eq("campaign_id", config.campaign_id)
-        .eq(entityField, entityId);
-
-      // Auto-send only when the config explicitly opted in AND the intent
-      // verdict is high-confidence — both required, everything else stays
-      // in the human review queue.
-      const autoSend =
-        Boolean(typedConfig.auto_send) && verdict.confidence === "high";
-
-      // Enqueue the outreach job; /api/jobs/* auth guards the outbox path.
-      // AWAITED: this insert is the entire product promise of a threshold
-      // crossing. Fire-and-forget inside a serverless function let Vercel
-      // freeze the instance before the insert reached Supabase, so the
-      // company was stamped ready-to-contact and the outreach silently
-      // never happened. If the enqueue fails the run fails loudly and the
-      // job system retries.
-      await enqueueJob({
-        type: "outreach.process",
-        payload: {
-          type: "signal",
-          signalId: config.signal_id,
-          campaignId: config.campaign_id,
-          organizationId: config.organization_id ?? undefined,
-          reason: verdict.reason,
-          confidence: verdict.confidence,
-          autoSend,
-          maxContacts: typedConfig.max_contacts_per_fire ?? 1,
-        },
-        // Queue fairness: attribute the outreach job to the campaign owner
-        // instead of the shared '<system>' partition.
-        userId: typedConfig.campaign.user_id ?? null,
+      // ── Evaluate intent via LLM ────────────────────────────────────────
+      const signal = typedConfig.signal as {
+        name?: string;
+        category?: string;
+      } | null;
+      const verdict = await evaluateIntent({
+        intent: (typedConfig.intent as string) ?? "",
+        signalName: signal?.name ?? "Unknown signal",
+        signalCategory: signal?.category ?? "custom",
+        snapshotSummary: changeDescription,
+        rawDiff: rawDiffForIntent,
+        isFirstRun: false,
       });
-    }
 
-    return {
-      trackingConfigId,
-      changed: true,
-      diff: diffSummary,
-      intentFired: verdict.fire,
-      reason: verdict.reason,
-      confidence: verdict.confidence,
-    };
-  });
+      if (verdict.fire) {
+        await getAdminClient()
+          .from("tracking_changes")
+          .insert({
+            tracking_config_id: trackingConfigId,
+            change_type: "threshold_crossed",
+            field_path: null,
+            previous_value: null,
+            current_value: { confidence: verdict.confidence },
+            description: verdict.reason,
+          });
+
+        const junctionTable = config.organization_id
+          ? "campaign_organizations"
+          : "campaign_people";
+        const entityField = config.organization_id
+          ? "organization_id"
+          : "person_id";
+        const entityId = config.organization_id || config.person_id;
+
+        await getAdminClient()
+          .from(junctionTable)
+          .update({ readiness_tag: "ready_to_contact" })
+          .eq("campaign_id", config.campaign_id)
+          .eq(entityField, entityId);
+
+        // Auto-send only when the config explicitly opted in AND the intent
+        // verdict is high-confidence — both required, everything else stays
+        // in the human review queue.
+        const autoSend =
+          Boolean(typedConfig.auto_send) && verdict.confidence === "high";
+
+        // Enqueue the outreach job; /api/jobs/* auth guards the outbox path.
+        // AWAITED: this insert is the entire product promise of a threshold
+        // crossing. Fire-and-forget inside a serverless function let Vercel
+        // freeze the instance before the insert reached Supabase, so the
+        // company was stamped ready-to-contact and the outreach silently
+        // never happened. If the enqueue fails the run fails loudly and the
+        // job system retries.
+        await enqueueJob({
+          type: "outreach.process",
+          payload: {
+            type: "signal",
+            signalId: config.signal_id,
+            campaignId: config.campaign_id,
+            organizationId: config.organization_id ?? undefined,
+            reason: verdict.reason,
+            confidence: verdict.confidence,
+            autoSend,
+            maxContacts: typedConfig.max_contacts_per_fire ?? 1,
+          },
+          // Queue fairness: attribute the outreach job to the campaign owner
+          // instead of the shared '<system>' partition.
+          userId: typedConfig.campaign.user_id ?? null,
+        });
+      }
+
+      return {
+        trackingConfigId,
+        changed: true,
+        diff: diffSummary,
+        intentFired: verdict.fire,
+        reason: verdict.reason,
+        confidence: verdict.confidence,
+      };
+    },
+    // Attribution: tracking spend belongs to the campaign owner (K19).
+    typedConfig.campaign.user_id ?? undefined,
+  );
 }

--- a/src/lib/services/cost-tracker.ts
+++ b/src/lib/services/cost-tracker.ts
@@ -14,6 +14,12 @@ export const PRICING = {
   claude_sonnet_output: 15.0,
   claude_sonnet_cache_read: 0.3,
   claude_sonnet_cache_write: 3.75,
+  // Claude Opus 5 (per million tokens) -- the email composer's model.
+  // Cache read is 0.1x input, 5-minute cache write is 1.25x input.
+  claude_opus_input: 5.0,
+  claude_opus_output: 25.0,
+  claude_opus_cache_read: 0.5,
+  claude_opus_cache_write: 6.25,
   // Claude Haiku 4.5 (per million tokens)
   claude_haiku_input: 1.0,
   claude_haiku_output: 5.0,
@@ -105,7 +111,7 @@ interface UsageEntry {
   user_id?: string;
 }
 
-export type ClaudeModel = "sonnet" | "haiku";
+export type ClaudeModel = "opus" | "sonnet" | "haiku";
 
 export interface ClaudeCostParams {
   model: ClaudeModel;
@@ -125,22 +131,30 @@ export interface ClaudeCostParams {
  */
 export function estimateClaudeCost(params: ClaudeCostParams): number {
   const { model } = params;
-  const uncachedRate =
-    model === "sonnet"
-      ? PRICING.claude_sonnet_input
-      : PRICING.claude_haiku_input;
-  const cacheReadRate =
-    model === "sonnet"
-      ? PRICING.claude_sonnet_cache_read
-      : PRICING.claude_haiku_cache_read;
-  const cacheWriteRate =
-    model === "sonnet"
-      ? PRICING.claude_sonnet_cache_write
-      : PRICING.claude_haiku_cache_write;
-  const outputRate =
-    model === "sonnet"
-      ? PRICING.claude_sonnet_output
-      : PRICING.claude_haiku_output;
+  const RATES = {
+    opus: {
+      input: PRICING.claude_opus_input,
+      cacheRead: PRICING.claude_opus_cache_read,
+      cacheWrite: PRICING.claude_opus_cache_write,
+      output: PRICING.claude_opus_output,
+    },
+    sonnet: {
+      input: PRICING.claude_sonnet_input,
+      cacheRead: PRICING.claude_sonnet_cache_read,
+      cacheWrite: PRICING.claude_sonnet_cache_write,
+      output: PRICING.claude_sonnet_output,
+    },
+    haiku: {
+      input: PRICING.claude_haiku_input,
+      cacheRead: PRICING.claude_haiku_cache_read,
+      cacheWrite: PRICING.claude_haiku_cache_write,
+      output: PRICING.claude_haiku_output,
+    },
+  }[model];
+  const uncachedRate = RATES.input;
+  const cacheReadRate = RATES.cacheRead;
+  const cacheWriteRate = RATES.cacheWrite;
+  const outputRate = RATES.output;
 
   const cacheRead = params.cacheReadTokens ?? 0;
   const cacheWrite = params.cacheCreationTokens ?? 0;
@@ -189,10 +203,22 @@ export function estimateClaudeCostFromUsage(
  * Automatically picks up action_id/action_label from the nearest `withAction`
  * context if one exists.
  */
+/**
+ * Inserts still in flight. Serverless can freeze the instance the moment a
+ * response returns, silently dropping fire-and-forget writes: long-lived
+ * paths (the job runner) await flushUsageTracking() before returning.
+ */
+const pendingInserts = new Set<Promise<void>>();
+
+/** Await every in-flight api_usage insert. Never throws. */
+export async function flushUsageTracking(): Promise<void> {
+  await Promise.allSettled([...pendingInserts]);
+}
+
 export function trackUsage(entry: UsageEntry): void {
   const ctx = actionStore.getStore();
 
-  void (async () => {
+  const insert = (async () => {
     try {
       const { error } = await getAdminClient()
         .from("api_usage")
@@ -214,4 +240,6 @@ export function trackUsage(entry: UsageEntry): void {
       console.error("[cost-tracker] unexpected error:", err);
     }
   })();
+  pendingInserts.add(insert);
+  void insert.finally(() => pendingInserts.delete(insert));
 }

--- a/src/lib/services/person-enrichment.ts
+++ b/src/lib/services/person-enrichment.ts
@@ -42,6 +42,9 @@ export async function enrichPerson(
   supabase: SupabaseClient,
   personId: string,
   person: PersonForEnrichment,
+  // Attribution: without it every per-person enrichment spend lands with
+  // user_id NULL, which the cost center's RLS can never show.
+  userId?: string | null,
 ): Promise<PersonEnrichmentResult> {
   const contactName = person.name || "Unknown";
   const companyName = person.organization?.name || null;
@@ -49,168 +52,173 @@ export async function enrichPerson(
     ? `Enrich person: ${contactName} (${companyName})`
     : `Enrich person: ${contactName}`;
 
-  return withAction(actionLabel, async () => {
-    await supabase
-      .from("people")
-      .update({ enrichment_status: "in_progress" })
-      .eq("id", personId);
+  return withAction(
+    actionLabel,
+    async () => {
+      await supabase
+        .from("people")
+        .update({ enrichment_status: "in_progress" })
+        .eq("id", personId);
 
-    const enrichmentData: Record<string, unknown> = {};
-    const errors: string[] = [];
-    const promises: Promise<void>[] = [];
+      const enrichmentData: Record<string, unknown> = {};
+      const errors: string[] = [];
+      const promises: Promise<void>[] = [];
 
-    if (person.linkedin_url) {
-      promises.push(
-        (async () => {
-          try {
-            const linkedin = new LinkedinService();
-            const scrapeResult = await linkedin.scrapeProfile(
-              person.linkedin_url!,
-            );
-            enrichmentData.linkedin = {
-              profileInfo: scrapeResult.profile || null,
-              posts: scrapeResult.posts.slice(0, 10),
-            };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            console.error(`[enrich] LinkedIn scrape failed: ${msg}`);
-            errors.push(`LinkedIn: ${msg}`);
-          }
-        })(),
-      );
-    }
+      if (person.linkedin_url) {
+        promises.push(
+          (async () => {
+            try {
+              const linkedin = new LinkedinService();
+              const scrapeResult = await linkedin.scrapeProfile(
+                person.linkedin_url!,
+              );
+              enrichmentData.linkedin = {
+                profileInfo: scrapeResult.profile || null,
+                posts: scrapeResult.posts.slice(0, 10),
+              };
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : "Unknown error";
+              console.error(`[enrich] LinkedIn scrape failed: ${msg}`);
+              errors.push(`LinkedIn: ${msg}`);
+            }
+          })(),
+        );
+      }
 
-    if (person.twitter_url) {
-      promises.push(
-        (async () => {
-          try {
-            const x = new XService();
-            const result = await x.enrichTwitterProfile(person.twitter_url!);
-            enrichmentData.twitter = {
-              user: result.user,
-              tweets: result.tweets.slice(0, 10),
-            };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : "Unknown error";
-            console.error(`[enrich] Twitter enrich failed: ${msg}`);
-            errors.push(`Twitter: ${msg}`);
-          }
-        })(),
-      );
-    }
+      if (person.twitter_url) {
+        promises.push(
+          (async () => {
+            try {
+              const x = new XService();
+              const result = await x.enrichTwitterProfile(person.twitter_url!);
+              enrichmentData.twitter = {
+                user: result.user,
+                tweets: result.tweets.slice(0, 10),
+              };
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : "Unknown error";
+              console.error(`[enrich] Twitter enrich failed: ${msg}`);
+              errors.push(`Twitter: ${msg}`);
+            }
+          })(),
+        );
+      }
 
-    if (contactName !== "Unknown") {
-      const exa = new ExaService();
+      if (contactName !== "Unknown") {
+        const exa = new ExaService();
 
-      const contactTitle = person.title || null;
-      const queryParts = [`"${contactName}"`];
-      if (companyName) queryParts.push(`"${companyName}"`);
-      if (contactTitle) queryParts.push(contactTitle);
-      const specificQuery = queryParts.join(" ");
+        const contactTitle = person.title || null;
+        const queryParts = [`"${contactName}"`];
+        if (companyName) queryParts.push(`"${companyName}"`);
+        if (contactTitle) queryParts.push(contactTitle);
+        const specificQuery = queryParts.join(" ");
 
-      // URLs already on the company's card, so the same link doesn't appear
-      // on both the company and the contact.
-      const companyUrls = new Set<string>();
-      if (person.organization) {
-        const { data: orgRow } = await supabase
-          .from("organizations")
-          .select("enrichment_data")
-          .eq("name", person.organization.name ?? "")
-          .maybeSingle();
+        // URLs already on the company's card, so the same link doesn't appear
+        // on both the company and the contact.
+        const companyUrls = new Set<string>();
+        if (person.organization) {
+          const { data: orgRow } = await supabase
+            .from("organizations")
+            .select("enrichment_data")
+            .eq("name", person.organization.name ?? "")
+            .maybeSingle();
 
-        const orgEnrichment = orgRow?.enrichment_data as Record<
-          string,
-          unknown
-        > | null;
-        if (orgEnrichment) {
-          const searches = orgEnrichment.searches as
-            | Array<{ results: Array<{ url: string }> }>
-            | undefined;
-          if (searches) {
-            for (const s of searches) {
-              for (const r of s.results) {
-                if (r.url) companyUrls.add(r.url);
+          const orgEnrichment = orgRow?.enrichment_data as Record<
+            string,
+            unknown
+          > | null;
+          if (orgEnrichment) {
+            const searches = orgEnrichment.searches as
+              | Array<{ results: Array<{ url: string }> }>
+              | undefined;
+            if (searches) {
+              for (const s of searches) {
+                for (const r of s.results) {
+                  if (r.url) companyUrls.add(r.url);
+                }
               }
             }
           }
         }
+
+        const dedup = (
+          results: Array<{
+            title: string;
+            url: string;
+            publishedDate: string | null;
+            text: string | null;
+          }>,
+        ) => results.filter((r) => !companyUrls.has(r.url));
+
+        const search = (
+          key: "news" | "articles" | "background",
+          query: string,
+          label: string,
+          category?: "news",
+        ) =>
+          promises.push(
+            (async () => {
+              try {
+                const result = await exa.search(query, {
+                  numResults: 3,
+                  includeText: true,
+                  ...(category ? { category } : {}),
+                });
+                enrichmentData[key] = dedup(
+                  result.results.map((r) => ({
+                    title: r.title,
+                    url: r.url,
+                    publishedDate: r.publishedDate,
+                    text: r.text || null,
+                  })),
+                );
+              } catch (err) {
+                const msg =
+                  err instanceof Error ? err.message : "Unknown error";
+                errors.push(`${label}: ${msg}`);
+              }
+            })(),
+          );
+
+        search("news", `${specificQuery} news announcement`, "News", "news");
+        search(
+          "articles",
+          `${specificQuery} article talk interview podcast`,
+          "Articles",
+        );
+        search(
+          "background",
+          `${specificQuery} background bio profile`,
+          "Background",
+        );
       }
 
-      const dedup = (
-        results: Array<{
-          title: string;
-          url: string;
-          publishedDate: string | null;
-          text: string | null;
-        }>,
-      ) => results.filter((r) => !companyUrls.has(r.url));
+      // Nobody to ask: no LinkedIn, no X, and no usable name for a web search.
+      if (promises.length === 0) {
+        await supabase
+          .from("people")
+          .update({ enrichment_status: "failed" })
+          .eq("id", personId);
+        return {
+          status: "failed" as const,
+          enrichmentData: {},
+          errors: ["No enrichment sources available"],
+        };
+      }
 
-      const search = (
-        key: "news" | "articles" | "background",
-        query: string,
-        label: string,
-        category?: "news",
-      ) =>
-        promises.push(
-          (async () => {
-            try {
-              const result = await exa.search(query, {
-                numResults: 3,
-                includeText: true,
-                ...(category ? { category } : {}),
-              });
-              enrichmentData[key] = dedup(
-                result.results.map((r) => ({
-                  title: r.title,
-                  url: r.url,
-                  publishedDate: r.publishedDate,
-                  text: r.text || null,
-                })),
-              );
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : "Unknown error";
-              errors.push(`${label}: ${msg}`);
-            }
-          })(),
-        );
+      await Promise.all(promises);
 
-      search("news", `${specificQuery} news announcement`, "News", "news");
-      search(
-        "articles",
-        `${specificQuery} article talk interview podcast`,
-        "Articles",
-      );
-      search(
-        "background",
-        `${specificQuery} background bio profile`,
-        "Background",
-      );
-    }
+      const status =
+        Object.keys(enrichmentData).length > 0 ? "enriched" : "failed";
 
-    // Nobody to ask: no LinkedIn, no X, and no usable name for a web search.
-    if (promises.length === 0) {
-      await supabase
-        .from("people")
-        .update({ enrichment_status: "failed" })
-        .eq("id", personId);
+      await mergeEnrichmentData("people", personId, enrichmentData, status);
+
       return {
-        status: "failed" as const,
-        enrichmentData: {},
-        errors: ["No enrichment sources available"],
+        status,
+        enrichmentData,
+        errors: errors.length > 0 ? errors : undefined,
       };
-    }
-
-    await Promise.all(promises);
-
-    const status =
-      Object.keys(enrichmentData).length > 0 ? "enriched" : "failed";
-
-    await mergeEnrichmentData("people", personId, enrichmentData, status);
-
-    return {
-      status,
-      enrichmentData,
-      errors: errors.length > 0 ? errors : undefined,
-    };
-  });
+    },
+    userId ?? undefined,
+  );
 }

--- a/src/lib/services/sender-research.ts
+++ b/src/lib/services/sender-research.ts
@@ -134,6 +134,10 @@ One sentence each, written in third person. Skip anything the sources do not cle
  */
 export async function researchSender(
   profile: UserProfile,
+  // Attribution: neither caller runs inside a withAction context, so
+  // without this the research spend lands with user_id NULL and the cost
+  // center (RLS-scoped) can never show it.
+  userId?: string | null,
 ): Promise<ResearchSenderResult> {
   const urls = [
     profile.linkedin_url,
@@ -225,6 +229,7 @@ ${wrapUntrusted(body)}`;
       tokens_input: usage.inputTokens ?? 0,
       tokens_output: usage.outputTokens ?? 0,
       estimated_cost_usd: estimateClaudeCostFromUsage(MODEL_LABEL, usage),
+      user_id: userId ?? undefined,
       metadata: { model: MODEL_LABEL, profileId: profile.id },
     });
 

--- a/src/lib/tools/sender-fact-tools.ts
+++ b/src/lib/tools/sender-fact-tools.ts
@@ -73,7 +73,7 @@ export const researchSenderProfile = tool({
     const profile = await resolveProfile(supabase, input.profileId);
     if (!profile) return { error: NO_PROFILE_ERROR };
 
-    const result = await researchSender(profile);
+    const result = await researchSender(profile, userId);
     if (!result.ok) return { error: result.error };
 
     const existing = await loadSenderFacts(supabase, profile.id);

--- a/src/lib/tools/sequence-tools.ts
+++ b/src/lib/tools/sequence-tools.ts
@@ -286,7 +286,9 @@ export const draftSequenceEmails = tool({
         "(2) optionally call getCompanyDetail(organizationId) if you need deep company context; " +
         "(3) call writeEmail with the personalized content, passing sequenceId, sequenceStepId, enrollmentId, and ai_reasoning; " +
         "(4) then move on to the next contact. Do NOT preload enrichment for all contacts up front. " +
-        "Step 1 is the initial cold email. Follow-ups reference the prior email and add urgency. The final step is a polite breakup. " +
+        (steps.length > 1
+          ? "Step 1 is the initial cold email. Follow-ups reference the prior email and add urgency. The final step is a polite breakup. "
+          : "This is a single-step sequence: its only email is first contact. Never frame it as a follow-up or breakup, and never imply prior emails. ") +
         `After all drafts are created, tell the user to review them at /outreach/review?sequence=${sequenceId}`,
     };
   },


### PR DESCRIPTION
Wave 4, PR-11 of the hardening plan (K10, K18, K19 + the compose/cost clusters). **Stacked on #85** (shares `execute.ts`/`tracking-run.ts` with the jobs chain): merge #84 → #85 → this; GitHub retargets automatically.

## Highlights

- **The email composer's Opus spend was completely invisible** (K18): `cost-tracker` had no opus tier and `composeEmail` never called `trackUsage`. Added the `claude-opus-5` tier at current list pricing ($5/$25 per MTok, cache multipliers included) and wired tracking into the composer.
- **The compose prompt cache never worked.** Call-level `providerOptions.anthropic.cacheControl` maps to top-level auto-caching, which places the breakpoint on the *last* cacheable block: the per-contact user prompt that changes on every fan-out call. The breakpoint now rides on the system message itself, so the large stable system prompt (skill + voice + fact bank + learnings) actually serves from cache across the batch.
- **Spend attribution** (K19 + siblings): tracking runs, per-person enrichment, department classification, and sender research now pass their owner into the tracking context: no more `user_id NULL` rows the RLS-scoped cost center can never display. `trackUsage` inserts are also flushable, and the job runner awaits them before returning (same serverless-freeze class as K9).
- **K10:** the composer no longer receives a fabricated `unknown@example.com` for personal-email-only contacts (both the cron and regenerate paths), and `draftSequenceEmails`' agent instructions stop calling a 1-step sequence's only email "a polite breakup" (the instruction-level sibling of the isFinal bug from #76).
- Timing learnings no longer crowd copy/targeting learnings out of the compose prompt cap (they were sliced in, then dropped at render); `/api/settings/costs` returns 500 on query failure instead of a fake $0 dashboard; classify-departments reports failed writes.

Tests: 910 passed (2 new pricing tests); tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)