### PR TITLE
fix(enrichment): lifecycle and ground-truth integrity

### DIFF
--- a/src/__tests__/claim-reconciler.test.ts
+++ b/src/__tests__/claim-reconciler.test.ts
@@ -119,3 +119,76 @@ describe("reconcileClaims", () => {
     expect(out[0].status).toBe("unverified");
   });
 });
+
+describe("reconcileClaims and the shape of the scrape", () => {
+  it("does not contradict when the scrape never found a careers page", () => {
+    // tryScrapeHiringData returns { careersUrl: null, jobs: [] } when no
+    // careers link exists. That is an absence of evidence: treating it as
+    // ground truth marked every true hiring claim contradicted for any
+    // company without a discoverable careers page, and the UI then said
+    // "The live careers page says otherwise" about a page never read.
+    const out = reconcileClaims(
+      [claim({ type: "hiring_role", statement: "Hiring a Growth Director" })],
+      {
+        now: NOW,
+        careers: { careersUrl: null, jobs: [], scrapedAt: NOW.toISOString() },
+      },
+    );
+    expect(out[0].status).toBe("unverified");
+  });
+
+  it("does not contradict when a real page yielded zero jobs", () => {
+    // Stagehand can extract nothing from a JS-heavy page. Zero scraped jobs
+    // cannot distinguish "not hiring" from "could not read the page", so it
+    // must not overrule dated news claims.
+    const out = reconcileClaims(
+      [claim({ type: "hiring_role", statement: "Hiring a Growth Director" })],
+      {
+        now: NOW,
+        careers: {
+          careersUrl: "https://fyxer.com/careers",
+          jobs: [],
+          scrapedAt: NOW.toISOString(),
+        },
+      },
+    );
+    expect(out[0].status).toBe("unverified");
+  });
+
+  it("matches a decorated job title", () => {
+    // The docstring's own example used to fail: neither string contains the
+    // other once both carry extra text.
+    const out = reconcileClaims(
+      [claim({ type: "hiring_role", statement: "Hiring: Growth Director" })],
+      {
+        now: NOW,
+        careers: {
+          careersUrl: "https://fyxer.com/careers",
+          jobs: [{ title: "Growth Director (Remote)" }],
+          scrapedAt: NOW.toISOString(),
+        },
+      },
+    );
+    expect(out[0].status).toBe("verified");
+  });
+
+  it("matches a sentence-form claim against a decorated title", () => {
+    const out = reconcileClaims(
+      [
+        claim({
+          type: "hiring_role",
+          statement: "Fyxer is hiring a Head of Growth",
+        }),
+      ],
+      {
+        now: NOW,
+        careers: {
+          careersUrl: "https://fyxer.com/careers",
+          jobs: [{ title: "Head of Growth (Remote)" }],
+          scrapedAt: NOW.toISOString(),
+        },
+      },
+    );
+    expect(out[0].status).toBe("verified");
+  });
+});

--- a/src/__tests__/enrich-contact-summary.test.ts
+++ b/src/__tests__/enrich-contact-summary.test.ts
@@ -284,3 +284,40 @@ describe("ownership", () => {
     expect(updates).toHaveLength(0);
   });
 });
+
+describe("stuck in_progress recovery", () => {
+  it("re-enriches a row stuck at in_progress instead of skipping it", async () => {
+    // The status is set before the scrape chain; a serverless run killed
+    // mid-scrape leaves it there forever, and the recency skip then returned
+    // status "enriched" for 7 days while the row still said in_progress:
+    // permanent "In Progress" in the UI with no recovery path at all.
+    const { isRecentlyEnriched } =
+      await import("@/lib/services/knowledge-base");
+    vi.mocked(isRecentlyEnriched).mockResolvedValueOnce(true);
+    seed({
+      enrichment_status: "in_progress",
+      work_email: "ann@acme.com",
+    });
+
+    const result = (await enrichContact.execute!(
+      { contactId: PERSON_ID },
+      {} as never,
+    )) as { skipped?: boolean };
+
+    expect(result.skipped).toBeUndefined();
+  });
+
+  it("still skips a recently enriched row in a settled state", async () => {
+    const { isRecentlyEnriched } =
+      await import("@/lib/services/knowledge-base");
+    vi.mocked(isRecentlyEnriched).mockResolvedValueOnce(true);
+    seed({ enrichment_status: "enriched", enrichment_data: {} });
+
+    const result = (await enrichContact.execute!(
+      { contactId: PERSON_ID },
+      {} as never,
+    )) as { skipped?: boolean };
+
+    expect(result.skipped).toBe(true);
+  });
+});

--- a/src/__tests__/score-tools.test.ts
+++ b/src/__tests__/score-tools.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSupabaseFake, type FakeRow } from "./helpers/supabase-fake";
+
+/**
+ * The scoring and status tools take campaign LINK ids, and agents routinely
+ * pass entity ids instead (the file documents it). A 0-row UPDATE returns no
+ * error from Supabase, so these tools reported scores and statuses as stored
+ * while nothing was persisted and prioritization silently never happened.
+ */
+
+let campaignOrgs: FakeRow[] = [];
+let campaignPeople: FakeRow[] = [];
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () =>
+    createSupabaseFake({
+      tables: {
+        campaign_organizations: () => campaignOrgs,
+        campaign_people: () => campaignPeople,
+        people: () => [],
+      },
+    }),
+  ),
+}));
+
+import {
+  scoreCompany,
+  scoreContact,
+  updateCompanyStatus,
+  deleteCompanies,
+} from "@/lib/tools/enrichment-tools";
+
+const LINK_ORG = "11111111-1111-1111-1111-111111111111";
+const LINK_PERSON = "22222222-2222-2222-2222-222222222222";
+const WRONG_ID = "99999999-9999-9999-9999-999999999999";
+
+beforeEach(() => {
+  campaignOrgs = [
+    {
+      id: LINK_ORG,
+      campaign_id: "c1",
+      organization_id: "org-1",
+      status: "discovered",
+    },
+  ];
+  campaignPeople = [{ id: LINK_PERSON, campaign_id: "c1", person_id: "p1" }];
+});
+
+describe("scoreCompany", () => {
+  it("stores the score against the link row", async () => {
+    const result = await scoreCompany.execute!(
+      { companyId: LINK_ORG, score: 8, reason: "strong ICP fit with timing" },
+      {} as never,
+    );
+
+    expect(result).toMatchObject({ score: 8 });
+    expect(campaignOrgs[0].relevance_score).toBe(8);
+  });
+
+  it("refuses an ID that matched nothing instead of claiming success", async () => {
+    await expect(
+      scoreCompany.execute!(
+        { companyId: WRONG_ID, score: 8, reason: "strong ICP fit with timing" },
+        {} as never,
+      ),
+    ).rejects.toThrow(/link ID/);
+    expect(campaignOrgs[0].relevance_score).toBeUndefined();
+  });
+});
+
+describe("scoreContact", () => {
+  it("refuses a person ID passed as a link ID", async () => {
+    await expect(
+      scoreContact.execute!(
+        { contactId: WRONG_ID, score: 7, reason: "recent posts align well" },
+        {} as never,
+      ),
+    ).rejects.toThrow(/campaign-people link ID/);
+  });
+});
+
+describe("updateCompanyStatus", () => {
+  it("reports which IDs matched nothing", async () => {
+    const result = (await updateCompanyStatus.execute!(
+      { companyIds: [LINK_ORG, WRONG_ID], status: "qualified" },
+      {} as never,
+    )) as { updated: number; notFound?: string[] };
+
+    expect(result.updated).toBe(1);
+    expect(result.notFound).toEqual([WRONG_ID]);
+    expect(campaignOrgs[0].status).toBe("qualified");
+  });
+});
+
+describe("deleteCompanies", () => {
+  it("unlinks people per campaign, not everything under the first link's campaign", async () => {
+    // Two links from two campaigns the caller owns. The old code took
+    // links[0].campaign_id for the whole batch, so campaign B's people were
+    // unlinked from campaign A.
+    campaignOrgs = [
+      { id: LINK_ORG, campaign_id: "camp-a", organization_id: "org-a" },
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        campaign_id: "camp-b",
+        organization_id: "org-b",
+      },
+    ];
+    const deletes: Array<{ filters: unknown }> = [];
+    const fake = createSupabaseFake({
+      tables: {
+        campaign_organizations: () => campaignOrgs,
+        campaign_people: () => campaignPeople,
+        people: () => [
+          { id: "pa", organization_id: "org-a" },
+          { id: "pb", organization_id: "org-b" },
+        ],
+      },
+      onQuery: (q) => {
+        if (q.kind === "delete" && q.table === "campaign_people")
+          deletes.push({ filters: q.filters });
+      },
+    });
+    const { createClient } = await import("@/lib/supabase/server");
+    vi.mocked(createClient).mockResolvedValueOnce(fake);
+
+    const result = (await deleteCompanies.execute!(
+      {
+        companyIds: [LINK_ORG, "33333333-3333-3333-3333-333333333333"],
+      },
+      {} as never,
+    )) as { deleted: number };
+
+    expect(result.deleted).toBe(2);
+    // One campaign_people delete per campaign, each scoped to its own.
+    expect(deletes).toHaveLength(2);
+    const campaignFilters = deletes.map(
+      (d) =>
+        (d.filters as Array<{ column: string; value?: unknown }>).find(
+          (f) => f.column === "campaign_id",
+        )?.value,
+    );
+    expect(campaignFilters.sort()).toEqual(["camp-a", "camp-b"]);
+  });
+
+  it("reports IDs that matched nothing rather than counting them deleted", async () => {
+    const result = (await deleteCompanies.execute!(
+      { companyIds: [LINK_ORG, WRONG_ID] },
+      {} as never,
+    )) as { deleted: number; notFound?: string[] };
+
+    expect(result.deleted).toBe(1);
+    expect(result.notFound).toEqual([WRONG_ID]);
+  });
+});

--- a/src/lib/services/claim-reconciler.ts
+++ b/src/lib/services/claim-reconciler.ts
@@ -9,12 +9,57 @@ function ageMs(claim: CompanyClaim, now: Date): number | null {
   return Number.isNaN(t) ? null : now.getTime() - t;
 }
 
-/** Case-insensitive containment either way, so "Hiring: Growth Director" matches "Growth Director (Remote)". */
+/**
+ * Words that appear in claim sentences and job-posting decoration but carry no
+ * role identity. Without them stripped, "Hiring: Growth Director" and "Growth
+ * Director (Remote)" can never match: neither string contains the other once
+ * both carry extra text, and every live role read as contradicted.
+ */
+const ROLE_NOISE = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "at",
+  "for",
+  "hiring",
+  "hybrid",
+  "is",
+  "job",
+  "jr",
+  "junior",
+  "of",
+  "onsite",
+  "position",
+  "remote",
+  "role",
+  "senior",
+  "sr",
+  "the",
+  "to",
+  "we",
+]);
+
+function roleTokens(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !ROLE_NOISE.has(t));
+}
+
+/**
+ * Does the claim name a job on the live page? Token subset rather than string
+ * containment: extractor statements are full sentences ("Acme is hiring a Head
+ * of Growth") and scraped titles carry decoration ("Head of Growth (Remote)"),
+ * so the scraped title's identity tokens all appearing in the statement is the
+ * signal, and neither string containing the other is routine for real matches.
+ */
 function matchesScrapedJob(statement: string, careers: CareersScrape): boolean {
-  const s = statement.toLowerCase();
+  const claimed = new Set(roleTokens(statement));
   return careers.jobs.some((j) => {
-    const t = j.title.toLowerCase();
-    return s.includes(t) || t.includes(s);
+    const title = roleTokens(j.title);
+    return title.length > 0 && title.every((t) => claimed.has(t));
   });
 }
 
@@ -36,9 +81,20 @@ export function reconcileClaims(
 ): CompanyClaim[] {
   const out = claims.map((c) => ({ ...c }));
 
+  // Ground truth requires a page that was actually read and actually lists
+  // jobs. careersUrl:null means no careers page was ever found, and zero
+  // scraped jobs cannot distinguish "not hiring" from "could not read the
+  // page" (Stagehand extracts nothing from some JS-heavy pages): both used to
+  // mark every true hiring claim contradicted, and the UI then asserted "The
+  // live careers page says otherwise" about a page never read.
+  const careersIsGroundTruth =
+    opts.careers !== null &&
+    opts.careers.careersUrl !== null &&
+    opts.careers.jobs.length > 0;
+
   for (const c of out) {
     if (c.type !== "hiring_role") continue;
-    if (opts.careers) {
+    if (careersIsGroundTruth && opts.careers) {
       c.status = matchesScrapedJob(c.statement, opts.careers)
         ? "verified"
         : "contradicted";

--- a/src/lib/services/person-enrichment.ts
+++ b/src/lib/services/person-enrichment.ts
@@ -28,13 +28,14 @@ export interface PersonEnrichmentResult {
 export const PERSON_ENRICH_COLUMNS =
   // !organization_id disambiguates: people carries a second FK to
   // organizations (affiliation_detached_from), so unhinted embeds error.
-  "name, title, linkedin_url, twitter_url, organization:organizations!organization_id(name)";
+  "name, title, linkedin_url, twitter_url, organization_id, organization:organizations!organization_id(name)";
 
 export interface PersonForEnrichment {
   name: string;
   title: string | null;
   linkedin_url: string | null;
   twitter_url: string | null;
+  organization_id?: string | null;
   organization: { name?: string } | null;
 }
 
@@ -115,13 +116,24 @@ export async function enrichPerson(
 
         // URLs already on the company's card, so the same link doesn't appear
         // on both the company and the contact.
+        //
+        // Keyed by the organization id the row already carries, not the name:
+        // same-named org rows are an expected state (dedup is domain-only),
+        // and a name lookup errors on maybeSingle the moment a second "Acme"
+        // exists, silently skipping dedup, or worse, reading a namesake org's
+        // enrichment.
         const companyUrls = new Set<string>();
-        if (person.organization) {
-          const { data: orgRow } = await supabase
+        if (person.organization_id) {
+          const { data: orgRow, error: orgReadError } = await supabase
             .from("organizations")
             .select("enrichment_data")
-            .eq("name", person.organization.name ?? "")
+            .eq("id", person.organization_id)
             .maybeSingle();
+          if (orgReadError) {
+            console.error(
+              `[enrich] company-URL dedup read failed for org ${person.organization_id}: ${orgReadError.message}`,
+            );
+          }
 
           const orgEnrichment = orgRow?.enrichment_data as Record<
             string,

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -529,8 +529,21 @@ async function enrichContactById(
     );
   }
 
+  // A row stuck at in_progress has no other recovery path: the status is set
+  // before the scrape chain, and a serverless run killed mid-scrape leaves it
+  // there forever. Re-enriching is the recovery, so the recency skip must not
+  // apply: it used to return status "enriched" while the row still said
+  // in_progress, making the stuck state unfixable for 7 days.
+  const { data: statusRow } = await supabase
+    .from("people")
+    .select("enrichment_status")
+    .eq("id", personId)
+    .maybeSingle();
+  const stuckInProgress = statusRow?.enrichment_status === "in_progress";
+
   // Check recency -- skip if recently enriched
-  const recent = await isRecentlyEnriched("people", personId);
+  const recent =
+    !stuckInProgress && (await isRecentlyEnriched("people", personId));
   if (recent) {
     const { data: person } = await supabase
       .from("people")
@@ -553,7 +566,7 @@ async function enrichContactById(
       // The !organization_id hint is load-bearing: people has a second FK to
       // organizations (affiliation_detached_from), so an unhinted embed is
       // ambiguous and PostgREST rejects the whole query.
-      "name, title, location, linkedin_url, twitter_url, organization:organizations!organization_id(name)",
+      "name, title, location, linkedin_url, twitter_url, organization_id, organization:organizations!organization_id(name)",
     )
     .eq("id", personId)
     .single();
@@ -621,30 +634,36 @@ async function enrichContactById(
 
     // Collect URLs already in the company's enrichment data so we don't
     // show the same links on both the company and contact cards.
+    //
+    // Keyed by the organization id the row already carries: same-named org
+    // rows are an expected state (findOrCreateOrganization dedups by domain
+    // only), and a name lookup errors on maybeSingle the moment a second
+    // "Acme" exists, silently skipping this dedup.
     const companyUrls = new Set<string>();
-    if (person?.organization) {
-      const orgName = (person.organization as unknown as { name?: string })
-        ?.name;
-      if (orgName) {
-        const { data: orgRow } = await supabase
-          .from("organizations")
-          .select("enrichment_data")
-          .eq("name", orgName)
-          .maybeSingle();
+    if (person?.organization_id) {
+      const { data: orgRow, error: orgReadError } = await supabase
+        .from("organizations")
+        .select("enrichment_data")
+        .eq("id", person.organization_id)
+        .maybeSingle();
+      if (orgReadError) {
+        console.error(
+          `[enrichContact] company-URL dedup read failed for org ${person.organization_id}: ${orgReadError.message}`,
+        );
+      }
 
-        const orgEnrichment = orgRow?.enrichment_data as Record<
-          string,
-          unknown
-        > | null;
-        if (orgEnrichment) {
-          const searches = orgEnrichment.searches as
-            | Array<{ results: Array<{ url: string }> }>
-            | undefined;
-          if (searches) {
-            for (const s of searches) {
-              for (const r of s.results) {
-                if (r.url) companyUrls.add(r.url);
-              }
+      const orgEnrichment = orgRow?.enrichment_data as Record<
+        string,
+        unknown
+      > | null;
+      if (orgEnrichment) {
+        const searches = orgEnrichment.searches as
+          | Array<{ results: Array<{ url: string }> }>
+          | undefined;
+        if (searches) {
+          for (const s of searches) {
+            for (const r of s.results) {
+              if (r.url) companyUrls.add(r.url);
             }
           }
         }
@@ -2036,17 +2055,29 @@ export const deleteCompanies = tool({
   execute: async (input) => {
     const supabase = await createClient();
 
-    // Get organization_ids to unlink their people too
-    const { data: links } = await supabase
+    // Get organization_ids to unlink their people too. A failed read must
+    // abort: proceeding used to delete the org links anyway and leave every
+    // campaign_people row behind, contacts attached to companies the
+    // campaign no longer has, while the tool still reported deleted: N.
+    const { data: links, error: linksError } = await supabase
       .from("campaign_organizations")
       .select("organization_id, campaign_id")
       .in("id", input.companyIds);
+    if (linksError) {
+      throw new Error(`Failed to load company links: ${linksError.message}`);
+    }
 
-    if (links && links.length > 0) {
-      const campaignId = links[0].campaign_id;
-      const orgIds = links.map((l) => l.organization_id);
+    // Grouped by campaign, because nothing guarantees the batch is from one:
+    // taking links[0].campaign_id unlinked campaign B's people from campaign
+    // A whenever a batch spanned two campaigns the caller owns.
+    const orgIdsByCampaign = new Map<string, string[]>();
+    for (const l of links ?? []) {
+      const list = orgIdsByCampaign.get(l.campaign_id) ?? [];
+      list.push(l.organization_id);
+      orgIdsByCampaign.set(l.campaign_id, list);
+    }
 
-      // Get person_ids at these orgs
+    for (const [campaignId, orgIds] of orgIdsByCampaign) {
       const { data: people } = await supabase
         .from("people")
         .select("id")
@@ -2062,16 +2093,29 @@ export const deleteCompanies = tool({
       }
     }
 
-    const { error } = await supabase
+    // .select() reports what was actually removed: a delete RLS filtered to
+    // zero rows returns no error, and echoing the input length back reported
+    // deletions that never happened.
+    const { data: deletedRows, error } = await supabase
       .from("campaign_organizations")
       .delete()
-      .in("id", input.companyIds);
+      .in("id", input.companyIds)
+      .select("id");
 
     if (error) throw new Error(`Failed to unlink companies: ${error.message}`);
 
+    const deletedIds = (deletedRows ?? []).map((r) => r.id as string);
+    const notFound = input.companyIds.filter((id) => !deletedIds.includes(id));
+
     return {
-      deleted: input.companyIds.length,
-      companyIds: input.companyIds,
+      deleted: deletedIds.length,
+      companyIds: deletedIds,
+      ...(notFound.length > 0
+        ? {
+            notFound,
+            warning: `${notFound.length} link ID(s) matched nothing and were not deleted. Pass campaign-organization link IDs (the id field on getCompanies rows).`,
+          }
+        : {}),
     };
   },
 });
@@ -2132,15 +2176,25 @@ export const scoreCompany = tool({
   }),
   execute: async (input) => {
     const supabase = await createClient();
-    const { error } = await supabase
+    // .select() distinguishes "stored" from "matched nothing": a 0-row update
+    // returns no error, and agents routinely pass the organization ID here
+    // instead of the link ID, so the tool reported scores that were never
+    // persisted and prioritization silently never happened.
+    const { data: updated, error } = await supabase
       .from("campaign_organizations")
       .update({
         relevance_score: input.score,
         score_reason: input.reason,
       })
-      .eq("id", input.companyId);
+      .eq("id", input.companyId)
+      .select("id");
 
     if (error) throw new Error(`Failed to score company: ${error.message}`);
+    if (!updated || updated.length === 0) {
+      throw new Error(
+        `No campaign company found with link ID ${input.companyId}. Pass the campaign-organization link ID (the id field on getCompanies rows), not the organization ID.`,
+      );
+    }
     return {
       companyId: input.companyId,
       score: input.score,
@@ -2170,15 +2224,21 @@ export const scoreContact = tool({
   }),
   execute: async (input) => {
     const supabase = await createClient();
-    const { error } = await supabase
+    const { data: updated, error } = await supabase
       .from("campaign_people")
       .update({
         priority_score: input.score,
         score_reason: input.reason,
       })
-      .eq("id", input.contactId);
+      .eq("id", input.contactId)
+      .select("id");
 
     if (error) throw new Error(`Failed to score contact: ${error.message}`);
+    if (!updated || updated.length === 0) {
+      throw new Error(
+        `No campaign contact found with link ID ${input.contactId}. Pass the campaign-people link ID, not the person ID.`,
+      );
+    }
     return {
       contactId: input.contactId,
       score: input.score,
@@ -2202,16 +2262,26 @@ export const updateCompanyStatus = tool({
   execute: async (input) => {
     const supabase = await createClient();
 
-    const { error } = await supabase
+    const { data: updatedRows, error } = await supabase
       .from("campaign_organizations")
       .update({ status: input.status })
-      .in("id", input.companyIds);
+      .in("id", input.companyIds)
+      .select("id");
 
     if (error) throw new Error(`Failed to update companies: ${error.message}`);
 
+    const updatedIds = new Set((updatedRows ?? []).map((r) => r.id as string));
+    const notFound = input.companyIds.filter((id) => !updatedIds.has(id));
+
     return {
-      updated: input.companyIds.length,
+      updated: updatedIds.size,
       status: input.status,
+      ...(notFound.length > 0
+        ? {
+            notFound,
+            warning: `${notFound.length} link ID(s) matched nothing. Pass campaign-organization link IDs (the id field on getCompanies rows).`,
+          }
+        : {}),
     };
   },
 });
@@ -2261,26 +2331,47 @@ export const getGoogleReviews = tool({
       });
     }
 
+    let signalTracked = false;
     if (input.campaignId) {
       const supabase = await createClient();
-      const { data: signal } = await supabase
+      const { data: signal, error: signalError } = await supabase
         .from("signals")
         .select("id")
         .eq("slug", "google-reviews")
         .maybeSingle();
 
-      if (signal) {
-        await supabase.from("signal_results").insert({
-          signal_id: signal.id,
-          campaign_id: input.campaignId,
-          organization_id: input.organizationId,
-          output: result,
-          status: result.found ? "success" : "failed",
-        });
+      if (signalError) {
+        console.error(
+          `[getGoogleReviews] signal lookup failed: ${signalError.message}`,
+        );
+      } else if (!signal) {
+        // The built-ins seed lives only in the initial migration; an emptied
+        // signals table does not self-heal, and this used to drop tracking
+        // with no trace at all.
+        console.warn(
+          "[getGoogleReviews] google-reviews signal not found: the built-in signals seed is missing, so this run was not recorded in signal history",
+        );
+      } else {
+        const { error: insertError } = await supabase
+          .from("signal_results")
+          .insert({
+            signal_id: signal.id,
+            campaign_id: input.campaignId,
+            organization_id: input.organizationId,
+            output: result,
+            status: result.found ? "success" : "failed",
+          });
+        if (insertError) {
+          console.error(
+            `[getGoogleReviews] signal_results insert failed: ${insertError.message}`,
+          );
+        } else {
+          signalTracked = true;
+        }
       }
     }
 
-    return result;
+    return { ...result, ...(input.campaignId ? { signalTracked } : {}) };
   },
 });
 


### PR DESCRIPTION
Wave-6 cluster (PR-16 of the hardening plan): 8 verified findings in the enrichment lifecycle. **Stacked: merge #90 and #91 first**; this branch contains both (its base is #91's branch, with #90's branch merged in) so the diff shown here narrows to just this cluster once they land.

## The high one: empty careers scrapes contradicting real hiring signals (`claim-reconciler.ts:41`)
`tryScrapeHiringData` returns `{careersUrl: null, jobs: []}` when no careers link exists, and Stagehand can extract zero jobs from a JS-heavy page. Both callers wrap any fulfilled value into a non-null scrape, and `reconcileClaims` then ran `jobs.some(...)` over the empty array: every true hiring claim from news sources was marked `contradicted`, the system prompt forbids citing contradicted claims as timing signals, and the company UI rendered "The live careers page says otherwise" for a page that was never read. Real hiring signals were suppressed for any company without a discoverable careers page. Ground truth now requires a found page with at least one scraped job. **Gates prod repair 10** (resetting wrongly-contradicted claims).

## Matching too strict to match its own docstring (`claim-reconciler.ts:13`)
Bidirectional substring: "Hiring: Growth Director" vs "Growth Director (Remote)" fails both directions, so decorated titles contradicted live roles. Replaced with a token-subset match (scraped title's identity tokens ⊆ claim tokens, noise words stripped).

## Stuck `in_progress` with no recovery path (`enrichment-tools.ts:550`)
The status is set before the scrape chain; a serverless run killed mid-scrape left it forever, UI showing permanent "In Progress". Worse, the recency check then skipped re-enrichment for 7 days, returning status "enriched" while the row said `in_progress`. The recency skip no longer applies to stuck rows, so any re-enrich recovers them. **Ships before prod repair 11** (resetting stale `in_progress` rows).

## Company-URL dedup keyed by name (`person-enrichment.ts:115`, `enrichment-tools.ts:610`)
Same-named org rows are an expected state (`findOrCreateOrganization` dedups by domain only), and the name lookup errored on `maybeSingle` the moment a second "Acme" existed: the error was swallowed and dedup silently did nothing (or read a namesake's enrichment). Both sites now key on the `organization_id` the person row already carries, and surface the read error.

## Zero-row writes reported as success (`enrichment-tools.ts:2114`, `:2027`)
- `scoreCompany`/`scoreContact`/`updateCompanyStatus`: a 0-row UPDATE returns no error, and the file itself documents that agents routinely confuse ID kinds; scores were echoed back as stored while nothing persisted and the contact stayed unranked. All three now verify affected rows and name the correct ID kind in the refusal.
- `deleteCompanies`: assumed the whole batch belonged to `links[0].campaign_id` (cross-campaign batches unlinked people from the wrong campaign), swallowed the links-select error (skipping people-unlinking entirely while still reporting `deleted: N`), and echoed the input length as the deleted count. Now grouped per campaign, fail-closed on the read, and reporting actual deletions plus a `notFound` list.

## Dropped signal history (`enrichment-tools.ts:2254`)
`getGoogleReviews`' `signal_results` insert error was never read, and a missing built-ins seed (the documented emptied-signals-table failure mode) made the slug lookup silently null. Both are now logged, and the result carries `signalTracked` so the agent can see tracking did not happen.

Suite: 972 passed (12 new beyond the stacked branches), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)