### PR TITLE
fix(search): YC scraper bounds, honest hiring flag, filter-aware cache

### DIFF
--- a/src/__tests__/yc-cache-path.test.ts
+++ b/src/__tests__/yc-cache-path.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * searchYCCompanies' cache short-circuit. The cache stores only batch and
+ * industry, so it can only answer requests shaped that way: the old path
+ * matched every cached batch row regardless of region/teamSize/isHiring/query,
+ * auto-linked the non-matching companies to the campaign, and a single cached
+ * row suppressed the scrape for a 30-company request.
+ */
+
+let cachedRows: Array<Record<string, unknown>> = [];
+
+function chain(table: string) {
+  const c: Record<string, unknown> & PromiseLike<unknown> = {
+    select: () => c,
+    eq: () => c,
+    ilike: () => c,
+    limit: () => c,
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve({
+        data: table === "organizations" ? cachedRows : [],
+        error: null,
+      }).then(onF, onR),
+  } as unknown as Record<string, unknown> & PromiseLike<unknown>;
+  return c;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: (t: string) => chain(t) })),
+}));
+
+const scrapeYCCompanies = vi.fn();
+vi.mock("@/lib/services/yc-scraper", () => ({
+  scrapeYCCompanies: (...args: unknown[]) =>
+    (scrapeYCCompanies as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
+import { searchYCCompanies } from "@/lib/tools/search-tools";
+
+const org = (id: string): Record<string, unknown> => ({
+  id,
+  name: `Co ${id}`,
+  domain: `${id}.com`,
+  url: `https://${id}.com`,
+  industry: "fintech",
+  location: "SF",
+  description: null,
+  source: "yc_directory",
+  enrichment_data: { yc: { batch: "W25" } },
+});
+
+const run = (input: Record<string, unknown>) =>
+  (
+    searchYCCompanies as unknown as {
+      execute: (i: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    }
+  ).execute({ maxResults: 2, ...input });
+
+beforeEach(() => {
+  cachedRows = [];
+  scrapeYCCompanies.mockReset().mockResolvedValue({
+    companies: [],
+    totalFound: 0,
+  });
+});
+
+describe("searchYCCompanies cache", () => {
+  it("scrapes when the request carries filters the cache cannot answer", async () => {
+    cachedRows = [org("a"), org("b")];
+
+    await run({ batch: "W25", region: "Europe" });
+
+    expect(scrapeYCCompanies).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrapes when the cache holds fewer rows than requested", async () => {
+    // One cached row used to suppress the scrape entirely: a request for 30
+    // companies returned 1 with no indication more exist.
+    cachedRows = [org("a")];
+
+    await run({ batch: "W25" });
+
+    expect(scrapeYCCompanies).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves a full cacheable request from cache without scraping", async () => {
+    cachedRows = [org("a"), org("b")];
+
+    const result = await run({ batch: "W25" });
+
+    expect(scrapeYCCompanies).not.toHaveBeenCalled();
+    expect(result.source).toBe("cache");
+  });
+});

--- a/src/lib/services/yc-scraper.ts
+++ b/src/lib/services/yc-scraper.ts
@@ -103,11 +103,25 @@ async function scrapeDirectoryListing(filters: YCFilters): Promise<{
     await page.waitForTimeout(3000);
 
     // Scroll to load all lazy-loaded companies.
-    // Keep scrolling until no new cards appear for 2 consecutive passes.
+    // Keep scrolling until no new cards appear for 2 consecutive passes,
+    // bounded hard: with a broad or empty filter the directory
+    // infinite-scrolls thousands of cards, stableRounds resets on every
+    // count increase, and the loop used to run until Vercel froze the
+    // function mid-loop; the finally block never ran and the Browserbase
+    // concurrency slot leaked, stalling every later sessions.create.
+    const MAX_SCROLL_ROUNDS = 40;
+    const SCROLL_DEADLINE_MS = 90_000;
+    const scrollStart = Date.now();
     let previousCount = 0;
     let stableRounds = 0;
+    let rounds = 0;
 
-    while (stableRounds < 2) {
+    while (
+      stableRounds < 2 &&
+      rounds < MAX_SCROLL_ROUNDS &&
+      Date.now() - scrollStart < SCROLL_DEADLINE_MS
+    ) {
+      rounds++;
       await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
       await page.waitForTimeout(1500);
 
@@ -310,11 +324,15 @@ async function scrapeCompanyDetails(
           );
           const teamSize = teamMatch ? teamMatch[1] : null;
 
-          // Hiring
+          // Hiring. The selector must not match YC's site-wide chrome: every
+          // page carries a global "Startup Jobs" nav link whose href contains
+          // /jobs, so a bare [href*="jobs"] marked essentially every company
+          // as hiring. A company that IS hiring links its own listings at
+          // workatastartup.com/companies/<slug>.
           const isHiring =
             !!document.querySelector(
-              '[href*="jobs"], [href*="careers"], [class*="hiring"]',
-            ) || /currently hiring/i.test(bodyText);
+              'a[href*="workatastartup.com/companies"]',
+            ) || /currently hiring|is hiring/i.test(bodyText);
 
           // Founders
           const founders: Array<{

--- a/src/lib/tools/search-tools.ts
+++ b/src/lib/tools/search-tools.ts
@@ -3,6 +3,7 @@ import { generateObject, tool } from "ai";
 import { z } from "zod";
 import { apiSafeSchema } from "@/lib/ai/api-safe-schema";
 import { MODELS } from "@/lib/ai/models";
+import { llmTimeout } from "@/lib/utils/timeout";
 import { createClient } from "@/lib/supabase/server";
 import {
   callerHoldsOrganization,
@@ -572,6 +573,8 @@ export const discoverCompanies = tool({
       .join("\n\n");
 
     const { object: extracted, usage } = await generateObject({
+      // K17: without a timeout a hung extraction pins the whole tool call.
+      abortSignal: llmTimeout(),
       model: anthropic(MODELS.LIGHT),
       schema: apiSafeSchema(
         z.object({
@@ -773,25 +776,51 @@ export const searchYCCompanies = tool({
     const supabase = await createClient();
 
     // ── Step 1: Check cache ──────────────────────────────────────────────
-    let cacheQuery = supabase
-      .from("organizations")
-      .select("*")
-      .eq("source", "yc_directory");
+    // The cache stores only what it can filter on (batch, industry). A
+    // request carrying region, teamSize, isHiring, or a query MUST scrape:
+    // the old path matched every cached row for the batch regardless of the
+    // finer filters, auto-linked the non-matching companies to the campaign,
+    // and reported them as matches. And a partial cache must not
+    // short-circuit either: one cached row for a batch used to suppress the
+    // scrape for a 30-company request with no hint more exist.
+    const cacheable =
+      !input.region &&
+      !input.teamSize &&
+      input.isHiring === undefined &&
+      !input.query;
 
-    if (input.batch) {
-      cacheQuery = cacheQuery.eq(
-        "enrichment_data->yc->>batch",
-        input.batch.toUpperCase(),
-      );
+    interface CachedOrg {
+      id: string;
+      name: string;
+      domain: string | null;
+      url: string | null;
+      industry: string | null;
+      location: string | null;
+      description: string | null;
+      enrichment_data: Record<string, unknown> | null;
     }
-    if (input.industry) {
-      cacheQuery = cacheQuery.ilike("industry", `%${input.industry}%`);
+    let cachedOrgs: CachedOrg[] = [];
+    if (cacheable) {
+      let cacheQuery = supabase
+        .from("organizations")
+        .select("*")
+        .eq("source", "yc_directory");
+
+      if (input.batch) {
+        cacheQuery = cacheQuery.eq(
+          "enrichment_data->yc->>batch",
+          input.batch.toUpperCase(),
+        );
+      }
+      if (input.industry) {
+        cacheQuery = cacheQuery.ilike("industry", `%${input.industry}%`);
+      }
+
+      const { data: cached } = await cacheQuery.limit(input.maxResults);
+      cachedOrgs = (cached || []) as CachedOrg[];
     }
 
-    const { data: cached } = await cacheQuery.limit(input.maxResults);
-    const cachedOrgs = cached || [];
-
-    if (cachedOrgs.length > 0) {
+    if (cachedOrgs.length >= input.maxResults) {
       let newlyLinked = 0;
       if (input.campaignId) {
         const { data: existingLinks } = await supabase


### PR DESCRIPTION
Wave-7 cluster (PR-23 of the hardening plan): K17 plus the 3 YC/search findings. Independent (branched off main).

## Unbounded billed scrolling (`yc-scraper.ts:110`)
`while (stableRounds < 2)` had no iteration cap or deadline, and `stableRounds` resets on every count increase: a broad or empty filter infinite-scrolled the entire YC directory (thousands of cards, ~1.5s+ per pass) on a billed Browserbase session until Vercel hit `maxDuration` and froze the process mid-loop. The `finally` (releaseSession) never ran, leaking the Browserbase concurrency slot: the exact stall the release comment documents as previously making every later `sessions.create` queue forever. The loop now stops at 40 rounds or 90 seconds, whichever first.

## Everyone is hiring (`yc-scraper.ts:315`)
`isHiring` matched `[href*="jobs"], [href*="careers"], [class*="hiring"]` against the whole document, and YC's global chrome carries a "Startup Jobs" link on every page: the flag came back true for essentially every company, corrupting any ICP timing decision built on it. It now requires the company's own `workatastartup.com/companies/<slug>` listing link or explicit hiring text.

## Cache ignoring most of the request (`search-tools.ts:791`)
The cache path filtered only by batch and industry, so "W25 fintech in Europe that are hiring" matched every cached W25 row, auto-linked the non-matching companies to the campaign via `linkOrganizationToCampaign`, and reported them as matches. And any nonzero hit count suppressed the scrape entirely: one cached row satisfied a 30-company request with no hint more exist. The cache now answers only requests shaped like what it stores (batch/industry, no finer filters) and only when it holds at least `maxResults` rows; everything else scrapes.

## K17
The directory-extraction `generateObject` call had no abort signal; it now carries `llmTimeout()` like every other LLM call in the codebase.

Suite: 922 passed (3 new), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)