### PR TITLE
fix(activity): honest pagination cursor; detail errors stay in their row

### DIFF
--- a/src/__tests__/activity-route-cursor.test.ts
+++ b/src/__tests__/activity-route-cursor.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * GET /api/outreach/activity pagination. The page is ordered by `at` (a
+ * reply lifts an old email to the top) while the cursor walks `sent_at`, so
+ * a naive "oldest sent_at on the page" cursor can jump past sent rows that
+ * were fetched but sliced off: they are then filtered out (sent_at < cursor)
+ * on every later page, permanently missing from history.
+ */
+
+let sentRows: Array<Record<string, unknown>> = [];
+let pendingRows: Array<Record<string, unknown>> = [];
+
+function chain(table: string) {
+  const c: Record<string, unknown> & PromiseLike<unknown> = {
+    select: () => c,
+    order: () => c,
+    limit: () => c,
+    lt: () => c,
+    eq: () => c,
+    in: () => c,
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve({
+        data: table === "sent_emails" ? sentRows : pendingRows,
+        error: null,
+      }).then(onF, onR),
+  } as unknown as Record<string, unknown> & PromiseLike<unknown>;
+  return c;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAndUser: vi.fn(async () => ({
+    supabase: { from: (table: string) => chain(table) },
+    user: { id: "user-1" },
+  })),
+}));
+
+import { GET } from "@/app/api/outreach/activity/route";
+
+const sent = (
+  id: string,
+  sentAt: string,
+  replyAt?: string,
+): Record<string, unknown> => ({
+  id,
+  subject: "s",
+  to_email: "t@acme.com",
+  from_email: "me@me.com",
+  status: "sent",
+  sent_at: sentAt,
+  message_id: null,
+  person: null,
+  email_replies: replyAt
+    ? [{ kind: "reply", body_text: "hi", received_at: replyAt }]
+    : [],
+});
+
+const pending = (id: string, createdAt: string): Record<string, unknown> => ({
+  id,
+  subject: "p",
+  to_email: "t@acme.com",
+  status: "queued",
+  created_at: createdAt,
+  last_error: null,
+  last_error_at: null,
+  last_error_kind: null,
+  person: null,
+  enrollment: null,
+});
+
+const get = (limit: number) =>
+  GET(new Request(`http://test/api/outreach/activity?limit=${limit}`));
+
+beforeEach(() => {
+  sentRows = [];
+  pendingRows = [];
+});
+
+describe("activity nextCursor", () => {
+  it("does not advance past a fetched sent row the page sliced off", async () => {
+    // rowOld's reply lifts it to the top of the page; rowNew (never replied)
+    // falls below the slice. The old cursor (oldest sent_at on the page) was
+    // rowOld's T1, so the next page filtered sent_at < T1 and rowNew (T3)
+    // vanished from history forever.
+    sentRows = [
+      sent("new", "2026-08-03T00:00:00Z"),
+      sent("old", "2026-08-01T00:00:00Z", "2026-08-04T00:00:00Z"),
+    ];
+    pendingRows = [pending("d1", "2026-08-03T12:00:00Z")];
+
+    const res = await get(2);
+    const body = (await res.json()) as {
+      items: Array<{ id: string }>;
+      nextCursor: string | null;
+    };
+
+    expect(body.items.map((i) => i.id)).toEqual(["old", "draft:d1"]);
+    // The newest fetched sent row was not returned, so the cursor must not
+    // move at all: the next page re-fetches it instead of skipping it.
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("advances to the oldest fetched sent_at when every sent row was returned", async () => {
+    sentRows = [
+      sent("new", "2026-08-03T00:00:00Z"),
+      sent("old", "2026-08-01T00:00:00Z"),
+    ];
+
+    const res = await get(2);
+    const body = (await res.json()) as { nextCursor: string | null };
+
+    expect(body.nextCursor).toBe("2026-08-01T00:00:00Z");
+  });
+
+  it("returns no cursor when the sent fetch was not full", async () => {
+    sentRows = [sent("only", "2026-08-01T00:00:00Z")];
+
+    const res = await get(50);
+    const body = (await res.json()) as { nextCursor: string | null };
+
+    expect(body.nextCursor).toBeNull();
+  });
+});

--- a/src/app/api/outreach/activity/route.ts
+++ b/src/app/api/outreach/activity/route.ts
@@ -209,13 +209,26 @@ export async function GET(request: Request) {
   filtered.sort((a, b) => b.at.localeCompare(a.at));
   const page = filtered.slice(0, limit);
 
+  // Only sent rows are cursor-paginated (pending mail is a bounded set). The
+  // page is ordered by `at` (a reply lifts an old email to the top), so "the
+  // oldest sent_at on the page" can sit far below sent rows that were fetched
+  // but sliced off; a cursor there skips them on every later page, forever.
+  // The cursor may only advance past rows that were actually returned: walk
+  // the fetched sent rows newest-first and stop at the first one the page
+  // does not contain. Rows below that boundary are re-fetched next page
+  // (consumers should dedupe by id).
+  const sentRows = (sentRes.data ?? []) as unknown as SentRow[];
+  let nextCursor: string | null = null;
+  if (sentRows.length === limit) {
+    const returnedIds = new Set(page.map((i) => i.id));
+    for (const row of sentRows) {
+      if (!returnedIds.has(row.id)) break;
+      nextCursor = row.sent_at;
+    }
+  }
+
   return Response.json({
     items: page,
-    // Only sent rows are cursor-paginated (pending mail is a bounded set), so
-    // the cursor is the oldest sent_at on the page.
-    nextCursor:
-      page.length === limit
-        ? (page.filter((i) => i.sent_at).at(-1)?.sent_at ?? null)
-        : null,
+    nextCursor,
   });
 }

--- a/src/components/outreach/activity-detail.tsx
+++ b/src/components/outreach/activity-detail.tsx
@@ -60,7 +60,14 @@ export function ActivityDetail({
     if (isPending || data) return;
     let cancelled = false;
     apiFetch(`/api/outreach/activity/${id}`)
-      .then((r) => r.json())
+      .then((r) => {
+        // A 404/500 body is {error}, not a DetailPayload. Storing it as one
+        // put the render on data.sent.to_email of undefined: a TypeError that
+        // tripped the route error boundary and replaced the whole outreach
+        // page instead of failing this one row.
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((payload: DetailPayload) => {
         if (!cancelled) {
           setData(payload);


### PR DESCRIPTION
Wave-7 cluster (PR-21 of the hardening plan): the 2 activity-feed findings. Independent (branched off main).

## Cursor skipping fetched history (`activity/route.ts:218`)
The feed merges sent mail and pending drafts and sorts by `at`, where a new reply lifts an old email to the top; the cursor, though, paginates `sent_at`. "Oldest sent_at on the page" therefore lands far below sent rows that were fetched but fell under the page slice, and the next request's `sent_at < cursor` filter skips them on every later page: silently missing history for any future infinite-scroll consumer (latent today: no UI caller passes `before` yet). The cursor now walks the fetched sent rows newest-first and only advances past rows the page actually returned; anything below the first gap is re-fetched next page (consumers dedupe by id).

## One bad row nuking the whole page (`activity-detail.tsx:63`)
The detail fetch stored a 404/500 `{error}` body as a `DetailPayload` with state `idle`, and the render dereferenced `data.sent.to_email` on `undefined`: a TypeError that tripped the route error boundary and replaced the entire `/outreach` dashboard. Expanding a row whose `sent_emails` row was deleted or RLS-denied did this deterministically. Non-OK responses now land in the component's existing per-row "failed" state.

Suite: 922 passed (3 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)