### PR TITLE
fix(profile): sender profile and fact bank integrity

### DIFF
--- a/src/__tests__/sender-research.test.ts
+++ b/src/__tests__/sender-research.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { dedupeFacts, factsFromModel } from "@/lib/services/sender-research";
+import {
+  dedupeFacts,
+  factsFromModel,
+  isSharedProfileHost,
+  sameResource,
+} from "@/lib/services/sender-research";
 
 describe("dedupeFacts", () => {
   it("drops a fact already in the bank, ignoring case and punctuation", () => {
@@ -68,5 +73,34 @@ describe("factsFromModel", () => {
       { category: "pov", fact: "Real opinion" },
     ]);
     expect(out).toEqual([{ category: "pov", fact: "Real opinion" }]);
+  });
+});
+
+describe("shared-platform source filtering", () => {
+  it("treats platform hosts as shared and own domains as not", () => {
+    expect(isSharedProfileHost("linkedin.com")).toBe(true);
+    expect(isSharedProfileHost("www.linkedin.com")).toBe(true);
+    expect(isSharedProfileHost("x.com")).toBe(true);
+    expect(isSharedProfileHost("acme.com")).toBe(false);
+  });
+
+  it("matches the same profile page across URL variants", () => {
+    // On a shared platform the domain filter is no identity filter: only the
+    // exact page the user gave us is theirs, and results 2-3 of an Exa search
+    // are the best OTHER linkedin.com matches, i.e. namesakes. Stranger facts
+    // extracted as "their own profile" end up woven into the user's outreach
+    // as claims about themselves.
+    expect(
+      sameResource(
+        "https://www.linkedin.com/in/jane-doe/",
+        "http://linkedin.com/in/jane-doe",
+      ),
+    ).toBe(true);
+    expect(
+      sameResource(
+        "https://www.linkedin.com/in/jane-doe-8b2a1",
+        "https://linkedin.com/in/jane-doe",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/app/api/profile/research-facts/route.ts
+++ b/src/app/api/profile/research-facts/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
-import { loadSenderFacts } from "@/lib/sender-facts";
+import { loadAllSenderFacts } from "@/lib/sender-facts";
 import { dedupeFacts, researchSender } from "@/lib/services/sender-research";
 import { getSupabaseAndUser } from "@/lib/supabase/server";
 import type { UserProfile } from "@/lib/types/profile";
@@ -59,8 +59,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
 
-  const existing = await loadSenderFacts(supabase, profile.id);
-  const survivors = dedupeFacts(result.facts, existing);
+  // Dedupe against the FULL bank, and refuse on a failed read: an empty or
+  // truncated baseline re-inserts every fact that already exists, bloating
+  // the bank fed into every composed email.
+  const existingRes = await loadAllSenderFacts(supabase, profile.id);
+  if (!existingRes.ok) {
+    return NextResponse.json(
+      {
+        error: `Could not load the existing fact bank (${existingRes.error}), so nothing was saved: inserting without it would duplicate facts. Retry.`,
+      },
+      { status: 500 },
+    );
+  }
+  const survivors = dedupeFacts(result.facts, existingRes.facts);
   const skippedAsDuplicates = result.facts.length - survivors.length;
 
   if (survivors.length === 0) {

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -50,6 +50,7 @@ export default function ProfileDetailPage() {
   const [form, setForm] = useState<ProfileFormData>(emptyForm);
   const [loading, setLoading] = useState(!isNew);
   const [notFound, setNotFound] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -57,12 +58,20 @@ export default function ProfileDetailPage() {
 
     const load = async () => {
       const supabase = createClient();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("user_profile")
         .select("*")
         .eq("id", params.id)
         .maybeSingle();
 
+      // A failed query is not a missing profile: rendering the terminal
+      // "Profile not found" for a transient failure tells the user their
+      // profile was deleted.
+      if (error) {
+        setLoadError(error.message);
+        setLoading(false);
+        return;
+      }
       if (!data) {
         setNotFound(true);
         setLoading(false);
@@ -149,6 +158,17 @@ export default function ProfileDetailPage() {
           <PageHeaderSkeleton />
           <ListRowsSkeleton count={4} />
         </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p role="alert" className="text-destructive text-sm">
+          Could not load this profile: {loadError}. It has not been deleted:
+          reload to try again.
+        </p>
       </div>
     );
   }
@@ -404,14 +424,21 @@ const CATEGORY_LABELS: Record<FactCategory, string> = {
   personal: "Personal",
 };
 
-/** All facts for a profile, insertion order. RLS scopes to the current user. */
+/**
+ * All facts for a profile, insertion order. RLS scopes to the current user.
+ * Throws on a failed read: returning [] rendered a populated fact bank as
+ * "No facts yet" (inviting duplicate re-entry), and a failed refetch right
+ * after research replaced the visible list with the empty state, making
+ * research look like it deleted the bank.
+ */
 async function fetchFacts(profileId: string): Promise<SenderFact[]> {
   const supabase = createClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("sender_facts")
     .select("id, category, fact, source")
     .eq("profile_id", profileId)
     .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
   return (data as SenderFact[]) ?? [];
 }
 
@@ -430,6 +457,7 @@ function FactBankSection({
 }) {
   const [facts, setFacts] = useState<SenderFact[]>([]);
   const [factsLoading, setFactsLoading] = useState(true);
+  const [factsError, setFactsError] = useState<string | null>(null);
 
   const [newCategory, setNewCategory] = useState<FactCategory>("background");
   const [newFact, setNewFact] = useState("");
@@ -444,8 +472,14 @@ function FactBankSection({
 
   useEffect(() => {
     const load = async () => {
-      setFacts(await fetchFacts(profileId));
-      setFactsLoading(false);
+      try {
+        setFacts(await fetchFacts(profileId));
+        setFactsError(null);
+      } catch (err) {
+        setFactsError(err instanceof Error ? err.message : "load failed");
+      } finally {
+        setFactsLoading(false);
+      }
     };
     void load();
   }, [profileId]);
@@ -530,7 +564,15 @@ function FactBankSection({
       if (!res.ok) {
         setResearchError(json.error ?? "Research failed");
       } else {
-        setFacts(await fetchFacts(profileId));
+        // A failed refetch keeps the current list on screen: wiping it right
+        // after "+N facts added" makes research look like it deleted the bank.
+        try {
+          setFacts(await fetchFacts(profileId));
+        } catch {
+          toast.error(
+            "Facts were saved, but the list could not be refreshed. Reload to see them.",
+          );
+        }
         setResearchNote(
           json.added
             ? `+${json.added} fact${json.added === 1 ? "" : "s"} added`
@@ -578,6 +620,11 @@ function FactBankSection({
 
       {factsLoading ? (
         <ListRowsSkeleton count={3} />
+      ) : factsError ? (
+        <p role="alert" className="text-destructive text-sm">
+          Could not load the fact bank: {factsError}. Your facts are likely
+          still saved: reload rather than re-adding them.
+        </p>
       ) : facts.length === 0 ? (
         <p className="text-muted-foreground text-sm">
           No facts yet. Add one below, or research your profile to fill the bank

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -22,6 +22,7 @@ import type { UserProfile } from "@/lib/types/profile";
 export default function ProfilesIndexPage() {
   const [profiles, setProfiles] = useState<UserProfile[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
@@ -30,13 +31,21 @@ export default function ProfilesIndexPage() {
 
     const fetchProfiles = async () => {
       const supabase = createClient();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("user_profile")
         .select("*")
         .order("created_at", { ascending: false });
 
       if (mountedRef.current) {
-        setProfiles(Array.isArray(data) ? data : []);
+        // A failed load is not "No profiles yet": that empty state tells the
+        // user to create one, and following it mints a duplicate seller
+        // identity that compose then picks from ambiguously.
+        if (error) {
+          setLoadError(error.message);
+        } else {
+          setLoadError(null);
+          setProfiles(Array.isArray(data) ? data : []);
+        }
         setLoading(false);
       }
     };
@@ -98,6 +107,11 @@ export default function ProfilesIndexPage() {
             <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
             <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
           </div>
+        ) : loadError ? (
+          <p role="alert" className="text-destructive text-sm">
+            Could not load profiles: {loadError}. Your profiles are likely still
+            there: reload rather than creating a new one.
+          </p>
         ) : profiles.length === 0 ? (
           <p className="text-muted-foreground text-sm">
             No profiles yet. Create one so the agent knows who it is writing as.

--- a/src/components/campaign/profile-selector.tsx
+++ b/src/components/campaign/profile-selector.tsx
@@ -21,14 +21,24 @@ export function ProfileSelector({
 }: ProfileSelectorProps) {
   const [profiles, setProfiles] = useState<UserProfile[]>([]);
   const [saving, setSaving] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
 
   useEffect(() => {
     const load = async () => {
       const supabase = createClient();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("user_profile")
         .select("*")
         .order("created_at", { ascending: false });
+      // A failed load must not render as "no profiles": the component
+      // disappears entirely on an empty list, so a query failure (including
+      // the known RLS-as-anon mode) silently hid a campaign's linked profile
+      // with no way to see or change it.
+      if (error) {
+        setLoadFailed(true);
+        return;
+      }
+      setLoadFailed(false);
       setProfiles((data as UserProfile[]) ?? []);
     };
     load();
@@ -50,6 +60,14 @@ export function ProfileSelector({
     }
     setSaving(false);
   };
+
+  if (loadFailed) {
+    return (
+      <span role="alert" className="text-destructive text-xs">
+        Profiles failed to load
+      </span>
+    );
+  }
 
   if (profiles.length === 0) return null;
 

--- a/src/lib/sender-facts.ts
+++ b/src/lib/sender-facts.ts
@@ -89,3 +89,23 @@ export async function loadSenderFacts(
   }
   return (data ?? []) as SenderFact[];
 }
+
+/**
+ * The FULL fact bank, for dedupe baselines. loadSenderFacts is prompt-shaped:
+ * it truncates to MAX_FACTS_IN_PROMPT and degrades errors to [], both of
+ * which are wrong for dedupe, where a short or empty baseline re-inserts
+ * every fact that already exists. Surfaces the error so callers can refuse
+ * to insert against a baseline they could not read.
+ */
+export async function loadAllSenderFacts(
+  supabase: SupabaseClient,
+  profileId: string,
+): Promise<{ ok: true; facts: SenderFact[] } | { ok: false; error: string }> {
+  const { data, error } = await supabase
+    .from("sender_facts")
+    .select("id, category, fact, source")
+    .eq("profile_id", profileId)
+    .order("created_at", { ascending: false });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, facts: (data ?? []) as SenderFact[] };
+}

--- a/src/lib/services/sender-research.ts
+++ b/src/lib/services/sender-research.ts
@@ -113,6 +113,36 @@ function hostOf(url: string): string | null {
   }
 }
 
+/**
+ * Hosts where a domain restriction is not an identity restriction: everyone's
+ * profile lives on the same domain, so only the exact page the user gave us
+ * can be treated as theirs.
+ */
+const SHARED_PROFILE_HOSTS = new Set([
+  "linkedin.com",
+  "x.com",
+  "twitter.com",
+  "github.com",
+  "medium.com",
+]);
+
+export function isSharedProfileHost(host: string): boolean {
+  return SHARED_PROFILE_HOSTS.has(host.toLowerCase().replace(/^www\./, ""));
+}
+
+/** Same page, tolerating protocol/www/trailing-slash/query differences. */
+export function sameResource(a: string, b: string): boolean {
+  const norm = (u: string) => {
+    try {
+      const parsed = new URL(/^https?:\/\//i.test(u) ? u : `https://${u}`);
+      return `${parsed.hostname.replace(/^www\./, "")}${parsed.pathname.replace(/\/+$/, "")}`.toLowerCase();
+    } catch {
+      return u.toLowerCase();
+    }
+  };
+  return norm(a) === norm(b);
+}
+
 const EXTRACTION_SYSTEM = `Extract facts about THIS person/company for use in their own outreach emails. Only include what the sources state: never infer, embellish, or fill gaps.
 
 Categories:
@@ -174,7 +204,18 @@ export async function researchSender(
           numResults: 3,
           includeDomains: [host],
         });
-        const text = result.results
+        // On a shared platform (linkedin.com, x.com, ...) the domain filter
+        // is no identity filter at all: results 2-3 are the best OTHER
+        // matches on the platform, which for a common name are namesakes.
+        // The prompt then asserts all sources are "their own profile URLs",
+        // so stranger facts land in the sender's bank and get woven into
+        // their outreach as claims about themselves. Only the requested page
+        // itself is the sender's own on these hosts; a company's own domain
+        // keeps all pages.
+        const own = isSharedProfileHost(host)
+          ? result.results.filter((r) => sameResource(r.url, url))
+          : result.results;
+        const text = own
           .map((r) => `${r.title}\n${r.text ?? ""}`.trim())
           .filter(Boolean)
           .join("\n---\n")

--- a/src/lib/tools/profile-tools.ts
+++ b/src/lib/tools/profile-tools.ts
@@ -53,17 +53,22 @@ export const updateUserProfile = tool({
     }
 
     if (profileId) {
-      const { error } = await supabase
+      // .select() distinguishes "updated" from "matched nothing": a 0-row
+      // update returns no error, so a stale or mistyped profileId reported
+      // action:'updated' while the user's correction silently never landed
+      // and drafts kept the old offering_summary.
+      const { data: updatedRows, error } = await supabase
         .from("user_profile")
         .update(fields)
-        .eq("id", profileId);
-      if (error) throw new Error(`Failed to update profile: ${error.message}`);
-
-      const { data: profile } = await supabase
-        .from("user_profile")
-        .select("*")
         .eq("id", profileId)
-        .single();
+        .select("*");
+      if (error) throw new Error(`Failed to update profile: ${error.message}`);
+      const profile = updatedRows?.[0];
+      if (!profile) {
+        return {
+          error: `No profile found with id ${profileId}. It may have been deleted: call getUserProfile to see the current profiles, then retry.`,
+        };
+      }
 
       return { profile, action: "updated", updated: Object.keys(fields) };
     }

--- a/src/lib/tools/sender-fact-tools.ts
+++ b/src/lib/tools/sender-fact-tools.ts
@@ -5,6 +5,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import {
   FACT_CATEGORIES,
+  loadAllSenderFacts,
   loadSenderFacts,
   type FactCategory,
 } from "@/lib/sender-facts";
@@ -76,8 +77,15 @@ export const researchSenderProfile = tool({
     const result = await researchSender(profile, userId);
     if (!result.ok) return { error: result.error };
 
-    const existing = await loadSenderFacts(supabase, profile.id);
-    const survivors = dedupeFacts(result.facts, existing);
+    // Full-bank baseline, refused on error: an empty or truncated baseline
+    // re-inserts facts that already exist.
+    const existingRes = await loadAllSenderFacts(supabase, profile.id);
+    if (!existingRes.ok) {
+      return {
+        error: `Could not load the existing fact bank (${existingRes.error}), so nothing was saved: inserting without it would duplicate facts. Retry.`,
+      };
+    }
+    const survivors = dedupeFacts(result.facts, existingRes.facts);
     const skippedAsDuplicates = result.facts.length - survivors.length;
 
     if (survivors.length === 0) {
@@ -149,8 +157,13 @@ export const addSenderFacts = tool({
     const profile = await resolveProfile(supabase, input.profileId);
     if (!profile) return { error: NO_PROFILE_ERROR };
 
-    const existing = await loadSenderFacts(supabase, profile.id);
-    const survivors = dedupeFacts(input.facts, existing);
+    const existingRes = await loadAllSenderFacts(supabase, profile.id);
+    if (!existingRes.ok) {
+      return {
+        error: `Could not load the existing fact bank (${existingRes.error}), so nothing was saved: inserting without it would duplicate facts. Retry.`,
+      };
+    }
+    const survivors = dedupeFacts(input.facts, existingRes.facts);
     const skippedAsDuplicates = input.facts.length - survivors.length;
 
     if (survivors.length === 0) {


### PR DESCRIPTION
Wave-7 cluster (PR-20 of the hardening plan): 7 verified findings around the sender profile and fact bank. Independent (branched off main). **Gates prod repair 16** (deduping exact-duplicate sender_facts).

## Failed reads rendered as terminal states (4 findings, K7 family)
- Profile detail page: any query failure rendered the terminal "Profile not found", telling the user their profile was deleted. Now a distinct error state.
- Profiles index: a failed load rendered "No profiles yet. Create one...", and following that instruction mints a duplicate seller identity that compose then picks from ambiguously (`limit 1`). Now an explicit error saying not to create a new one.
- Campaign profile selector: a failed load made the component return `null` (its empty-list behavior), so a campaign's linked profile silently disappeared with no way to see, change, or clear it, indistinguishable from "no profiles". Now renders a visible failure.
- Fact bank: a failed read rendered "No facts yet" (inviting duplicate re-entry), and a failed refetch right after "+N facts added" wiped the visible list, making research look like it deleted the bank. Now an error state, and the post-research refetch failure keeps the list with a toast.

## Zero-row update reported as updated (`profile-tools.ts:56`)
`updateUserProfile` with a stale profileId matched 0 rows with no error, discarded the re-select's error, and returned `action: 'updated'` with `profile: undefined`: the model reported the profile updated while drafts kept the old `offering_summary`. Now verifies affected rows and names the recovery (`getUserProfile` then retry).

## Namesakes in the sender's own fact bank (`sender-research.ts:168`)
For shared-platform URLs the Exa search takes 3 results restricted only by domain, so results 2-3 are the best *other* linkedin.com matches: for a common name, namesakes. All three were concatenated under a prompt asserting the sources are "their own profile URLs", so a stranger's "15 years at Oracle" became a stored fact about the user, woven into their outreach as a claim about themselves. Same namesake mechanism as the known prospect-enrichment bug, on the sender side. Shared hosts now keep only the exact requested page; a company's own domain keeps all pages.

## Dedupe against a partial baseline (`research-facts/route.ts:62` + both agent tools)
The dedupe baseline came from the prompt-shaped loader, which truncates to `MAX_FACTS_IN_PROMPT` (40) and degrades read errors to `[]`: once the bank outgrew 40 facts, or on any transient failure, re-running research re-inserted every fact that already existed, bloating the bank fed into every composed email. All three insert sites now use a full-bank loader and refuse to insert when the baseline could not be read.

Suite: 921 passed, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)