### PR TITLE
fix(dashboard): shared contacted bucket, truthful time series, surfaced errors

### DIFF
--- a/src/__tests__/campaign-stats.test.tsx
+++ b/src/__tests__/campaign-stats.test.tsx
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+beforeAll(() => {
+  // StatCard's count-up hook reads prefers-reduced-motion; jsdom has no
+  // matchMedia. Reduced motion also makes the counter render its final value
+  // immediately, which is what the assertions need.
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: true,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+});
+
+import { CampaignStats } from "@/components/campaign/campaign-stats";
+import type { CampaignCompany, CampaignContact } from "@/lib/types/campaign";
+
+/**
+ * The contacted bucket. Bounced and complained sends still left, so they
+ * belong in the denominator: excluding them inflated the reply rate and made
+ * this card disagree with the dashboard, which was already fixed for this.
+ */
+
+const contact = (id: string, outreach: string): CampaignContact =>
+  ({
+    id,
+    outreach_status: outreach,
+    enrichment_status: "pending",
+  }) as unknown as CampaignContact;
+
+describe("CampaignStats", () => {
+  it("counts bounced contacts as contacted and in the reply-rate denominator", () => {
+    const contacts = [
+      ...Array.from({ length: 7 }, (_, i) => contact(`s${i}`, "sent")),
+      contact("b1", "bounced"),
+      contact("b2", "bounced"),
+      contact("r1", "replied"),
+    ];
+
+    render(
+      <CampaignStats companies={[] as CampaignCompany[]} contacts={contacts} />,
+    );
+
+    // 10 contacted (7 sent + 2 bounced + 1 replied), so the rate is 10%,
+    // not 1/8 = 13%.
+    expect(screen.getByText("1 of 10 contacted")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/dashboard-route.test.ts
+++ b/src/__tests__/dashboard-route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * GET /api/dashboard. Two failure classes: query errors rendered as an
+ * empty-but-healthy dashboard (K22), and the time-series cap truncating the
+ * WRONG end (ascending + limit keeps the oldest rows, so the most recent
+ * days silently vanish from the chart on busy installs).
+ */
+
+interface QueryLog {
+  table: string;
+  order?: { column: string; ascending: boolean };
+  inArgs?: { column: string; values: unknown[] };
+}
+
+const queries: QueryLog[] = [];
+let events: Array<{ status: string; created_at: string }> = [];
+let failCounts = false;
+
+function chain(table: string) {
+  const log: QueryLog = { table };
+  queries.push(log);
+  const c: Record<string, unknown> & PromiseLike<unknown> = {
+    select: (_cols?: string, opts?: { count?: string; head?: boolean }) => {
+      if (opts?.count) {
+        return {
+          in: (column: string, values: unknown[]) => {
+            log.inArgs = { column, values };
+            return countResult();
+          },
+          eq: () => countResult(),
+          then: countResult().then,
+        };
+      }
+      return c;
+    },
+    eq: () => c,
+    gte: () => c,
+    order: (column: string, opts: { ascending: boolean }) => {
+      log.order = { column, ascending: opts.ascending };
+      return c;
+    },
+    limit: () => c,
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve({
+        data: table === "outreach_events" ? events : [],
+        error: null,
+      }).then(onF, onR),
+  } as unknown as Record<string, unknown> & PromiseLike<unknown>;
+  return c;
+}
+
+function countResult() {
+  const p: PromiseLike<unknown> & Record<string, unknown> = {
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve(
+        failCounts
+          ? { count: null, error: { message: "connection reset" } }
+          : { count: 3, error: null },
+      ).then(onF, onR),
+  } as unknown as PromiseLike<unknown> & Record<string, unknown>;
+  return p;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAndUser: vi.fn(async () => ({
+    supabase: { from: (table: string) => chain(table) },
+    user: { id: "user-1" },
+  })),
+}));
+
+import { GET } from "@/app/api/dashboard/route";
+
+const get = (range = "30d") =>
+  GET(new Request(`http://test/api/dashboard?range=${range}`));
+
+beforeEach(() => {
+  queries.length = 0;
+  events = [];
+  failCounts = false;
+});
+
+describe("GET /api/dashboard", () => {
+  it("fetches the time-series newest-first so the cap truncates old days, not recent ones", async () => {
+    events = [
+      { status: "sent", created_at: "2026-08-05T10:00:00Z" },
+      { status: "replied", created_at: "2026-08-01T10:00:00Z" },
+    ];
+
+    const res = await get();
+    const body = (await res.json()) as {
+      timeSeries: Array<{ date: string }>;
+    };
+
+    const tsQuery = queries.find(
+      (q) => q.table === "outreach_events" && q.order,
+    );
+    expect(tsQuery?.order?.ascending).toBe(false);
+    // and the output is still presented oldest-first for the chart
+    expect(body.timeSeries.map((d) => d.date)).toEqual([
+      "2026-08-01",
+      "2026-08-05",
+    ]);
+  });
+
+  it("counts bounced and complained sends as contacted", async () => {
+    await get();
+
+    const sentQuery = queries.find((q) => q.inArgs);
+    expect(sentQuery?.inArgs?.values).toEqual(
+      expect.arrayContaining(["bounced", "complained", "sent", "replied"]),
+    );
+  });
+
+  it("returns 500 on a failed query instead of an empty healthy dashboard", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    failCounts = true;
+
+    const res = await get();
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("connection reset");
+    quiet.mockRestore();
+  });
+});

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,4 +1,5 @@
 import { getSupabaseAndUser } from "@/lib/supabase/server";
+import { CONTACTED_STATUSES, isContactedStatus } from "@/lib/outreach-status";
 
 /**
  * Dashboard aggregates.
@@ -49,13 +50,7 @@ export async function GET(request: Request) {
       // A send that bounced still left. Excluding it shrank the denominator
       // every rate is measured against, and would have made the new bounce
       // card move the wrong way.
-      .in("outreach_status", [
-        "sent",
-        "opened",
-        "replied",
-        "bounced",
-        "complained",
-      ]),
+      .in("outreach_status", [...CONTACTED_STATUSES]),
     supabase
       .from("campaign_people")
       .select("*", { count: "exact", head: true })
@@ -65,18 +60,23 @@ export async function GET(request: Request) {
       .select("*", { count: "exact", head: true })
       .eq("outreach_status", "bounced"),
 
-    // Time-series from outreach_events (capped to prevent memory issues)
+    // Time-series from outreach_events (capped to prevent memory issues).
+    // Descending, so when the window holds more rows than the cap the cap
+    // truncates the OLDEST days: ascending kept the head and silently dropped
+    // the most recent days from the chart, and with range=all froze it at the
+    // first 10000 events ever. The grouping below is order-independent and
+    // the output is re-sorted ascending.
     dateFilter
       ? supabase
           .from("outreach_events")
           .select("status, created_at")
           .gte("created_at", dateFilter)
-          .order("created_at", { ascending: true })
+          .order("created_at", { ascending: false })
           .limit(10000)
       : supabase
           .from("outreach_events")
           .select("status, created_at")
-          .order("created_at", { ascending: true })
+          .order("created_at", { ascending: false })
           .limit(10000),
 
     // Campaign list
@@ -88,6 +88,25 @@ export async function GET(request: Request) {
       .select("campaign_id, outreach_status")
       .limit(10000),
   ]);
+
+  // A failed query is not a zero. `count ?? 0` rendered every failure as an
+  // empty-but-healthy dashboard, which is the K22 class this route sat in.
+  const failed = [
+    leadsRes,
+    sentRes,
+    repliedRes,
+    bouncedRes,
+    timeSeriesRes,
+    campaignsRes,
+    allPeopleRes,
+  ].find((r) => r.error);
+  if (failed?.error) {
+    console.error("[dashboard] query failed:", failed.error.message);
+    return Response.json(
+      { error: `Dashboard query failed: ${failed.error.message}` },
+      { status: 500 },
+    );
+  }
 
   const totals = {
     leads: leadsRes.count ?? 0,
@@ -125,12 +144,7 @@ export async function GET(request: Request) {
     }
     const stats = campaignMap.get(row.campaign_id)!;
     stats.leads++;
-    if (
-      ["sent", "opened", "replied", "bounced", "complained"].includes(
-        row.outreach_status,
-      )
-    )
-      stats.sent++;
+    if (isContactedStatus(row.outreach_status)) stats.sent++;
     if (row.outreach_status === "replied") stats.replied++;
   }
 

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -6,6 +6,7 @@ import { RotateCw, Sparkles } from "lucide-react";
 
 import { CampaignHeader } from "@/components/campaign/campaign-header";
 import { CampaignStats } from "@/components/campaign/campaign-stats";
+import { isContactedStatus } from "@/lib/outreach-status";
 import { CompaniesList } from "@/components/campaign/companies-list";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -237,14 +238,8 @@ export default function CampaignDetailPage() {
           enrichedDelta += 1;
         }
         const prevOutreach = prevOutreachStatuses.current.get(c.id);
-        const isContacted =
-          c.outreach_status === "sent" ||
-          c.outreach_status === "opened" ||
-          c.outreach_status === "replied";
-        const wasContacted =
-          prevOutreach === "sent" ||
-          prevOutreach === "opened" ||
-          prevOutreach === "replied";
+        const isContacted = isContactedStatus(c.outreach_status);
+        const wasContacted = isContactedStatus(prevOutreach);
         if (!wasContacted && isContacted) contactedDelta += 1;
       }
 
@@ -332,11 +327,8 @@ export default function CampaignDetailPage() {
   };
 
   const replyRate = useMemo(() => {
-    const contacted = contacts.filter(
-      (c) =>
-        c.outreach_status === "sent" ||
-        c.outreach_status === "opened" ||
-        c.outreach_status === "replied",
+    const contacted = contacts.filter((c) =>
+      isContactedStatus(c.outreach_status),
     ).length;
     const replied = contacts.filter(
       (c) => c.outreach_status === "replied",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,6 +52,10 @@ interface DashboardData {
 export default function DashboardPage() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [range, setRange] = useState("30d");
+  // The range the rendered data actually belongs to. Kept separately from
+  // `range` so a failed refetch cannot label stale 30d numbers as the 90d the
+  // user just asked for.
+  const [loadedRange, setLoadedRange] = useState("30d");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -63,6 +67,7 @@ export default function DashboardPage() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       setData(json);
+      setLoadedRange(r);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
       console.error("[dashboard] Failed to fetch:", err);
@@ -125,11 +130,21 @@ export default function DashboardPage() {
           </p>
         </div>
 
+        {/* A failed refetch used to render silently: the old numbers stayed
+            up under the newly selected range's label, wrong data presented as
+            the requested range with no way to tell. */}
+        {error && (
+          <p role="alert" className="text-destructive text-sm">
+            Could not refresh the dashboard: {error}. Showing the last loaded
+            data instead.
+          </p>
+        )}
+
         <StatCards totals={data.totals} />
 
         <OutreachChart
           timeSeries={data.timeSeries}
-          range={range}
+          range={loadedRange}
           onRangeChange={handleRangeChange}
         />
 

--- a/src/components/campaign/campaign-stats.tsx
+++ b/src/components/campaign/campaign-stats.tsx
@@ -1,4 +1,5 @@
 import { StatCard } from "@/components/ui/stat-card";
+import { isContactedStatus } from "@/lib/outreach-status";
 import type { CampaignCompany, CampaignContact } from "@/lib/types/campaign";
 
 interface CampaignStatsProps {
@@ -15,11 +16,11 @@ export function CampaignStats({ companies, contacts }: CampaignStatsProps) {
   const enrichedCount = contacts.filter(
     (c) => c.enrichment_status === "enriched",
   ).length;
-  const contactedCount = contacts.filter(
-    (c) =>
-      c.outreach_status === "sent" ||
-      c.outreach_status === "opened" ||
-      c.outreach_status === "replied",
+  // Shared bucket: bounced/complained count as contacted, or a bounce
+  // silently shrinks the reply-rate denominator and this card disagrees with
+  // the dashboard, which was already fixed for exactly this.
+  const contactedCount = contacts.filter((c) =>
+    isContactedStatus(c.outreach_status),
   ).length;
   const repliedCount = contacts.filter(
     (c) => c.outreach_status === "replied",

--- a/src/lib/outreach-status.ts
+++ b/src/lib/outreach-status.ts
@@ -1,0 +1,26 @@
+/**
+ * The one definition of "an email left for this contact".
+ *
+ * bounced and complained are IN. A send that bounced still left: excluding it
+ * shrinks the denominator every rate is measured against, makes a bounce
+ * *raise* the apparent reply rate, and made the campaign page disagree with
+ * the dashboard about how many people were contacted. 'opened' survives only
+ * to keep legacy rows counted: nothing writes it today (Signal sends no
+ * tracking pixel).
+ *
+ * This list existed as four hand-copied predicates that had already drifted:
+ * the dashboard had the full set, the campaign header and stats card did not.
+ */
+export const CONTACTED_STATUSES = [
+  "sent",
+  "opened",
+  "replied",
+  "bounced",
+  "complained",
+] as const;
+
+export function isContactedStatus(status: string | null | undefined): boolean {
+  return (
+    status != null && (CONTACTED_STATUSES as readonly string[]).includes(status)
+  );
+}


### PR DESCRIPTION
Wave-7 cluster (PR-18 of the hardening plan): K22 plus 4 findings around dashboard and campaign metrics. Independent of the other open PRs (branched off main).

## One definition of "contacted" (`campaign-stats.tsx:18` and friends)
The status bucket existed as four hand-copied predicates that had already drifted: the dashboard route deliberately includes `bounced`/`complained` (a send that bounced still left; excluding it shrinks every rate's denominator), but the campaign stats card and two sites in the campaign page did not. Send 10, 2 bounce, 1 replies: the card showed "Contacted 8" and a 13% reply rate while the dashboard said 10 and 10%. New `src/lib/outreach-status.ts` exports `CONTACTED_STATUSES`/`isContactedStatus`, used by all four sites.

## Time-series truncating the wrong end (`dashboard/route.ts:74`)
The events query ordered ascending with `limit(10000)`, so past 10k events in the window the cap kept the OLDEST rows: the chart's most recent days silently vanished (activity appears to die off while sends are happening today), and `range=all` froze permanently at the first 10000 events ever. Now fetched descending (cap truncates old days) and re-sorted ascending for the chart.

## K22: query failures rendered as a healthy empty dashboard
Every `count ?? 0` and `data ?? []` turned a failed query into zeros. Any failed query now returns a 500 with the message, which the page's existing error path handles.

## Stale data labeled as the requested range (`page.tsx:97`)
After a successful first load, a failed range-change refetch was discarded with the error UI gated behind `if (!data)`: the old 30d numbers kept rendering while the chart was told `range='90d'` and labeled them as such. The page now tracks the range the rendered data actually belongs to, and a visible alert says the refresh failed and stale data is showing.

Suite: 923 passed (4 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)