### PR TITLE
fix(email): discovery waterfall integrity

### DIFF
--- a/src/__tests__/email-pattern.test.ts
+++ b/src/__tests__/email-pattern.test.ts
@@ -43,10 +43,16 @@ interface OrgRow {
   email_pattern_updated_at: string | null;
 }
 
-function createFakeSupabase(initial: {
-  people?: Partial<PersonRow>[];
-  organizations?: Partial<OrgRow>[];
-}) {
+function createFakeSupabase(
+  initial: {
+    people?: Partial<PersonRow>[];
+    organizations?: Partial<OrgRow>[];
+  },
+  options?: {
+    updateError?: { message: string } | null;
+    selectError?: { message: string } | null;
+  },
+) {
   const tables = {
     people: (initial.people ?? []).map((p) => ({
       id: "",
@@ -108,10 +114,21 @@ function createFakeSupabase(initial: {
       then(onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) {
         const rows = tables[table] as unknown as Record<string, unknown>[];
         if (mode === "update") {
+          const error = options?.updateError ?? null;
+          if (error) {
+            return Promise.resolve({ data: null, error }).then(onF, onR);
+          }
           for (const r of rows) {
             if (preds.every((p) => p(r))) Object.assign(r, updates);
           }
           return Promise.resolve({ data: null, error: null }).then(onF, onR);
+        }
+        const selectError = options?.selectError ?? null;
+        if (selectError) {
+          return Promise.resolve({ data: null, error: selectError }).then(
+            onF,
+            onR,
+          );
         }
         const matches = rows.filter((r) => preds.every((p) => p(r)));
         const data = single ? (matches[0] ?? null) : matches;
@@ -666,5 +683,124 @@ describe("mxCheck", () => {
   it("returns false when DNS returns zero MX records", async () => {
     const resolver = vi.fn().mockResolvedValue([]);
     expect(await mxCheck("noemail.example.com", resolver)).toBe(false);
+  });
+});
+
+// ─── recordVerifiedEmail reports what it did ──────────────────────────────
+
+describe("recordVerifiedEmail return contract", () => {
+  const seedPerson = () => ({
+    people: [
+      {
+        id: "p1",
+        name: "Jane Doe",
+        organization_id: null,
+        work_email: null,
+      },
+    ],
+  });
+
+  it("says it recorded when it recorded", async () => {
+    const { client, tables } = createFakeSupabase(seedPerson());
+
+    const result = await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane@acme.com",
+      source: "user_entered",
+    });
+
+    expect(result.recorded).toBe(true);
+    expect(tables.people[0].work_email).toBe("jane@acme.com");
+  });
+
+  it("reports a role-prefix skip instead of implying success", async () => {
+    // The deterministic silent-drop: a user typing info@acme.com got ok:true
+    // from the route while nothing was recorded and the org pattern never
+    // recomputed.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { client, tables } = createFakeSupabase(seedPerson());
+
+    const result = await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "info@acme.com",
+      source: "user_entered",
+    });
+
+    expect(result.recorded).toBe(false);
+    expect(result.reason).toMatch(/role-prefix/);
+    expect(result.error).toBeUndefined();
+    expect(tables.people[0].work_email).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("reports a missing person", async () => {
+    const { client } = createFakeSupabase({ people: [] });
+
+    const result = await recordVerifiedEmail(client, {
+      personId: "ghost",
+      email: "jane@acme.com",
+      source: "user_entered",
+    });
+
+    expect(result).toEqual({ recorded: false, reason: "person_not_found" });
+  });
+
+  it("surfaces a failed write as an error, not a success", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client } = createFakeSupabase(seedPerson(), {
+      updateError: { message: "permission denied" },
+    });
+
+    const result = await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane@acme.com",
+      source: "user_entered",
+    });
+
+    expect(result.recorded).toBe(false);
+    expect(result.error).toContain("permission denied");
+    quiet.mockRestore();
+  });
+
+  it("surfaces a failed lookup as an error, not a missing person", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client } = createFakeSupabase(seedPerson(), {
+      selectError: { message: "connection reset" },
+    });
+
+    const result = await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "jane@acme.com",
+      source: "user_entered",
+    });
+
+    expect(result.recorded).toBe(false);
+    expect(result.error).toContain("connection reset");
+    expect(result.reason).toBeUndefined();
+    quiet.mockRestore();
+  });
+
+  it("reports a weaker-source skip by name", async () => {
+    const { client, tables } = createFakeSupabase({
+      people: [
+        {
+          id: "p1",
+          name: "Jane Doe",
+          organization_id: null,
+          work_email: "jane@acme.com",
+          work_email_source: "send_confirmed" as EmailSource,
+        },
+      ],
+    });
+
+    const result = await recordVerifiedEmail(client, {
+      personId: "p1",
+      email: "other@acme.com",
+      source: "team_page",
+    });
+
+    expect(result.recorded).toBe(false);
+    expect(result.reason).toContain("send_confirmed");
+    expect(tables.people[0].work_email).toBe("jane@acme.com");
   });
 });

--- a/src/__tests__/email-waterfall.test.ts
+++ b/src/__tests__/email-waterfall.test.ts
@@ -39,6 +39,9 @@ const state: { people: PersonRow[]; organizations: OrgRow[] } = {
   organizations: [],
 };
 
+/** What a SELECT against the named table fails with, if anything. */
+let tableErrors: Record<string, { message: string } | null> = {};
+
 function chain(table: "people" | "organizations") {
   let mode: "select" | "update" = "select";
   let single = false;
@@ -79,7 +82,17 @@ function chain(table: "people" | "organizations") {
         }
         return Promise.resolve({ data: null, error: null }).then(onF, onR);
       }
-      const matches = rows.filter((r) => preds.every((p) => p(r)));
+      const error = tableErrors[table] ?? null;
+      if (error) {
+        return Promise.resolve({ data: null, error }).then(onF, onR);
+      }
+      // Shallow copies, the way a real query returns detached rows. Handing
+      // back live references made every "snapshot" in production code
+      // secretly current, which hid exactly the class of stale-read bug the
+      // freshness test below exists to catch.
+      const matches = rows
+        .filter((r) => preds.every((p) => p(r)))
+        .map((r) => ({ ...r }));
       const data = single ? (matches[0] ?? null) : matches;
       return Promise.resolve({ data, error: null }).then(onF, onR);
     },
@@ -185,6 +198,7 @@ const row = () => state.people[0];
 beforeEach(() => {
   providerEnabled = true;
   exaResults.results = [];
+  tableErrors = {};
   recordAffiliationMock.mockClear();
   provider.findEmail.mockReset().mockResolvedValue(null);
   provider.verifyEmail
@@ -445,5 +459,55 @@ describe("candidate selection", () => {
 
     expect(result.email).toBe("known@acme.com");
     expect(provider.verifyEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("when the company lookup fails", () => {
+  it("fails closed instead of silently running a degraded waterfall", async () => {
+    // A discarded error here nulls the domain, which gates the org pattern,
+    // the paid finder, the inferred pattern and the blind guess: the whole
+    // waterfall silently degrades to a domainless Exa query, and "Could not
+    // find an email address." is presented as a clean answer for a contact
+    // whose org has a perfectly good domain.
+    seed();
+    tableErrors.organizations = { message: "connection reset by peer" };
+
+    const result = await findEmailForPerson("p1");
+
+    expect(result.email).toBeNull();
+    expect(result.reason).toContain("connection reset");
+    expect(result.reason).toMatch(/retry/i);
+    // and nothing was written to the row off the degraded run
+    expect(row().work_email).toBeNull();
+  });
+});
+
+describe("recordNegatives freshness", () => {
+  it("merges rejections against the row's current data, not the opening snapshot", async () => {
+    // The negatives write used to spread a snapshot taken at the top of
+    // findEmailForPerson -- before the Exa search and up to three provider
+    // verifications, a multi-second window. Any enrichment merged in that
+    // window was silently clobbered by the stale spread.
+    seed();
+    provider.findEmail.mockResolvedValue({
+      email: "j.doe@acme.com",
+      confidence: 0.9,
+    });
+    provider.verifyEmail.mockImplementation(async (email: string) => {
+      if (email === "j.doe@acme.com") {
+        // A concurrent enrichment run lands while we are verifying.
+        row().enrichment_data = { linkedin: { posts: [] } };
+        return { status: "undeliverable", catchAll: false };
+      }
+      return { status: "deliverable", catchAll: false };
+    });
+
+    await findEmailForPerson("p1", { verify: true });
+
+    expect(row().work_email).toBe("jane.doe@acme.com");
+    const data = row().enrichment_data as Record<string, unknown>;
+    expect(data.rejectedEmails).toEqual(["j.doe@acme.com"]);
+    // The concurrent write survived the negatives merge.
+    expect(data.linkedin).toEqual({ posts: [] });
   });
 });

--- a/src/__tests__/enrich-contact-summary.test.ts
+++ b/src/__tests__/enrich-contact-summary.test.ts
@@ -117,6 +117,21 @@ vi.mock("@/lib/supabase/server", () => ({
   ),
 }));
 
+/**
+ * The ownership gate. `people` is a shared pool and enrichContactById writes
+ * to it, so it carries the same session + callerHoldsPerson test as every
+ * sibling path.
+ */
+let sessionPresent = true;
+let callerHolds = true;
+vi.mock("@/lib/tools/ownership", () => ({
+  toolSession: vi.fn(async () =>
+    sessionPresent ? { supabase: {}, userId: "u1" } : null,
+  ),
+  callerHoldsPerson: vi.fn(async () => callerHolds),
+  notFound: (what: string) => ({ error: `${what} not found.` }),
+}));
+
 import {
   enrichContact,
   summarizeContactEnrichment,
@@ -124,6 +139,8 @@ import {
 
 beforeEach(() => {
   seed();
+  sessionPresent = true;
+  callerHolds = true;
 });
 
 describe("summarizeContactEnrichment", () => {
@@ -241,5 +258,29 @@ describe("title write-back", () => {
     await enrichContact.execute!({ contactId: PERSON_ID }, {} as never);
 
     expect(bioUpdate()?.title).toBe("Product Support");
+  });
+});
+
+describe("ownership", () => {
+  it("refuses without an authenticated session", async () => {
+    // enrichContactById writes to the shared people pool and can mint a
+    // company-domain email via findEmailForPerson, so it carries the same
+    // gate as /api/find-email and the sibling tools.
+    sessionPresent = false;
+
+    await expect(
+      enrichContact.execute!({ contactId: PERSON_ID }, {} as never),
+    ).rejects.toThrow(/sign in/i);
+  });
+
+  it("refuses a person the caller does not hold, worded as absence", async () => {
+    callerHolds = false;
+    updates.length = 0;
+
+    await expect(
+      enrichContact.execute!({ contactId: PERSON_ID }, {} as never),
+    ).rejects.toThrow(/No person found/);
+    // and nothing was written to the row
+    expect(updates).toHaveLength(0);
   });
 });

--- a/src/__tests__/findemails-batch.test.ts
+++ b/src/__tests__/findemails-batch.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * findEmails' batch pre-checks. The affiliation-confidence query is what
+ * stands between "an error happened" and a fabricated data-quality verdict:
+ * with an empty confidence map every id falls below the send threshold and
+ * the tool reports "N skipped: not confirmed to work at this company", which
+ * the agent relays to the user as fact.
+ */
+
+let selectError: { message: string } | null = null;
+
+const fakeSupabase = {
+  from: () => {
+    const c: Record<string, unknown> & PromiseLike<unknown> = {
+      select: () => c,
+      in: () => c,
+      then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+        Promise.resolve(
+          selectError
+            ? { data: null, error: selectError }
+            : { data: [], error: null },
+        ).then(onF, onR),
+    } as unknown as Record<string, unknown> & PromiseLike<unknown>;
+    return c;
+  },
+};
+
+vi.mock("@/lib/tools/ownership", () => ({
+  toolSession: async () => ({ supabase: fakeSupabase, userId: "u1" }),
+  callerHoldsPerson: async () => true,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => fakeSupabase,
+}));
+
+import { findEmails } from "@/lib/tools/email-tools";
+
+type FindEmailsResult = {
+  found: unknown[];
+  notFound: string[];
+  skipped: string[];
+  summary: string;
+};
+
+const run = (personIds: string[]) =>
+  (
+    findEmails as unknown as {
+      execute: (input: { personIds: string[] }) => Promise<FindEmailsResult>;
+    }
+  ).execute({ personIds });
+
+beforeEach(() => {
+  selectError = null;
+});
+
+describe("findEmails when the affiliation check fails", () => {
+  it("reports the failure instead of fabricating a skip explanation", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    selectError = { message: "connection reset by peer" };
+
+    const result = await run(["11111111-1111-1111-1111-111111111111"]);
+
+    expect(result.summary).toContain("connection reset");
+    expect(result.summary).toMatch(/retry/i);
+    expect(result.summary).not.toMatch(/not confirmed to work/);
+    expect(result.found).toEqual([]);
+    expect(result.notFound).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    quiet.mockRestore();
+  });
+
+  it("still skips genuinely unconfirmed contacts when the query works", async () => {
+    // data: [] means the ids resolved to no rows: unconfirmed, the safe way
+    // round, and honestly described.
+    const result = await run(["11111111-1111-1111-1111-111111111111"]);
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.summary).toMatch(/not confirmed to work/);
+  });
+});

--- a/src/__tests__/person-location-capture.test.ts
+++ b/src/__tests__/person-location-capture.test.ts
@@ -101,6 +101,14 @@ vi.mock("@/lib/supabase/server", () => ({
   ),
 }));
 
+// enrichContact now carries the same ownership gate as its siblings; this
+// suite is about location write-back, so the caller always holds the person.
+vi.mock("@/lib/tools/ownership", () => ({
+  toolSession: vi.fn(async () => ({ supabase: {}, userId: "u1" })),
+  callerHoldsPerson: vi.fn(async () => true),
+  notFound: (what: string) => ({ error: `${what} not found.` }),
+}));
+
 import { findOrCreatePerson } from "@/lib/services/knowledge-base";
 import { enrichContact } from "@/lib/tools/enrichment-tools";
 

--- a/src/app/api/email/record-verified/route.ts
+++ b/src/app/api/email/record-verified/route.ts
@@ -51,11 +51,22 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  await recordVerifiedEmail(supabase, {
+  const result = await recordVerifiedEmail(supabase, {
     personId,
     email,
     source: "user_entered",
   });
 
-  return NextResponse.json({ ok: true });
+  // A database failure is a 500 the client can retry. A semantic skip (role
+  // prefix, weaker source) is not an error, but reporting bare ok:true for it
+  // told the UI a user-confirmed address was recorded when nothing was.
+  if (result.error) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    recorded: result.recorded,
+    ...(result.reason ? { reason: result.reason } : {}),
+  });
 }

--- a/src/lib/services/email-pattern.ts
+++ b/src/lib/services/email-pattern.ts
@@ -369,17 +369,26 @@ export async function recordVerifiedEmail(
     email: string;
     source: Exclude<EmailSource, "pattern_derived">;
   },
-): Promise<void> {
+  // Reports what happened rather than resolving void: every early return here
+  // used to be indistinguishable from success, so the record-verified route
+  // answered ok:true while a user-confirmed address was silently dropped.
+  // `reason` is a semantic skip (nothing failed); `error` is a failure the
+  // caller should surface.
+): Promise<{ recorded: boolean; reason?: string; error?: string }> {
   const { personId, email, source } = args;
   const local = localPart(email);
   if (isRolePrefix(local)) {
     console.warn(
       `[recordVerifiedEmail] skipping role-prefix address for person ${personId}: ${email}`,
     );
-    return;
+    return {
+      recorded: false,
+      reason:
+        "role-prefix address (info@, sales@, ...): not recorded as a personal work email",
+    };
   }
 
-  const { data: person } = await supabase
+  const { data: person, error: readError } = await supabase
     .from("people")
     .select(
       "organization_id, work_email, work_email_source, work_email_confidence",
@@ -387,7 +396,13 @@ export async function recordVerifiedEmail(
     .eq("id", personId)
     .maybeSingle();
 
-  if (!person) return;
+  if (readError) {
+    console.error(
+      `[recordVerifiedEmail] person lookup failed for ${personId}: ${readError.message}`,
+    );
+    return { recorded: false, error: readError.message };
+  }
+  if (!person) return { recorded: false, reason: "person_not_found" };
 
   const newEmail = email.toLowerCase();
   const sameEmail = person.work_email?.toLowerCase() === newEmail;
@@ -405,10 +420,13 @@ export async function recordVerifiedEmail(
       finalSource = existingSource;
     }
   } else if (incomingWeight < existingWeight) {
-    return;
+    return {
+      recorded: false,
+      reason: `kept the existing address: its source (${existingSource}) outranks ${source}`,
+    };
   }
 
-  await supabase
+  const { error: writeError } = await supabase
     .from("people")
     .update({
       work_email: newEmail,
@@ -427,9 +445,18 @@ export async function recordVerifiedEmail(
     })
     .eq("id", personId);
 
+  if (writeError) {
+    console.error(
+      `[recordVerifiedEmail] write failed for ${personId}: ${writeError.message}`,
+    );
+    return { recorded: false, error: writeError.message };
+  }
+
   if (person.organization_id) {
     await recomputeOrgPattern(supabase, person.organization_id);
   }
+
+  return { recorded: true };
 }
 
 /**

--- a/src/lib/tools/email-tools.ts
+++ b/src/lib/tools/email-tools.ts
@@ -181,11 +181,26 @@ export async function findEmailForPerson(
   let domain: string | null = null;
   let orgIsCatchAll: boolean | null = null;
   if (person.organization_id) {
-    const { data: org } = await supabase
+    const { data: org, error: orgError } = await supabase
       .from("organizations")
       .select("domain, name, is_catch_all")
       .eq("id", person.organization_id)
       .single();
+    // A discarded error here nulls the domain, which gates the org pattern,
+    // the paid finder, the inferred pattern and the blind guess: the whole
+    // waterfall silently degrades to a domainless Exa query, and "not found"
+    // is presented as a clean answer for a contact whose org has a perfectly
+    // good domain. Fail closed and say it is retryable.
+    if (orgError) {
+      console.error(
+        `[findEmail] company lookup failed for person ${personId}: ${orgError.message}`,
+      );
+      return {
+        email: null,
+        reason: `Could not load the contact's company (${orgError.message}), so the email search was not run. Retry.`,
+        personId,
+      };
+    }
     domain = org?.domain ?? null;
     orgIsCatchAll = org?.is_catch_all ?? null;
   }
@@ -406,12 +421,7 @@ export async function findEmailForPerson(
         verification: "deliverable",
         verifiedBy: provider.id,
       });
-      await recordNegatives(
-        supabase,
-        personId,
-        person.enrichment_data,
-        rejected,
-      );
+      await recordNegatives(supabase, personId, rejected);
       // A confirmed address is also pattern evidence for everyone else at the
       // org — this is what finally bootstraps the pattern flywheel, which
       // cannot start from guesses alone.
@@ -446,7 +456,7 @@ export async function findEmailForPerson(
     if (!fallback) fallback = { candidate, result };
   }
 
-  await recordNegatives(supabase, personId, person.enrichment_data, rejected);
+  await recordNegatives(supabase, personId, rejected);
 
   if (!fallback) {
     // If the address we already held is among the rejected, do not leave it
@@ -574,18 +584,35 @@ function hasPositiveEvidence(
  * the same thing twice. Written straight to enrichment_data rather than via
  * mergeEnrichmentData because that helper also flips enrichment_status to
  * "enriched", which a failed email lookup has not earned.
+ *
+ * Reads the row fresh rather than accepting a snapshot: the caller's copy of
+ * enrichment_data predates the Exa search and up to three provider
+ * verifications, a multi-second window, and spreading a stale base silently
+ * clobbered anything a concurrent enrichment run merged in the meantime.
  */
 async function recordNegatives(
   supabase: Awaited<ReturnType<typeof createClient>>,
   personId: string,
-  existing: unknown,
   rejected: string[],
 ): Promise<void> {
   if (rejected.length === 0) return;
-  const base = (existing as Record<string, unknown>) ?? {};
+  const { data: fresh, error: readError } = await supabase
+    .from("people")
+    .select("enrichment_data")
+    .eq("id", personId)
+    .single();
+  if (readError) {
+    // Best-effort cache: losing it costs a repeat verification later, while
+    // writing over an unreadable row could cost real enrichment data.
+    console.error(
+      `[findEmail] could not read enrichment before recording negatives for ${personId}: ${readError.message}`,
+    );
+    return;
+  }
+  const base = (fresh?.enrichment_data as Record<string, unknown>) ?? {};
   const priorRaw = base.rejectedEmails;
   const prior = Array.isArray(priorRaw) ? (priorRaw as string[]) : [];
-  await supabase
+  const { error: writeError } = await supabase
     .from("people")
     .update({
       enrichment_data: {
@@ -594,6 +621,11 @@ async function recordNegatives(
       },
     })
     .eq("id", personId);
+  if (writeError) {
+    console.error(
+      `[findEmail] could not record rejected addresses for ${personId}: ${writeError.message}`,
+    );
+  }
 }
 
 /** Scrapes candidate addresses for a person out of Exa result text. */
@@ -724,13 +756,13 @@ export const findEmail = tool({
 
 export const findEmails = tool({
   description:
-    "Batch-discover email addresses for multiple contacts. Skips contacts that already have emails, and contacts not confirmed to work at their company. Returns found, not-found and skipped lists.",
+    "Batch-discover email addresses for multiple contacts. Returns found, not-found and skipped lists. Contacts with a stored address are returned in found with their existing source, not newly discovered. Contacts not confirmed to work at their company are skipped. Discovery is free: it stores unverified suggestions, and verification is paid for just-in-time when a draft is actually sent.",
   inputSchema: z.object({
     personIds: z
       .array(z.string().uuid())
       .max(25)
       .describe(
-        "Array of person IDs (max 25 per call). Each unresolved contact can cost a provider find plus up to 3 verifications, so batch size is a spend bound. Call again for the next batch.",
+        "Array of person IDs (max 25 per call). Call again for the next batch.",
       ),
   }),
   execute: async ({ personIds }) => {
@@ -747,10 +779,26 @@ export const findEmails = tool({
     }
     const { supabase, userId } = session;
 
-    const { data: rows } = await supabase
+    const { data: rows, error: rowsError } = await supabase
       .from("people")
       .select("id, affiliation_confidence")
       .in("id", personIds);
+
+    // On a failed query the confidence map is empty, so every contact would
+    // fall below the send threshold and land in `skipped` under a fabricated
+    // "not confirmed to work at this company" explanation, which the agent
+    // then relays to the user as a confident data-quality verdict.
+    if (rowsError) {
+      console.error(
+        `[findEmails] affiliation lookup failed: ${rowsError.message}`,
+      );
+      return {
+        found: [],
+        notFound: [],
+        skipped: [],
+        summary: `Could not check which contacts are confirmed at their company (${rowsError.message}). No lookups were run: retry the call.`,
+      };
+    }
 
     const confidence = new Map<string, number | null>(
       (
@@ -761,7 +809,10 @@ export const findEmails = tool({
       ).map((r) => [r.id, r.affiliation_confidence]),
     );
 
-    const found: Array<{ personId: string; email: string }> = [];
+    // `source` says where each address came from: "existing"/stored sources
+    // mean the contact already had it, so "Found N of M" is not N discoveries.
+    const found: Array<{ personId: string; email: string; source?: string }> =
+      [];
     const notFound: string[] = [];
     const skipped: string[] = [];
 
@@ -787,7 +838,7 @@ export const findEmails = tool({
       try {
         const result = await findEmailForPerson(personId);
         if (result.email) {
-          found.push({ personId, email: result.email });
+          found.push({ personId, email: result.email, source: result.source });
         } else {
           notFound.push(personId);
         }

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -510,6 +510,25 @@ async function enrichContactById(
     personId = link.person_id;
   }
 
+  // Ownership, same test as every sibling path into this code. `people` is a
+  // shared pool, and this function writes to it (enrichment_data, title,
+  // discoveredEmail via findEmailForPerson): without the gate, any user could
+  // enrich, and mint a company-domain address for, any person UUID on the
+  // instance. Worded as absence rather than refusal so the error does not
+  // confirm which guessed UUIDs are real contacts.
+  const session = await toolSession();
+  if (!session) {
+    throw new Error(
+      "No authenticated session available in tool context. Ask the user to sign in.",
+    );
+  }
+  if (!(await callerHoldsPerson(session.supabase, session.userId, personId))) {
+    throw new Error(
+      `No person found for ID ${personId}. Pass the person ID ` +
+        `(people.id, the person_id field on getContacts rows), not a campaign-people link ID.`,
+    );
+  }
+
   // Check recency -- skip if recently enriched
   const recent = await isRecentlyEnriched("people", personId);
   if (recent) {


### PR DESCRIPTION
Wave-6 cluster (PR-14 of the hardening plan): 6 verified findings in the email discovery waterfall. The lazy-verification owner decision (discovery stores free unchecked suggestions; Hunter is billed just-in-time in claimAndSendDraft) is deliberately preserved: nothing here adds a paid call.

## findEmailForPerson
- The organizations lookup discarded its error, so a transient DB failure nulled `domain`, which gates the org pattern, the paid finder, the inferred pattern and the blind guess: the entire waterfall silently degraded to a domainless Exa query and returned "Could not find an email address." as a clean answer for a contact whose org has a perfectly good domain. Now fails closed with a retryable error.
- `recordNegatives` spread an `enrichment_data` snapshot taken at the top of the function, before the Exa search plus up to three provider verifications (a multi-second window), then wrote the whole column: any enrichment merged concurrently was silently clobbered (and in the reverse interleaving, the negatives cache was lost, so the next revalidate paid to be told the same address is dead). It now re-reads the row immediately before writing and surfaces both legs' errors.

## findEmails (batch)
- The affiliation-confidence query's error was discarded: on failure the confidence map was empty, every id fell below the send threshold, and the tool reported "N skipped: not confirmed to work at this company, so a company-domain guess would be misleading", a fabricated data-quality verdict the agent relayed to the user as fact. Now returns an explicit retryable error with nothing run.
- The tool description claimed it "skips contacts that already have emails" (they are returned in `found`) and that each contact "can cost a provider find plus up to 3 verifications" (batch discovery never bills; verify is never passed). Both false claims removed; `found` entries now carry their `source` so stored addresses are distinguishable from discoveries.

## recordVerifiedEmail + /api/email/record-verified
- `recordVerifiedEmail` resolved void, so its role-prefix skip, missing-person return, weaker-source skip, and its people.update failure were all indistinguishable from success; the route answered `ok:true` unconditionally, so a user typing a confirmed address (deterministically for e.g. `info@acme.com`) saw it recorded while nothing was, and the org pattern never recomputed. It now returns `{recorded, reason?, error?}`; the route answers 500 on db failure and `{ok, recorded, reason}` on semantic skips.

## enrichContactById (security)
- Called `findEmailForPerson` (and performed all its people writes) with no ownership gate, unlike every sibling path (`findEmail`/`findEmails` tools, `/api/find-email`, `/api/enrich`, `getContactDetail`): in a multi-user deployment any user could enrich, and mint a plausible company-domain address for, any person UUID in the shared pool. Now carries the same `toolSession` + `callerHoldsPerson` test, worded as absence so it does not confirm which guessed UUIDs are real.

## Test infrastructure
The waterfall fake now returns detached row copies the way PostgREST does: returning live references made every "snapshot" in production code secretly current, which is precisely what hid the recordNegatives staleness bug.

Suite: 931 passed (12 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)