### PR TITLE
fix(settings): email settings failures stop masquerading as not-connected

### DIFF
--- a/src/__tests__/email-transport.test.ts
+++ b/src/__tests__/email-transport.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { encryptSecret } from "@/lib/crypto";
 import { resolveSenderConfig } from "@/lib/services/email-transport";
 
-function fakeSupabase(row: unknown) {
+function fakeSupabase(row: unknown, error: { message: string } | null = null) {
   const builder: Record<string, unknown> = {};
   for (const name of ["select", "eq", "maybeSingle"]) {
     builder[name] = () => builder;
   }
   builder.then = (resolve: (v: unknown) => unknown) =>
-    Promise.resolve({ data: row, error: null }).then(resolve);
+    Promise.resolve(
+      error ? { data: null, error } : { data: row, error: null },
+    ).then(resolve);
   return { from: () => builder } as never;
 }
 
@@ -99,5 +101,24 @@ describe("resolveSenderConfig", () => {
       "user_1",
     );
     expect(result).toMatchObject({ dailyLimit: 30 });
+  });
+});
+
+describe("resolveSenderConfig when the settings read fails", () => {
+  it("reports a retryable failure, not an unconfigured mailbox", async () => {
+    // "Email is not configured. Go to Settings" for a DB blip sends a fully
+    // connected user to re-do setup (and reset their warmup clock), and the
+    // followups cron records the same misleading reason for every send.
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await resolveSenderConfig(
+      fakeSupabase(null, { message: "connection reset by peer" }),
+      "user_1",
+    );
+
+    expect("error" in result && result.error).toContain("connection reset");
+    expect("error" in result && result.error).toMatch(/retry/i);
+    expect("error" in result && result.error).not.toMatch(/not configured/i);
+    quiet.mockRestore();
   });
 });

--- a/src/app/api/settings/email/route.ts
+++ b/src/app/api/settings/email/route.ts
@@ -17,13 +17,26 @@ export async function GET() {
 
   const { supabase, user } = ctx;
 
-  const { data: settings } = await supabase
+  const { data: settings, error: settingsError } = await supabase
     .from("user_settings")
     .select(
       "gmail_address, gmail_connected_at, from_name, reply_to_email, daily_send_limit, sending_paused, send_window_start, send_window_end, send_timezone, send_window_scope, auto_adjust_send_window",
     )
     .eq("user_id", user.id)
     .maybeSingle();
+
+  // A failed read is not "not connected". Returning is_configured:false here
+  // rendered every transient failure as a disconnected mailbox, inviting the
+  // user to "reconnect" and reset the warmup clock; it also defeats the
+  // tenant-hardening migration's explicit fail-safe, which counts on a
+  // column-grant problem surfacing as a visible error.
+  if (settingsError) {
+    console.error("[settings/email] read failed:", settingsError.message);
+    return NextResponse.json(
+      { error: `Could not load email settings: ${settingsError.message}` },
+      { status: 500 },
+    );
+  }
 
   const dailyLimit = settings?.daily_send_limit ?? 30;
 
@@ -83,12 +96,22 @@ export async function POST(request: Request) {
     }
 
     // Preserve the warmup-ramp clock when re-connecting the same address
-    // (e.g. after rotating the app password).
-    const { data: existing } = await supabase
+    // (e.g. after rotating the app password). A failed read must abort:
+    // proceeding treats the account as brand new and silently resets the
+    // clock, cutting the daily send capacity back to day one.
+    const { data: existing, error: existingError } = await supabase
       .from("user_settings")
       .select("gmail_address, gmail_connected_at")
       .eq("user_id", user.id)
       .maybeSingle();
+    if (existingError) {
+      return NextResponse.json(
+        {
+          error: `Could not load existing settings, so nothing was changed: ${existingError.message}. Retry.`,
+        },
+        { status: 500 },
+      );
+    }
     const connectedAt =
       existing?.gmail_address === address && existing?.gmail_connected_at
         ? existing.gmail_connected_at

--- a/src/app/api/settings/email/test/route.ts
+++ b/src/app/api/settings/email/test/route.ts
@@ -166,7 +166,12 @@ export async function POST(request: Request) {
     }
 
     const sentAt = new Date().toISOString();
-    await supabase
+    // The real SMTP send has already happened, so a failed state write must
+    // be reported as such: swallowing it returned sent:true while
+    // test_message_id was never stored, "check" then 400s with "No test send
+    // to check", and the resend cooldown never engages, so retries keep
+    // sending real emails.
+    const { error: stateError } = await supabase
       .from("user_settings")
       .update({
         test_message_id: messageId,
@@ -180,6 +185,15 @@ export async function POST(request: Request) {
         updated_at: sentAt,
       })
       .eq("user_id", user.id);
+
+    if (stateError) {
+      return NextResponse.json(
+        {
+          error: `The test email WAS sent, but its record could not be stored (${stateError.message}). Wait for the email to arrive rather than resending.`,
+        },
+        { status: 500 },
+      );
+    }
 
     return NextResponse.json({
       sent: true,
@@ -253,7 +267,9 @@ export async function POST(request: Request) {
       snippet,
     };
 
-    await supabase
+    // A settled verdict that fails to persist re-scans IMAP on every later
+    // check, which is exactly what persisting the verdict exists to prevent.
+    const { error: verdictError } = await supabase
       .from("user_settings")
       .update({
         test_replied_at: repliedAt,
@@ -262,6 +278,11 @@ export async function POST(request: Request) {
         updated_at: new Date().toISOString(),
       })
       .eq("user_id", user.id);
+    if (verdictError) {
+      console.error(
+        `[settings/email/test] verdict write failed: ${verdictError.message}`,
+      );
+    }
 
     return NextResponse.json({
       status: hit.status,

--- a/src/components/settings/email-settings.tsx
+++ b/src/components/settings/email-settings.tsx
@@ -82,6 +82,7 @@ export function EmailSettings() {
   const [testTo, setTestTo] = useState("");
   const [testSending, setTestSending] = useState(false);
   const [testChecking, setTestChecking] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [testStatus, setTestStatus] = useState<TestStatus>("idle");
   const [testReply, setTestReply] = useState<TestReply | null>(null);
   const [testWarning, setTestWarning] = useState<string | null>(null);
@@ -94,7 +95,13 @@ export function EmailSettings() {
   const load = async () => {
     try {
       const res = await apiFetch("/api/settings/email");
-      if (!res.ok) return;
+      // A failed load must not render the "Not connected" setup form: the
+      // mailbox may be fully connected, and a user who re-enters credentials
+      // to "reconnect" can reset their warmup clock.
+      if (!res.ok) {
+        if (mountedRef.current) setLoadError(`HTTP ${res.status}`);
+        return;
+      }
       const data = await res.json();
       if (!mountedRef.current) return;
 
@@ -170,8 +177,10 @@ export function EmailSettings() {
         setTestReply(null);
         setTestWarning(null);
       }
-    } catch {
-      // silently fail
+    } catch (err) {
+      if (mountedRef.current) {
+        setLoadError(err instanceof Error ? err.message : "network error");
+      }
     } finally {
       if (mountedRef.current) setLoading(false);
     }
@@ -450,6 +459,33 @@ export function EmailSettings() {
         <p className="text-muted-foreground text-sm">
           Loading email settings...
         </p>
+      </SettingsSection>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <SettingsSection
+        title="Email"
+        description="Connect your Gmail or Google Workspace mailbox for sending outreach."
+      >
+        <div className="space-y-3">
+          <p role="alert" className="text-destructive text-sm">
+            Could not load email settings: {loadError}. Your mailbox may still
+            be connected, so do not re-enter credentials based on this screen.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setLoadError(null);
+              setLoading(true);
+              void load();
+            }}
+          >
+            Retry
+          </Button>
+        </div>
       </SettingsSection>
     );
   }

--- a/src/lib/services/email-transport.ts
+++ b/src/lib/services/email-transport.ts
@@ -36,13 +36,26 @@ export async function resolveSenderConfig(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<SenderConfig | { error: string }> {
-  const { data: settings } = await supabase
+  const { data: settings, error: settingsError } = await supabase
     .from("user_settings")
     .select(
       "gmail_address, gmail_app_password_enc, gmail_connected_at, from_name, reply_to_email, daily_send_limit, sending_paused, send_window_start, send_window_end, send_timezone, send_window_scope",
     )
     .eq("user_id", userId)
     .maybeSingle();
+
+  // A failed read is a retryable outage, not an unconfigured mailbox. Telling
+  // a fully connected user "Email is not configured. Go to Settings" sends
+  // them to re-do setup (and reset their warmup clock) over a DB blip, and
+  // the followups cron records the same misleading reason for every send.
+  if (settingsError) {
+    console.error(
+      `[email-transport] settings read failed for ${userId}: ${settingsError.message}`,
+    );
+    return {
+      error: `Could not load email settings (${settingsError.message}). This is a temporary failure: retry the send. It does not mean email is unconfigured.`,
+    };
+  }
 
   if (!settings?.gmail_address || !settings.gmail_app_password_enc) {
     return { error: NOT_CONNECTED };


### PR DESCRIPTION
Wave-7 cluster (PR-19 of the hardening plan): 4 verified findings in email settings & transport. Independent (branched off main).

The findings share one failure shape: a failed `user_settings` read or write rendered as "not connected / not configured", and the user-visible remedy for that state (re-entering credentials) resets `gmail_connected_at`, the warmup-ramp clock that `getEffectiveDailyLimit` builds the account's daily send capacity on.

- **GET `/api/settings/email`** swallowed the select error and returned `is_configured: false` defaults, defeating the tenant-hardening migration's documented fail-safe (a column-grant problem is supposed to surface as a visible error). Now 500s.
- **POST `connect_gmail`**: the existing-row read that preserves the warmup clock on reconnect also swallowed its error, so the exact failure that pushed a user into "reconnecting" then guaranteed the clock reset it was designed to prevent. The connect now aborts with nothing changed.
- **`resolveSenderConfig`** (the single choke point every send resolves identity through) reported any DB failure as "Email is not configured. Go to Settings > Email and connect your Gmail account." A transient outage during a followups cron run recorded that misleading reason on every send in the run. Failures are now named as retryable outages.
- **Test-send route**: both `user_settings` writes ignored their errors. The post-SMTP state write failure meant the email really went out but `sent:true` hid that nothing was recorded: "check" 400'd and the resend cooldown never engaged, so retries kept sending real SMTP mail. Now surfaced with an explicit "the email WAS sent, wait rather than resending". The verdict-persist failure (which forces IMAP re-scans the guard exists to prevent) is logged.
- **Email settings component**: `load()` bailed silently on `!res.ok`, rendering the "Not connected" badge and the app-password setup form for a connected mailbox (and pause/kill-switch state as defaults). Now an explicit error state with a retry that says not to re-enter credentials.

Suite: 920 passed, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)