### PR TITLE
fix(tracking-ui): failures render as errors, not empty states

### DIFF
--- a/src/app/tracking/page.tsx
+++ b/src/app/tracking/page.tsx
@@ -42,6 +42,8 @@ function TrackingPageContent() {
   const [rows, setRows] = useState<TrackingRow[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("by-signal");
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const fetchedCampaignRef = useRef<string>("");
   const mountedRef = useRef(true);
 
   const fetchCampaigns = useCallback(async () => {
@@ -56,6 +58,7 @@ function TrackingPageContent() {
   }, []);
 
   const fetchTrackingData = useCallback(async (campaignId: string) => {
+    fetchedCampaignRef.current = campaignId;
     if (!campaignId) {
       setRows([]);
       return;
@@ -64,7 +67,7 @@ function TrackingPageContent() {
     const supabase = createClient();
 
     // Fetch tracking configs with joins -- include organization_id directly
-    const { data: configs } = await supabase
+    const { data: configs, error: configsError } = await supabase
       .from("tracking_configs")
       .select(
         "id, organization_id, schedule, status, intent, auto_send, last_run_at, next_run_at, organization:organizations(name, domain), signal:signals(name, category)",
@@ -72,7 +75,19 @@ function TrackingPageContent() {
       .eq("campaign_id", campaignId)
       .order("created_at", { ascending: false });
 
-    if (!mountedRef.current || !configs) {
+    // Stale-selection guard: a slow response for a previously selected
+    // campaign must not paint its rows under the new selection.
+    if (!mountedRef.current || fetchedCampaignRef.current !== campaignId)
+      return;
+    // A failed query is not "no tracking configured": rendering the empty
+    // state over an error hid real configs behind a dashed placeholder.
+    if (configsError) {
+      setLoadError(configsError.message);
+      setRows([]);
+      return;
+    }
+    setLoadError(null);
+    if (!configs) {
       setRows([]);
       return;
     }
@@ -110,6 +125,15 @@ function TrackingPageContent() {
         )
         .order("detected_at", { ascending: false }),
     ]);
+    // Secondary loads degrade the rows (missing readiness tags / latest
+    // changes) rather than the whole table, but never silently.
+    if (orgLinksRes.error)
+      console.error("[tracking] readiness load failed:", orgLinksRes.error);
+    if (latestChangesRes.error)
+      console.error(
+        "[tracking] latest-changes load failed:",
+        latestChangesRes.error,
+      );
     const orgLinks = orgLinksRes.data;
     const latestChanges = latestChangesRes.data;
 
@@ -164,6 +188,7 @@ function TrackingPageContent() {
       },
     );
 
+    if (fetchedCampaignRef.current !== campaignId) return;
     setRows(mappedRows);
   }, []);
 
@@ -284,6 +309,13 @@ function TrackingPageContent() {
         {!selectedCampaignId ? (
           <p className="text-muted-foreground py-12 text-center text-sm">
             Select a campaign to view tracked entities.
+          </p>
+        ) : loadError ? (
+          <p
+            role="alert"
+            className="text-destructive py-12 text-center text-sm"
+          >
+            Could not load tracking data: {loadError}
           </p>
         ) : rows.length === 0 ? (
           <div className="border-border flex flex-col items-center gap-2 rounded-lg border border-dashed px-6 py-12 text-center">

--- a/src/components/tracking/tracking-table.tsx
+++ b/src/components/tracking/tracking-table.tsx
@@ -40,6 +40,7 @@ export interface CompanyGroup {
   activeSignals: number;
   lastRunAt: string | null;
   latestChangeDescription: string | null;
+  latestChangeDate: string | null;
   rows: TrackingRow[];
 }
 
@@ -54,6 +55,7 @@ function formatDate(dateStr: string | null): string {
 function ExpandableSignalRow({ row }: { row: TrackingRow }) {
   const [expanded, setExpanded] = useState(false);
   const [changes, setChanges] = useState<TrackingChange[]>([]);
+  const [changesError, setChangesError] = useState<string | null>(null);
   const [loadingChanges, setLoadingChanges] = useState(false);
   const [localStatus, setLocalStatus] = useState(row.status);
   const [running, setRunning] = useState(false);
@@ -62,12 +64,15 @@ function ExpandableSignalRow({ row }: { row: TrackingRow }) {
     if (!expanded && changes.length === 0) {
       setLoadingChanges(true);
       const supabase = createClient();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("tracking_changes")
         .select("*")
         .eq("tracking_config_id", row.id)
         .order("detected_at", { ascending: false })
         .limit(20);
+      // A failed load must not render as "No changes recorded yet."
+      if (error) setChangesError(error.message);
+      else setChangesError(null);
       setChanges((data as TrackingChange[]) ?? []);
       setLoadingChanges(false);
     }
@@ -191,6 +196,11 @@ function ExpandableSignalRow({ row }: { row: TrackingRow }) {
       {expanded && (
         <tr>
           <td colSpan={8} className="bg-muted/30 border-b px-6 py-3">
+            {changesError && (
+              <p role="alert" className="text-destructive px-3 py-2 text-xs">
+                Could not load changes: {changesError}
+              </p>
+            )}
             {loadingChanges ? (
               <p className="text-muted-foreground text-xs">Loading...</p>
             ) : (
@@ -205,6 +215,7 @@ function ExpandableSignalRow({ row }: { row: TrackingRow }) {
 
 function ExpandableCompanyRow({ group }: { group: CompanyGroup }) {
   const [expanded, setExpanded] = useState(false);
+  const [changesError, setChangesError] = useState<string | null>(null);
   const [changesByConfig, setChangesByConfig] = useState<
     Record<string, TrackingChange[]>
   >({});
@@ -215,18 +226,24 @@ function ExpandableCompanyRow({ group }: { group: CompanyGroup }) {
       setLoadingChanges(true);
       const supabase = createClient();
       const configIds = group.rows.map((r) => r.id);
-      const { data } = await supabase
+      // A wider window with a per-config cap below: one global limit meant
+      // a single chatty config could crowd every other config's timeline
+      // out of the 50-row window entirely.
+      const { data, error } = await supabase
         .from("tracking_changes")
         .select("*")
         .in("tracking_config_id", configIds)
         .order("detected_at", { ascending: false })
-        .limit(50);
+        .limit(200);
+      if (error) setChangesError(error.message);
+      else setChangesError(null);
 
+      const PER_CONFIG_CAP = 20;
       const grouped: Record<string, TrackingChange[]> = {};
       for (const change of (data as TrackingChange[]) ?? []) {
         const cid = change.tracking_config_id;
         if (!grouped[cid]) grouped[cid] = [];
-        grouped[cid].push(change);
+        if (grouped[cid].length < PER_CONFIG_CAP) grouped[cid].push(change);
       }
       setChangesByConfig(grouped);
       setLoadingChanges(false);
@@ -267,6 +284,11 @@ function ExpandableCompanyRow({ group }: { group: CompanyGroup }) {
       {expanded && (
         <tr>
           <td colSpan={8} className="bg-muted/30 border-b px-6 py-3">
+            {changesError && (
+              <p role="alert" className="text-destructive px-3 py-2 text-xs">
+                Could not load changes: {changesError}
+              </p>
+            )}
             {loadingChanges ? (
               <p className="text-muted-foreground text-xs">Loading...</p>
             ) : (
@@ -315,6 +337,7 @@ export function TrackingTable({
           activeSignals: 0,
           lastRunAt: null,
           latestChangeDescription: null,
+          latestChangeDate: null,
           rows: [],
         });
       }
@@ -328,12 +351,15 @@ export function TrackingTable({
       ) {
         group.lastRunAt = row.lastRunAt;
       }
+      // Compared against the group's own latest CHANGE date: comparing to
+      // lastRunAt (possibly overwritten this very iteration) let an older
+      // change win over a newer one.
       if (
         row.latestChangeDate &&
-        (!group.latestChangeDescription ||
-          (group.latestChangeDescription &&
-            row.latestChangeDate > (group.lastRunAt ?? "")))
+        (!group.latestChangeDate ||
+          row.latestChangeDate > group.latestChangeDate)
       ) {
+        group.latestChangeDate = row.latestChangeDate;
         group.latestChangeDescription = row.latestChangeDescription;
       }
       // Promote readiness: ready > monitoring > not_ready
@@ -368,7 +394,7 @@ export function TrackingTable({
           <tbody>
             {groups.map((group) => (
               <ExpandableCompanyRow
-                key={group.organizationName}
+                key={group.organizationDomain || group.organizationName}
                 group={group}
               />
             ))}

--- a/src/lib/tools/tracking-tools.ts
+++ b/src/lib/tools/tracking-tools.ts
@@ -223,11 +223,19 @@ export const bulkCreateTracking = tool({
     }
 
     // Check for existing tracking configs to avoid duplicates
-    const { data: existing } = await supabase
+    const { data: existing, error: existingError } = await supabase
       .from("tracking_configs")
       .select("organization_id")
       .eq("campaign_id", input.campaignId)
       .eq("signal_id", input.signalId);
+    // Fail closed: with an empty dedupe set, the batch insert includes
+    // already-tracked orgs and the unique index aborts the WHOLE atomic
+    // insert, so nothing gets tracked and the error is baffling.
+    if (existingError) {
+      return {
+        error: `Could not check existing tracking configs: ${existingError.message}. Try again.`,
+      };
+    }
 
     const existingOrgIds = new Set(
       (existing || []).map((e: Record<string, unknown>) => e.organization_id),
@@ -343,11 +351,19 @@ export const getTrackingConfigs = tool({
 
     // Fetch latest change for each config
     const configIds = (configs || []).map((c: Record<string, unknown>) => c.id);
-    const { data: latestChanges } = await supabase
+    const { data: latestChanges, error: changesError } = await supabase
       .from("tracking_changes")
       .select("tracking_config_id, description, change_type, detected_at")
       .in("tracking_config_id", configIds)
       .order("detected_at", { ascending: false });
+    // Logged, not silently null: a failed load otherwise reads to the agent
+    // as "no config has ever detected a change", a false factual claim.
+    if (changesError) {
+      console.error(
+        "[tracking-tools] latest-changes load failed:",
+        changesError,
+      );
+    }
 
     // Group to get latest per config
     const changeMap = new Map<string, Record<string, unknown>>();


### PR DESCRIPTION
Wave 3, PR-9 of the hardening plan (the tracking-UI cluster: 8 findings). Off main, disjoint from every open PR: merge any time.

Mechanical but user-facing: the tracking page and table rendered every query failure as an innocent empty state ("No tracking configured", "No changes recorded yet."), the by-company view let one chatty config crowd all other timelines out of a global 50-row window, the "Latest change" column could show an older change than the latest (it compared change dates against a just-overwritten run date), same-named companies produced colliding React keys, and `bulkCreateTracking` responded to a failed dedupe check by handing the unique index a batch guaranteed to abort. Also: a stale-selection guard so switching campaigns quickly can't paint the previous campaign's rows.

Tests: 903 passed on this branch; tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)