### PR TITLE
fix(github): stub overwrites, pagination, real top repos, signal tracking

### DIFF
--- a/src/__tests__/github-tools.test.ts
+++ b/src/__tests__/github-tools.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSupabaseFake, type FakeRow } from "./helpers/supabase-fake";
+
+/**
+ * The GitHub pipeline: stargazer collection and profile enrichment. The
+ * failure this file guards hardest against is the stub overwrite: a stargazer
+ * pass carries six fields, and letting it replace a stored full profile
+ * destroys all GitHub grounding for drafting while looking freshly enriched.
+ */
+
+/** Routes GitHub API paths to canned responses. */
+const routes = new Map<string, { status?: number; body: unknown }>();
+
+function respond(path: string) {
+  for (const [prefix, r] of routes) {
+    if (path.includes(prefix)) {
+      return {
+        ok: (r.status ?? 200) < 400,
+        status: r.status ?? 200,
+        headers: { get: () => "5000" },
+        json: async () => r.body,
+      };
+    }
+  }
+  throw new Error(`unrouted github fetch: ${path}`);
+}
+
+vi.mock("@/lib/fetch-with-timeout", () => ({
+  fetchWithTimeout: async (url: string) => respond(url),
+}));
+
+let people: FakeRow[] = [];
+let signals: FakeRow[] = [];
+let signalResults: FakeRow[] = [];
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () =>
+    createSupabaseFake({
+      tables: {
+        people: () => people,
+        signals: () => signals,
+        signal_results: () => signalResults,
+      },
+    }),
+  ),
+}));
+
+vi.mock("@/lib/services/knowledge-base", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/services/knowledge-base")>();
+  return {
+    ...actual,
+    linkPersonToCampaign: vi.fn(async () => ({ id: "cp" })),
+  };
+});
+
+import {
+  fetchGitHubStargazers,
+  enrichGitHubProfiles,
+} from "@/lib/tools/github-tools";
+
+const CAMPAIGN = "11111111-1111-1111-1111-111111111111";
+
+function starPage(logins: string[]) {
+  return logins.map((login) => ({
+    starred_at: "2026-08-01T00:00:00Z",
+    user: {
+      login,
+      avatar_url: `https://avatars.test/${login}`,
+      html_url: `https://github.com/${login}`,
+    },
+  }));
+}
+
+beforeEach(() => {
+  routes.clear();
+  people = [];
+  signals = [];
+  signalResults = [];
+});
+
+describe("fetchGitHubStargazers", () => {
+  const repo = (stars: number) => ({
+    full_name: "acme/tool",
+    description: "d",
+    stargazers_count: stars,
+    forks_count: 1,
+    language: "TypeScript",
+    html_url: "https://github.com/acme/tool",
+  });
+
+  it("does not let a stargazer stub overwrite a stored full profile", async () => {
+    const richGithub = {
+      username: "jane",
+      profile_url: "https://github.com/jane",
+      bio: "builds things",
+      followers: 4200,
+      top_repos: [{ name: "flagship", stars: 20000 }],
+      fetched_at: "2026-07-01T00:00:00Z",
+    };
+    people = [
+      {
+        id: "p1",
+        github_url: "https://github.com/jane",
+        enrichment_data: { github: richGithub, news: ["kept"] },
+        enrichment_status: "enriched",
+        last_enriched_at: "2026-07-01T00:00:00Z",
+        location: "SF",
+      },
+    ];
+    routes.set("/repos/acme/tool/stargazers", { body: starPage(["jane"]) });
+    routes.set("/repos/acme/tool", { body: repo(1) });
+
+    await fetchGitHubStargazers.execute!(
+      { owner: "acme", repo: "tool", count: 100 },
+      {} as never,
+    );
+
+    const github = (people[0].enrichment_data as Record<string, unknown>)
+      .github as Record<string, unknown>;
+    expect(github.top_repos).toEqual([{ name: "flagship", stars: 20000 }]);
+    expect(github.followers).toBe(4200);
+    // The new signal fields still land.
+    expect(github.starred_repo).toBe("acme/tool");
+    // Lifecycle columns untouched: a stub is not an enrichment, and a fresh
+    // stamp here made isRecentlyEnriched skip the person for 7 days.
+    expect(people[0].enrichment_status).toBe("enriched");
+    expect(people[0].last_enriched_at).toBe("2026-07-01T00:00:00Z");
+    expect(github.fetched_at).toBe("2026-07-01T00:00:00Z");
+    // and sibling top-level keys survive
+    expect((people[0].enrichment_data as Record<string, unknown>).news).toEqual(
+      ["kept"],
+    );
+  });
+
+  it("fetches enough pages when the newest page is partial", async () => {
+    // 150 stars: page 2 holds 50, page 1 holds 100. ceil(100/100)=1 page from
+    // the end used to stop before page 1 and return 50 for a count of 100.
+    routes.set("/repos/acme/tool/stargazers?per_page=100&page=2", {
+      body: starPage(Array.from({ length: 50 }, (_, i) => `late${i}`)),
+    });
+    routes.set("/repos/acme/tool/stargazers?per_page=100&page=1", {
+      body: starPage(Array.from({ length: 100 }, (_, i) => `early${i}`)),
+    });
+    routes.set("/repos/acme/tool", { body: repo(150) });
+
+    const result = (await fetchGitHubStargazers.execute!(
+      { owner: "acme", repo: "tool", count: 100 },
+      {} as never,
+    )) as { fetched: number };
+
+    expect(result.fetched).toBe(100);
+  });
+
+  it("reports when signal tracking did not happen", async () => {
+    // Empty signals table: the built-ins seed is missing (documented failure
+    // mode). The tool used to claim full success while the campaign's signal
+    // history silently omitted the run.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    routes.set("/repos/acme/tool/stargazers", { body: starPage(["jane"]) });
+    routes.set("/repos/acme/tool", { body: repo(1) });
+
+    const result = (await fetchGitHubStargazers.execute!(
+      { owner: "acme", repo: "tool", count: 10, campaignId: CAMPAIGN },
+      {} as never,
+    )) as { signal_tracked?: boolean };
+
+    expect(result.signal_tracked).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("records the signal when the seed exists", async () => {
+    signals = [{ id: "sig-1", slug: "github-stargazers" }];
+    routes.set("/repos/acme/tool/stargazers", { body: starPage(["jane"]) });
+    routes.set("/repos/acme/tool", { body: repo(1) });
+
+    const result = (await fetchGitHubStargazers.execute!(
+      { owner: "acme", repo: "tool", count: 10, campaignId: CAMPAIGN },
+      {} as never,
+    )) as { signal_tracked?: boolean };
+
+    expect(result.signal_tracked).toBe(true);
+    expect(signalResults).toHaveLength(1);
+  });
+});
+
+describe("enrichGitHubProfiles", () => {
+  it("ranks top repos by stars itself: the API has no stars sort", async () => {
+    routes.set("/users/jane/repos", {
+      body: [
+        {
+          name: "aardvark-toy",
+          full_name: "jane/aardvark-toy",
+          description: null,
+          html_url: "u",
+          stargazers_count: 2,
+          forks_count: 0,
+          language: "Python",
+          topics: [],
+          fork: false,
+          created_at: "",
+          updated_at: "",
+          pushed_at: "",
+        },
+        {
+          name: "zeta-flagship",
+          full_name: "jane/zeta-flagship",
+          description: "the real work",
+          html_url: "u2",
+          stargazers_count: 20000,
+          forks_count: 900,
+          language: "TypeScript",
+          topics: ["ai"],
+          fork: false,
+          created_at: "",
+          updated_at: "",
+          pushed_at: "",
+        },
+      ],
+    });
+    routes.set("/users/jane", {
+      body: {
+        login: "jane",
+        html_url: "https://github.com/jane",
+        avatar_url: "a",
+        name: "Jane",
+        email: null,
+        twitter_username: null,
+        bio: null,
+        location: null,
+      },
+    });
+
+    const result = (await enrichGitHubProfiles.execute!(
+      { usernames: ["jane"] },
+      {} as never,
+    )) as unknown as {
+      profiles: Array<{ top_repos: Array<{ name: string }> }>;
+    };
+
+    expect(result.profiles[0].top_repos[0].name).toBe("zeta-flagship");
+  });
+});

--- a/src/lib/tools/github-tools.ts
+++ b/src/lib/tools/github-tools.ts
@@ -97,7 +97,50 @@ async function findOrCreateGitHubPerson(profile: {
       : null;
 
   if (existing) {
-    await mergeEnrichmentData("people", existing.id, { github: githubData });
+    const existingData =
+      (existing.enrichment_data as Record<string, unknown> | null) ?? {};
+    const existingGithub =
+      (existingData.github as Record<string, unknown> | null) ?? {};
+    const hasFullProfile = !!profile.raw;
+
+    if (hasFullProfile) {
+      // A full profile refresh: new data wins over the old blob, and the
+      // enrichment lifecycle columns are correctly stamped by the merge.
+      await mergeEnrichmentData("people", existing.id, {
+        github: { ...existingGithub, ...githubData },
+      });
+    } else {
+      // A stargazer stub. mergeEnrichmentData replaces top-level keys
+      // wholesale, so passing the stub used to overwrite a stored full
+      // profile (bio, followers, top_repos) with six fields, while
+      // fetched_at looked fresh so nothing ever re-enriched. And its status
+      // default stamped enrichment_status='enriched' onto rows holding only
+      // a stub, which isRecentlyEnriched then skipped for 7 days. Keep the
+      // rich blob, record only the new signal fields, touch no lifecycle
+      // columns.
+      const { error: stubError } = await supabase
+        .from("people")
+        .update({
+          enrichment_data: {
+            ...existingData,
+            github: {
+              ...githubData,
+              ...existingGithub,
+              starred_repo:
+                profile.starred_repo ?? existingGithub.starred_repo ?? null,
+              starred_at:
+                profile.starred_at ?? existingGithub.starred_at ?? null,
+            },
+          },
+        })
+        .eq("id", existing.id);
+      if (stubError) {
+        throw new Error(
+          `Failed to record stargazer signal: ${stubError.message}`,
+        );
+      }
+    }
+
     // Fill-if-null only: a location from discovery or a manual edit wins
     // over the GitHub profile string.
     if (rawLocation) {
@@ -219,9 +262,14 @@ export const fetchGitHubStargazers = tool({
       starred_at: string;
     }> = [];
 
+    // Lower bound allows one page beyond pagesNeeded: the newest page holds
+    // totalStars % 100 entries, so ceil(count/100) pages from the end can
+    // hold fewer than `count` stargazers (150-star repo, count 100: page 2
+    // has 50, and the old bound stopped before page 1, returning half the
+    // request; at worst, one stargazer for a count of 100).
     for (
       let page = accessiblePages;
-      page >= Math.max(1, accessiblePages - pagesNeeded + 1) &&
+      page >= Math.max(1, accessiblePages - pagesNeeded) &&
       stargazers.length < input.count;
       page--
     ) {
@@ -307,33 +355,56 @@ export const fetchGitHubStargazers = tool({
       stargazers: stargazers.slice(0, 50),
     };
 
-    // 4. Store in signal_results
+    // 4. Store in signal_results. Failures are reported, not swallowed: a
+    // missing built-ins seed or a refused insert used to drop the campaign's
+    // signal history silently while the tool claimed full success.
+    let signalTracked = false;
     if (input.campaignId) {
       const supabase = await createClient();
-      const { data: signal } = await supabase
+      const { data: signal, error: signalError } = await supabase
         .from("signals")
         .select("id")
         .eq("slug", "github-stargazers")
         .maybeSingle();
 
-      if (signal) {
-        await supabase.from("signal_results").insert({
-          signal_id: signal.id,
-          campaign_id: input.campaignId,
-          organization_id: input.companyId ?? null,
-          output: {
-            repository: output.repository,
-            total_stars: output.total_stars,
-            fetched: output.fetched,
-            saved_to_db: output.saved_to_db,
-            usernames: output.usernames,
-          },
-          status: stargazers.length > 0 ? "success" : "partial",
-        });
+      if (signalError) {
+        console.error(
+          `[fetchGitHubStargazers] signal lookup failed: ${signalError.message}`,
+        );
+      } else if (!signal) {
+        console.warn(
+          "[fetchGitHubStargazers] github-stargazers signal not found: the built-in signals seed is missing, so this run was not recorded in signal history",
+        );
+      } else {
+        const { error: insertError } = await supabase
+          .from("signal_results")
+          .insert({
+            signal_id: signal.id,
+            campaign_id: input.campaignId,
+            organization_id: input.companyId ?? null,
+            output: {
+              repository: output.repository,
+              total_stars: output.total_stars,
+              fetched: output.fetched,
+              saved_to_db: output.saved_to_db,
+              usernames: output.usernames,
+            },
+            status: stargazers.length > 0 ? "success" : "partial",
+          });
+        if (insertError) {
+          console.error(
+            `[fetchGitHubStargazers] signal_results insert failed: ${insertError.message}`,
+          );
+        } else {
+          signalTracked = true;
+        }
       }
     }
 
-    return output;
+    return {
+      ...output,
+      ...(input.campaignId ? { signal_tracked: signalTracked } : {}),
+    };
   },
 });
 
@@ -388,7 +459,12 @@ export const enrichGitHubProfiles = tool({
                 pushed_at: string;
               }>
             >(
-              `/users/${username}/repos?sort=stars&direction=desc&per_page=10&type=owner`,
+              // The repos endpoint has NO 'stars' sort (only created/updated/
+              // pushed/full_name): sort=stars was silently ignored and the
+              // first 10 alphabetical repos (often toys) were stored as
+              // "top repos". Fetch a full page biased to recent activity and
+              // rank by stars client-side.
+              `/users/${username}/repos?sort=pushed&direction=desc&per_page=100&type=owner`,
             ),
           ]);
           return { profile: profileRes.data, repos: reposRes.data };
@@ -402,9 +478,10 @@ export const enrichGitHubProfiles = tool({
           const raw = result.value.profile;
           const repos = result.value.repos ?? [];
 
-          // Map repos to a clean structure
+          // Map repos to a clean structure, ranked by stars ourselves.
           const topRepos = repos
             .filter((r) => !r.fork) // skip forks
+            .sort((a, b) => b.stargazers_count - a.stargazers_count)
             .slice(0, 10)
             .map((r) => ({
               name: r.name,


### PR DESCRIPTION
Wave-6 cluster (PR-17 of the hardening plan): 5 verified findings in the GitHub tools. **Stacked on #93** (chain: #90 → #91 → #93 → this); the diff narrows to this cluster as the chain merges.

## The high one: stargazer stubs destroying full profiles (`github-tools.ts:91`, `:100`)
`enrichGitHubProfiles` stores a rich blob (bio, company, followers, top_repos, languages). A later `fetchGitHubStargazers` pass on any repo the same person starred hit the existing-person branch with a 6-field stub, and `mergeEnrichmentData` replaces top-level keys wholesale: the rich blob was overwritten, all GitHub grounding for drafting destroyed, and `fetched_at` looked fresh so nothing ever re-enriched. The same call's status default also stamped `enrichment_status='enriched'` + `last_enriched_at` onto rows holding only a stub, so `isRecentlyEnriched` skipped them for 7 days while the UI showed them enriched. The stub path now merges under the existing blob, records only the new signal fields (`starred_repo`/`starred_at`), and touches no lifecycle columns. **Gates prod repair 13** (resetting stub-overwritten profiles).

## Pagination undercount (`:222`)
Pages are fetched from the end (newest stargazers), but the newest page holds `totalStars % 100` entries, and the loop's lower bound only allowed `ceil(count/100)` pages: a 150-star repo with `count=100` returned 50 stargazers, and at worst (`totalStars % 100 == 1`) a count-100 request returned exactly one. The bound now allows one extra page, still capped by `count` and the rate-limit guard.

## "Top repos" were alphabetical (`:391`)
The `/users/{username}/repos` endpoint has no `stars` sort (only created/updated/pushed/full_name), so `sort=stars` was silently ignored and the first 10 alphabetical repos, routinely forks and toys, were stored and described to the model as the person's "top public repositories"; drafts personalized on trivia and missed the 20k-star flagship starting with "z". Now fetches a full page (biased to recent pushes) and ranks by stars client-side.

## Silent signal-history drops (`:313`)
The `github-stargazers` slug lookup silently no-oped when the built-ins seed was missing (the documented emptied-signals-table failure mode) and the insert error was never read, while the tool reported `saved_to_db: N`. Both paths now log, and the output carries `signal_tracked` so the agent can see whether the run was recorded.

Suite: 977 passed (5 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)