### PR TITLE
fix(org): identity and merge integrity

### DIFF
--- a/src/__tests__/company-website-route.test.ts
+++ b/src/__tests__/company-website-route.test.ts
@@ -95,6 +95,32 @@ vi.mock("@/lib/supabase/server", () => {
   };
 });
 
+/**
+ * The admin client, sharing the same fixture tables. The merge's emptiness
+ * check and final delete run through it: the orgs_delete RLS policy requires
+ * a campaign link the merge has just moved away, so the user-scoped delete
+ * matched zero rows on every install. Deletes are recorded so a test can
+ * assert which client performed them.
+ */
+const adminOps: Array<{ kind: string; table: string }> = [];
+vi.mock("@/lib/supabase/admin", () => ({
+  getAdminClient: () =>
+    createSupabaseFake({
+      tables: {
+        organizations: () => state.organizations,
+        campaign_organizations: () => state.campaign_organizations,
+        campaign_people: () => state.campaign_people,
+        people: () => state.people,
+        signal_results: () => state.signal_results,
+        tracking_configs: () => state.tracking_configs,
+      },
+      onQuery: (q) => {
+        if (q.kind !== "select")
+          adminOps.push({ kind: q.kind, table: q.table });
+      },
+    }),
+}));
+
 import { PATCH } from "@/app/api/companies/[id]/website/route";
 
 function patch(body: Record<string, unknown>, id = ORG) {
@@ -129,6 +155,7 @@ beforeEach(() => {
   state.tracking_configs = [];
   state.failWritesOn = null;
   state.mutating = null;
+  adminOps.length = 0;
 });
 
 /** The organization row as it stands now, so writes are observable. */
@@ -297,5 +324,43 @@ describe("PATCH /api/companies/[id]/website", () => {
       expect(state.people[0].organization_id).toBe(ORG);
       expect(org(ORG)).toBeDefined();
     });
+  });
+});
+
+describe("the merge's final delete", () => {
+  it("runs through the admin client, which is the only one that can do it", async () => {
+    // The orgs_delete policy requires a campaign_organizations link from the
+    // caller's campaign to the row, and the merge has just moved every such
+    // link to the twin: the user-scoped DELETE matched zero rows and returned
+    // no error, so every merge on every install left an orphaned domain-less
+    // duplicate and reported "The old entry was kept: 0 row(s) still point at
+    // it."
+    state.organizations.push({
+      id: TWIN,
+      name: "Cedar Lodge Nursing Home",
+      domain: "cedarlodge.co.uk",
+      url: "https://cedarlodge.co.uk",
+    });
+    resolveOrganizationDomain.mockResolvedValue({
+      domain: "cedarlodge.co.uk",
+      url: "https://cedarlodge.co.uk",
+      source: "google_places",
+      evidence: "Google Places lists Cedar Lodge Nursing Home",
+    });
+
+    const res = await patch({ resolve: true });
+    const body = (await res.json()) as {
+      merged?: boolean;
+      deletedOld?: boolean;
+    };
+
+    expect(body.merged).toBe(true);
+    expect(body.deletedOld).toBe(true);
+    expect(org(ORG)).toBeUndefined();
+    expect(
+      adminOps.filter(
+        (op) => op.kind === "delete" && op.table === "organizations",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/src/__tests__/domain-resolver.test.ts
+++ b/src/__tests__/domain-resolver.test.ts
@@ -169,3 +169,38 @@ describe("resolveOrganizationDomain", () => {
     expect(await resolveOrganizationDomain(CARE_HOME)).toBeNull();
   });
 });
+
+describe("site-builder apexes", () => {
+  it("refuses a platform apex that Places returned as the website", async () => {
+    // https://cedarlodge.business.site normalizes to the builder's apex: the
+    // sub-label that identified the business is already gone. Storing
+    // "business.site" as this company's domain dedupes every business hosted
+    // on the builder into one org, and the twin-merge then repoints one
+    // company's people onto an unrelated company.
+    getPlaceReviews.mockResolvedValue(
+      placesHit("Cedar Lodge Nursing Home", "https://cedarlodge.business.site"),
+    );
+
+    const resolved = await resolveOrganizationDomain(CARE_HOME);
+
+    expect(resolved).toBeNull();
+  });
+
+  it("refuses a platform apex from the Exa fallback too", async () => {
+    // business.site is NOT on the PSL private section, so the sub-label
+    // collapses away during normalization; a builder that IS on it (like
+    // wixsite.com) keeps its identifying sub-label and is fine to store.
+    search.mockResolvedValue(
+      exaResults([
+        {
+          url: "https://cedarlodge.business.site/about",
+          title: "Cedar Lodge Nursing Home | Birmingham",
+        },
+      ]),
+    );
+
+    const resolved = await resolveOrganizationDomain(CARE_HOME);
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/src/__tests__/find-contacts-route.test.ts
+++ b/src/__tests__/find-contacts-route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSupabaseFake, type FakeRow } from "./helpers/supabase-fake";
+
+/**
+ * POST /api/find-contacts takes a campaign_organizations link id AND a
+ * campaignId, and each passes its own ownership check. The pair still has to
+ * agree: for a caller who owns both campaigns, a link from campaign A with
+ * campaignId B would write campaign_people rows into a campaign that has no
+ * campaign_organizations row for the org, contacts invisible in its UI.
+ */
+
+const findContactsForOrganization = vi.fn();
+vi.mock("@/lib/services/contact-discovery", () => ({
+  findContactsForOrganization: (...args: unknown[]) =>
+    (findContactsForOrganization as unknown as (...a: unknown[]) => unknown)(
+      ...args,
+    ),
+}));
+
+vi.mock("@/lib/services/cost-tracker", () => ({
+  withAction: (_label: string, fn: () => Promise<unknown>) => fn(),
+}));
+
+const CAMPAIGN_A = "campaign-a";
+const CAMPAIGN_B = "campaign-b";
+const LINK_A = "link-a";
+
+let campaigns: FakeRow[] = [];
+let links: FakeRow[] = [];
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAndUser: vi.fn(async () => ({
+    supabase: createSupabaseFake({
+      tables: {
+        campaigns: () => campaigns,
+        campaign_organizations: () => links,
+        organizations: () => [
+          {
+            id: "org-1",
+            name: "Acme",
+            domain: "acme.com",
+            industry: null,
+            location: null,
+            description: null,
+          },
+        ],
+      },
+      relations: {
+        campaign_organizations: {
+          organization: { localKey: "organization_id" },
+        },
+      },
+    }),
+    user: { id: "user-1", email: "u@example.com" },
+  })),
+}));
+
+import { POST } from "@/app/api/find-contacts/route";
+
+function post(body: Record<string, unknown>) {
+  return POST(
+    new Request("http://test/api/find-contacts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+beforeEach(() => {
+  findContactsForOrganization.mockReset().mockResolvedValue({
+    organizationId: "org-1",
+    companyName: "Acme",
+    contacts: [],
+    alreadyLinked: [],
+    alreadyLinkedTotal: 0,
+    searchesRun: [],
+    totalFound: 0,
+    duplicatesSkipped: 0,
+    verifiedCount: 0,
+    uncertainCount: 0,
+    rejectedAsWrongCompany: 0,
+    departedCount: 0,
+    affiliationUnchanged: 0,
+  });
+  campaigns = [
+    { id: CAMPAIGN_A, user_id: "user-1", icp: null },
+    { id: CAMPAIGN_B, user_id: "user-1", icp: null },
+  ];
+  links = [{ id: LINK_A, campaign_id: CAMPAIGN_A, organization_id: "org-1" }];
+});
+
+describe("POST /api/find-contacts", () => {
+  it("runs discovery for a link that belongs to the named campaign", async () => {
+    const res = await post({ companyId: LINK_A, campaignId: CAMPAIGN_A });
+
+    expect(res.status).toBe(200);
+    expect(findContactsForOrganization).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a link from a different campaign, even one the caller owns", async () => {
+    const res = await post({ companyId: LINK_A, campaignId: CAMPAIGN_B });
+
+    expect(res.status).toBe(404);
+    expect(findContactsForOrganization).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/google-places-service.test.ts
+++ b/src/__tests__/google-places-service.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The domain cross-check. A Places text search matches on the name, so "Apex"
+ * routinely returns "Apex Gym": the caller passes the org's domain precisely
+ * so a namesake's rating and reviews cannot be filed under the target company
+ * and cited in outreach as its own customers.
+ */
+
+vi.mock("@/lib/services/cost-tracker", () => ({
+  trackUsage: vi.fn(),
+  PRICING: { google_places_search: 0.032 },
+}));
+
+import { GooglePlacesService } from "@/lib/services/google-places-service";
+import { trackUsage } from "@/lib/services/cost-tracker";
+
+const fetchMock = vi.fn();
+
+function placesResponse(places: unknown[]) {
+  return {
+    ok: true,
+    json: async () => ({ places }),
+  };
+}
+
+const gymPlace = {
+  id: "place-1",
+  displayName: { text: "Apex Gym" },
+  websiteUri: "https://www.apexgym.com",
+  rating: 4.8,
+  userRatingCount: 120,
+  formattedAddress: "1 High St",
+  googleMapsUri: "https://maps.google.com/x",
+  reviews: [],
+};
+
+beforeEach(() => {
+  vi.stubEnv("GOOGLE_API_KEY", "test-key");
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  vi.mocked(trackUsage).mockClear();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("getPlaceReviews domain cross-check", () => {
+  it("discards a match whose website is a different company", async () => {
+    fetchMock.mockResolvedValue(placesResponse([gymPlace]));
+
+    const result = await new GooglePlacesService().getPlaceReviews(
+      "Apex",
+      undefined,
+      "apex.io",
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.rating).toBeNull();
+    expect(result.reviews).toEqual([]);
+    expect(result.error).toMatch(/different business/);
+  });
+
+  it("keeps a match whose website agrees", async () => {
+    fetchMock.mockResolvedValue(placesResponse([gymPlace]));
+
+    const result = await new GooglePlacesService().getPlaceReviews(
+      "Apex Gym",
+      undefined,
+      "apexgym.com",
+    );
+
+    expect(result.found).toBe(true);
+    expect(result.rating).toBe(4.8);
+  });
+});
+
+describe("getPlaceReviews cost tracking", () => {
+  it("tracks a zero-result search: Google bills it anyway", async () => {
+    fetchMock.mockResolvedValue(placesResponse([]));
+
+    await new GooglePlacesService().getPlaceReviews("Nowhere Ltd");
+
+    expect(trackUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks a non-OK response", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => "quota",
+    });
+
+    await new GooglePlacesService().getPlaceReviews("Anyone");
+
+    expect(trackUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks a mismatched match", async () => {
+    fetchMock.mockResolvedValue(placesResponse([gymPlace]));
+
+    await new GooglePlacesService().getPlaceReviews(
+      "Apex",
+      undefined,
+      "apex.io",
+    );
+
+    expect(trackUsage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/enrich-company/route.ts
+++ b/src/app/api/enrich-company/route.ts
@@ -102,11 +102,6 @@ export async function POST(request: Request) {
     }
   }
 
-  // Resolve active signal slugs for this campaign
-  const activeSlugs = campaignId
-    ? await getActiveSignalSlugs(campaignId)
-    : null; // null = run all (no campaign context)
-
   // companyId is a campaign_organizations link ID -- resolve the organization.
   // Join through campaigns.user_id so we can also verify ownership when
   // campaignId wasn't explicitly supplied.
@@ -148,12 +143,22 @@ export async function POST(request: Request) {
   const org = link.organization as unknown as Record<string, unknown>;
   const orgId = link.organization_id;
 
+  // When the body carried no campaignId, the link's parent campaign IS the
+  // campaign context: the comment above always promised this derivation, but
+  // link.campaign_id was fetched and never used, so callers without an
+  // explicit campaignId ran all four signal searches (spending Exa/Places on
+  // signals the campaign disabled) and skipped contact discovery entirely.
+  const effectiveCampaignId = campaignId ?? (link.campaign_id as string);
+  const activeSlugs = effectiveCampaignId
+    ? await getActiveSignalSlugs(effectiveCampaignId)
+    : null; // null = run all (no campaign context)
+
   return enrichOrganization(
     org,
     orgId,
     activeSlugs,
     user.id,
-    campaignId,
+    effectiveCampaignId,
     companyId,
   );
 }

--- a/src/app/api/find-contacts/route.ts
+++ b/src/app/api/find-contacts/route.ts
@@ -53,12 +53,21 @@ export async function POST(request: Request) {
   const { data: link, error: linkError } = await supabase
     .from("campaign_organizations")
     .select(
-      "organization_id, organization:organizations(name, domain, industry, location, description)",
+      "organization_id, campaign_id, organization:organizations(name, domain, industry, location, description)",
     )
     .eq("id", companyId)
     .single();
 
   if (linkError || !link) {
+    return Response.json({ error: "Company not found" }, { status: 404 });
+  }
+
+  // The link has to belong to the campaign the caller named. Both ownership
+  // checks can pass individually for a caller who owns two campaigns, and a
+  // mismatched pair then writes campaign_people rows into a campaign with no
+  // campaign_organizations row for that org: contacts found inside a campaign
+  // and invisible in its UI, the exact dead-end find-more-people closed.
+  if (link.campaign_id !== campaignId) {
     return Response.json({ error: "Company not found" }, { status: 404 });
   }
 

--- a/src/lib/services/domain-resolver.ts
+++ b/src/lib/services/domain-resolver.ts
@@ -1,6 +1,9 @@
 import { ExaService } from "@/lib/services/exa-service";
 import { GooglePlacesService } from "@/lib/services/google-places-service";
-import { isDirectoryDomain } from "@/lib/services/directory-domains";
+import {
+  isDirectoryDomain,
+  isPlatformDomain,
+} from "@/lib/services/directory-domains";
 import { normalizeDomain } from "@/lib/services/knowledge-base";
 
 /**
@@ -96,7 +99,15 @@ function usableDomain(rawUrl: string): string | null {
     return null;
   }
   const domain = normalizeDomain(host);
-  if (!domain || isDirectoryDomain(domain)) return null;
+  // A site-builder apex (business.site, wixsite.com, ...) is not one
+  // company's own domain: the sub-label that identified the business is
+  // already gone by the time normalizeDomain collapses it. Returning one
+  // here dedupes every business hosted on that builder into a single org,
+  // which is the merge disaster PLATFORM_DOMAINS exists to prevent, and
+  // both resolver call paths bypass the manual-URL path's guard.
+  if (!domain || isDirectoryDomain(domain) || isPlatformDomain(domain)) {
+    return null;
+  }
   return domain;
 }
 

--- a/src/lib/services/google-places-service.ts
+++ b/src/lib/services/google-places-service.ts
@@ -74,9 +74,18 @@ export class GooglePlacesService {
         `Google Places search for "${textQuery}"`,
       );
 
+      // Google bills Text Search per request, whatever comes back. Tracking
+      // only the found-with-results path made the cost dashboard understate
+      // Places spend by the entire miss rate.
       if (!res.ok) {
         const body = await res.text();
         console.error(`[GooglePlaces] API error ${res.status}: ${body}`);
+        trackUsage({
+          service: "google",
+          operation: "places-search",
+          estimated_cost_usd: PRICING.google_places_search,
+          metadata: { textQuery, httpStatus: res.status },
+        });
         return {
           found: false,
           placeId: null,
@@ -96,6 +105,12 @@ export class GooglePlacesService {
 
       if (!places || places.length === 0) {
         console.log(`[GooglePlaces] No results for "${textQuery}"`);
+        trackUsage({
+          service: "google",
+          operation: "places-search",
+          estimated_cost_usd: PRICING.google_places_search,
+          metadata: { textQuery, found: false },
+        });
         return {
           found: false,
           placeId: null,
@@ -120,9 +135,32 @@ export class GooglePlacesService {
           const placeHost = new URL(websiteUri).hostname.replace(/^www\./, "");
           const targetHost = domain.replace(/^www\./, "");
           if (placeHost !== targetHost) {
+            // A mismatch means the matched Place is a different business (an
+            // "Apex Gym" for "Apex"). Proceeding anyway stored the wrong
+            // company's rating and reviews under the target org, and drafting
+            // then cited a namesake's customers as outreach hooks. The caller
+            // asked for cross-verification by passing the domain; honor it.
             console.log(
-              `[GooglePlaces] Domain mismatch: place=${placeHost}, target=${targetHost} (proceeding anyway)`,
+              `[GooglePlaces] Domain mismatch: place=${placeHost}, target=${targetHost}. Discarding the match.`,
             );
+            trackUsage({
+              service: "google",
+              operation: "places-search",
+              estimated_cost_usd: PRICING.google_places_search,
+              metadata: { textQuery, domainMismatch: true, placeHost },
+            });
+            return {
+              found: false,
+              placeId: null,
+              displayName: null,
+              rating: null,
+              userRatingCount: 0,
+              formattedAddress: null,
+              googleMapsUri: null,
+              websiteUri: null,
+              reviews: [],
+              error: `Google Places matched a different business (${placeHost}), not ${targetHost}.`,
+            };
           }
         } catch {
           // URL parsing failed, skip check

--- a/src/lib/services/organization-website.ts
+++ b/src/lib/services/organization-website.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/services/directory-domains";
 import { resolveOrganizationDomain } from "@/lib/services/domain-resolver";
 import { normalizeDomain } from "@/lib/services/knowledge-base";
+import { getAdminClient } from "@/lib/supabase/admin";
 
 /**
  * Give a company the website it never had.
@@ -147,9 +148,15 @@ async function mergeOrganizations(
   // Count what is left rather than assume the writes landed. Every one of these
   // tables loses rows, or a contact loses their employer, if the delete runs
   // while something still points here.
+  //
+  // Counted with the ADMIN client, because the emptiness check has to be
+  // global: the caller's RLS view only shows their own campaign links, so
+  // another tenant's link to fromId would be invisible, remaining would read
+  // zero, and the delete below would cascade that tenant's link away.
+  const admin = getAdminClient();
   let remaining = 0;
   for (const table of REFERRING_TABLES) {
-    const { data } = await supabase
+    const { data } = await admin
       .from(table)
       .select("id")
       .eq("organization_id", fromId);
@@ -157,12 +164,17 @@ async function mergeOrganizations(
   }
 
   // Verify the delete rather than infer it. organizations had no DELETE policy
-  // until 20260804000000, so this matched zero rows and returned no error
-  // while the caller reported `deletedOld: true` and a completed merge -- the
-  // old row was still there, still holding the name, on every install.
+  // until 20260804000000, and the policy that migration added can never
+  // authorize THIS delete either: it requires a campaign_organizations link
+  // from the caller's campaign to the row, and the merge has just moved or
+  // dropped every such link. So the RLS-scoped delete matched zero rows and
+  // returned no error on every install, and every merge left an orphaned
+  // domain-less duplicate behind. The admin client is the right authority
+  // here: the caller's right to merge was proven by the RLS-scoped moves
+  // above, and the global remaining-count proves the row is truly unreferenced.
   let deletedOld = false;
   if (remaining === 0) {
-    const { data: deleted } = await supabase
+    const { data: deleted } = await admin
       .from("organizations")
       .delete()
       .eq("id", fromId)

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -1042,7 +1042,11 @@ export const fetchSitemap = tool({
         if (result.success && result.data.links) {
           const sameDomainLinks = result.data.links.filter((link) => {
             try {
-              return new URL(link).hostname.endsWith(domain);
+              // Dot boundary required: bare endsWith let "notacme.com" pass
+              // as "acme.com", so a partner or competitor site linked from
+              // the homepage was scraped as the company's own pages.
+              const host = new URL(link).hostname;
+              return host === domain || host.endsWith(`.${domain}`);
             } catch {
               return false;
             }
@@ -1357,7 +1361,16 @@ async function enrichCompanyById(
   const extractor = new WebExtractionService();
   const errors: string[] = [];
 
-  const companyUrl = org.url || (org.domain ? `https://${org.domain}` : null);
+  // organizations.url is stored verbatim from LLM extraction, so "acme.com"
+  // without a scheme is a routine value. new URL() throws on it, which used
+  // to fail the entire company enrichment with an unactionable "Invalid URL".
+  const storedUrl = (org.url as string | null) || null;
+  const schemedUrl =
+    storedUrl && !/^https?:\/\//i.test(storedUrl)
+      ? `https://${storedUrl}`
+      : storedUrl;
+  const companyUrl =
+    schemedUrl || (org.domain ? `https://${org.domain}` : null);
 
   const contextParts: string[] = [];
   if (org.industry) contextParts.push(org.industry as string);
@@ -1366,8 +1379,16 @@ async function enrichCompanyById(
   const domainHint = org.domain ? ` ${org.domain}` : "";
   const specificName = `"${org.name}"${domainHint}${context}`;
 
-  const companyDomain =
-    org.domain || (companyUrl ? new URL(companyUrl).hostname : null);
+  let companyDomain = (org.domain as string | null) || null;
+  if (!companyDomain && companyUrl) {
+    try {
+      companyDomain = new URL(companyUrl).hostname;
+    } catch {
+      // A malformed stored URL degrades to name-based queries rather than
+      // failing the whole enrichment.
+      companyDomain = null;
+    }
+  }
 
   const productQuery = companyDomain
     ? `${org.name} products services`


### PR DESCRIPTION
Wave-6 cluster (PR-15 of the hardening plan): 8 verified findings around organization identity, dedup and merging. No migration: the merge-delete fix uses the admin client rather than a new RLS policy, per the plan's preference.

## The high one: site-builder apexes as company domains (`domain-resolver.ts:99`)
`usableDomain` rejected directory domains but never checked `isPlatformDomain`, so the resolver could return `business.site` as a company's own domain (a care home's Places `websiteUri` of `cedarlodge.business.site` normalizes to the bare apex: these builders are not on the PSL private section, so the identifying sub-label is gone). Both resolver call paths bypassed the guard the manual-URL path has. Consequences chained: `setCompanyWebsite`'s twin-lookup on `domain='business.site'` finds any other business on that builder and the merge repoints one company's people onto an unrelated company, and `discoverCompanies` dedupes-by-domain files the second business's data onto the first. Small businesses on hosted builders are the stated target ICP. Builders on the PSL private section (`cedarlodge.wixsite.com`) keep their sub-label and are still accepted.

## mergeOrganizations could never delete the old org (`organization-website.ts:167`)
The `orgs_delete` RLS policy requires a `campaign_organizations` link from the caller's campaign to the row, and the merge has just moved or dropped every such link: the DELETE matched zero rows with no error, so every merge on every install left an orphaned domain-less duplicate and reported "The old entry was kept: 0 row(s) still point at it." The emptiness check and delete now run through the admin client. The admin-side count is also the only correct one: the caller's RLS view cannot see another tenant's link to the row, and deleting on a caller-scoped count of zero would cascade that tenant's link away.

## Google Places namesake reviews (`google-places-service.ts:122`, `:147`)
- The domain cross-check logged "Domain mismatch ... (proceeding anyway)" and returned `found:true` with the wrong business's rating and reviews, which `getGoogleReviews` then merged into the org's enrichment and drafting cited as customer sentiment. A mismatch now discards the match with an explicit error. Same namesake-merge class as the known enrichment bug.
- Google bills Text Search per request; tracking only the found-with-results path made the cost dashboard understate Places spend by the entire miss rate. Every executed request is now tracked.

## Route contract gaps
- `/api/enrich-company`: when the body omitted `campaignId`, `link.campaign_id` was fetched and never used despite the comment promising derivation: disabled signal searches still billed and contact discovery was skipped. Now derived.
- `/api/find-contacts`: the link id was never checked to belong to the supplied `campaignId` (both ownership checks pass individually for a caller owning two campaigns); a mismatched pair wrote `campaign_people` rows into a campaign with no `campaign_organizations` row for the org: contacts invisible in that campaign's UI. Now 404s.

## Enrichment input hygiene (`enrichment-tools.ts`)
- Homepage-link filter used bare `endsWith(domain)`, so `notacme.com` passed as `acme.com` and a competitor's pages were scraped as the company's own. Dot boundary added.
- `new URL(org.url)` threw on scheme-less stored URLs (`"acme.com"`, which discoverCompanies stores verbatim from LLM extraction), failing the entire company enrichment with "Invalid URL". Scheme added when missing; hostname derivation degrades instead of throwing.

Suite: 929 passed (10 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)