### PR TITLE
fix(learning): atomic timing-stats rewrite; no fabricated 0% reply rates

### DIFF
--- a/src/__tests__/learning-tools-errors.test.ts
+++ b/src/__tests__/learning-tools-errors.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * getOutreachPerformance's failure honesty. A failed replies fetch used to
+ * default to [], every send got intent=null, and the tool reported a 0%
+ * reply rate: the agent then told the user "nothing is converting" as a
+ * confident conclusion drawn from a swallowed outage.
+ */
+
+let repliesError: { message: string } | null = null;
+
+function chain(table: string) {
+  const c: Record<string, unknown> & PromiseLike<unknown> = {
+    select: () => c,
+    eq: () => c,
+    gte: () => c,
+    limit: () => c,
+    in: () => c,
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) => {
+      if (table === "sent_emails") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "s1",
+              sent_local_hour: 9,
+              sent_weekday: 2,
+              step_number: 1,
+              sequence_id: null,
+              campaign_id: null,
+              features: {},
+            },
+          ],
+          error: null,
+        }).then(onF, onR);
+      }
+      if (table === "email_replies") {
+        return Promise.resolve(
+          repliesError
+            ? { data: null, error: repliesError }
+            : { data: [], error: null },
+        ).then(onF, onR);
+      }
+      return Promise.resolve({ data: [], error: null }).then(onF, onR);
+    },
+  } as unknown as Record<string, unknown> & PromiseLike<unknown>;
+  return c;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: (t: string) => chain(t) })),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(async () => ({ userId: "user-1" })),
+}));
+
+import { getOutreachPerformance } from "@/lib/tools/learning-tools";
+
+beforeEach(() => {
+  repliesError = null;
+});
+
+describe("getOutreachPerformance", () => {
+  it("refuses to fabricate a 0% reply rate from a failed replies fetch", async () => {
+    repliesError = { message: "connection reset by peer" };
+
+    const result = (await getOutreachPerformance.execute!({}, {} as never)) as {
+      error?: string;
+    };
+
+    expect(result.error).toContain("connection reset");
+    expect(result.error).toMatch(/retry/i);
+  });
+
+  it("still computes when the replies fetch succeeds", async () => {
+    const result = (await getOutreachPerformance.execute!({}, {} as never)) as {
+      error?: string;
+      sends?: number;
+    };
+
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/lib/jobs/executors/outreach-learn.ts
+++ b/src/lib/jobs/executors/outreach-learn.ts
@@ -230,21 +230,49 @@ async function learnForUser(
   const aggregates = computeAggregates(outcomes);
 
   // ── timing stats rewrite (always, guardrails or not) ─────────────────────
+  // Upsert-then-prune, not delete-then-insert: the old order had a window
+  // where the grid was empty, and an insert failure after a successful
+  // delete wiped the user's timing data for a whole week while the run
+  // reported clean success. Upserting keys on the table's primary key
+  // (user_id, weekday, day_part), so a failure leaves last week's grid
+  // intact; the prune then drops only buckets absent from this week's set.
   const statRows = timingStatsRows(userId, aggregates);
-  const { error: deleteError } = await supabase
-    .from("outreach_timing_stats")
-    .delete()
-    .eq("user_id", userId);
-  if (deleteError) {
-    console.error("[outreach-learn] timing stats delete failed:", deleteError);
-  } else if (statRows.length > 0) {
-    const { error: insertError } = await supabase
+  const rewriteAt = new Date().toISOString();
+  if (statRows.length > 0) {
+    const { error: upsertError } = await supabase
       .from("outreach_timing_stats")
-      .insert(statRows);
-    if (insertError) {
+      .upsert(
+        statRows.map((r) => ({ ...r, updated_at: rewriteAt })),
+        { onConflict: "user_id,weekday,day_part" },
+      );
+    if (upsertError) {
       console.error(
-        "[outreach-learn] timing stats insert failed:",
-        insertError,
+        "[outreach-learn] timing stats upsert failed (previous grid kept):",
+        upsertError,
+      );
+    } else {
+      const { error: pruneError } = await supabase
+        .from("outreach_timing_stats")
+        .delete()
+        .eq("user_id", userId)
+        .lt("updated_at", rewriteAt);
+      if (pruneError) {
+        console.error(
+          "[outreach-learn] timing stats prune failed:",
+          pruneError,
+        );
+      }
+    }
+  } else {
+    // No sends in the window at all: an empty grid is the truth.
+    const { error: deleteError } = await supabase
+      .from("outreach_timing_stats")
+      .delete()
+      .eq("user_id", userId);
+    if (deleteError) {
+      console.error(
+        "[outreach-learn] timing stats delete failed:",
+        deleteError,
       );
     }
   }

--- a/src/lib/tools/learning-tools.ts
+++ b/src/lib/tools/learning-tools.ts
@@ -183,10 +183,18 @@ export const getOutreachPerformance = tool({
     const intentBySend = new Map<string, ReplyIntent>();
     const bounced = new Set<string>();
     for (const ids of chunk(sends.map((s) => s.id as string))) {
-      const { data: replies } = await supabase
+      const { data: replies, error: repliesError } = await supabase
         .from("email_replies")
         .select("sent_email_id, kind, intent")
         .in("sent_email_id", ids);
+      // A failed replies fetch is not zero replies: reporting 0% reply rate
+      // off a swallowed error has the agent telling the user "nothing is
+      // converting" as a fabricated conclusion.
+      if (repliesError) {
+        return {
+          error: `Failed to load replies: ${repliesError.message}. No performance numbers were computed: retry.`,
+        };
+      }
       for (const r of replies ?? []) {
         const sendId = r.sent_email_id as string;
         if (r.kind === "bounce") {
@@ -208,10 +216,18 @@ export const getOutreachPerformance = tool({
     ] as string[];
     const signalNames = new Map<string, string>();
     if (sequenceIds.length > 0) {
-      const { data: seqs } = await supabase
+      const { data: seqs, error: seqsError } = await supabase
         .from("sequences")
         .select("id, signals(name)")
         .in("id", sequenceIds);
+      // Same rule: an empty signal breakdown from a swallowed error reads as
+      // "no signal is converting", which is a claim about the data, not about
+      // the outage.
+      if (seqsError) {
+        return {
+          error: `Failed to load signal names: ${seqsError.message}. No performance numbers were computed: retry.`,
+        };
+      }
       for (const seq of seqs ?? []) {
         const signal = Array.isArray(seq.signals)
           ? seq.signals[0]


### PR DESCRIPTION
Wave-7 cluster (PR-22 of the hardening plan): the 2 learning-loop findings. Independent (branched off main), no migration. **Gates prod repair 18** (forcing an outreach.learn re-run per user to rebuild timing stats).

## Delete-then-insert wiping a week of timing data (`outreach-learn.ts:234`)
The weekly rewrite deleted all of a user's `outreach_timing_stats` rows and then inserted the new set: an insert failure (payload too large, transient 5xx) after the successful delete left the grid empty for a week, with the error console-logged and the run returning `analyzed: true` as clean job success; a concurrent dashboard read also saw the empty window between the statements. The table's primary key `(user_id, weekday, day_part)` makes an upsert natural: new buckets land atomically over old ones, and only after that succeeds does a prune (`updated_at < rewriteAt`) drop buckets absent from this week's set. Every failure mode now leaves last week's grid intact.

## 0% reply rate as an outage artifact (`learning-tools.ts:186`)
`getOutreachPerformance` never read the `email_replies` query error: on any failed chunk, replies defaulted to `[]`, every send got `intent: null`, and the aggregates reported 0% reply rate by hour, step, and signal, which the agent confidently relayed as "no replies in the window, nothing is converting". The sequences/signals lookup had the same hole (signal breakdown silently empty). Both now return an explicit "no performance numbers were computed: retry" error.

Suite: 921 passed (2 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)