### PR TITLE
fix(fetch): apiFetch everywhere; cost center stops crashing settings

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { Loader2, Sparkles, X } from "lucide-react";
@@ -555,7 +556,7 @@ function FactBankSection({
     setResearchNote(null);
     setResearchError(null);
     try {
-      const res = await fetch("/api/profile/research-facts", {
+      const res = await apiFetch("/api/profile/research-facts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ profileId }),

--- a/src/components/company/add-person-dialog.tsx
+++ b/src/components/company/add-person-dialog.tsx
@@ -55,7 +55,7 @@ export function AddPersonDialog({
       setSearching(true);
       try {
         const url = `/api/people/orphans${query ? `?q=${encodeURIComponent(query)}` : ""}`;
-        const res = await fetch(url);
+        const res = await apiFetch(url);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const { people } = (await res.json()) as { people: OrphanRow[] };
         if (seq !== searchSeqRef.current) return;

--- a/src/components/company/classify-button.tsx
+++ b/src/components/company/classify-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import { Loader2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
@@ -22,7 +23,7 @@ export function ClassifyButton({
   async function run() {
     setBusy(true);
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `/api/companies/${companyId}/classify-departments`,
         { method: "POST" },
       );

--- a/src/components/company/embedded-org-chart.tsx
+++ b/src/components/company/embedded-org-chart.tsx
@@ -59,7 +59,7 @@ export function EmbeddedOrgChart({
   async function refresh() {
     setRefreshing(true);
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `/api/companies/${organizationId}/classify-departments`,
         { method: "POST" },
       );
@@ -150,7 +150,7 @@ export function EmbeddedOrgChart({
               const url = campaignId
                 ? `/api/people/${personId}/from-company?campaignId=${campaignId}&organizationId=${organizationId}`
                 : `/api/people/${personId}/from-company?organizationId=${organizationId}`;
-              const res = await fetch(url, { method: "DELETE" });
+              const res = await apiFetch(url, { method: "DELETE" });
               if (!res.ok) {
                 const err = await res.json().catch(() => ({}));
                 throw new Error(err.error ?? `HTTP ${res.status}`);
@@ -189,7 +189,7 @@ export function EmbeddedOrgChart({
             const url = campaignId
               ? `/api/people/${personId}/from-company?campaignId=${campaignId}&organizationId=${organizationId}`
               : `/api/people/${personId}/from-company?organizationId=${organizationId}`;
-            const res = await fetch(url, { method: "DELETE" });
+            const res = await apiFetch(url, { method: "DELETE" });
             if (!res.ok) {
               const err = await res.json().catch(() => ({}));
               throw new Error(err.error ?? `HTTP ${res.status}`);

--- a/src/components/settings/cost-center.tsx
+++ b/src/components/settings/cost-center.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import { formatRelative } from "@/components/ui/relative-time";
 
 import { SettingsSection } from "@/components/settings/settings-section";
@@ -131,6 +132,7 @@ export function CostCenter() {
   const [page, setPage] = useState(1);
   const [data, setData] = useState<CostData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const mountedRef = useRef(true);
 
@@ -149,16 +151,27 @@ export function CostCenter() {
     const url =
       `/api/settings/costs?period=${period}&page=${page}&pageSize=${PAGE_SIZE}` +
       (refreshNonce > 0 ? `&_=${refreshNonce}` : "");
-    fetch(url, { cache: "no-store" })
-      .then((r) => r.json())
+    // apiFetch, and res.ok checked: a raw fetch's 401 body ({error}) parsed
+    // fine, was stored as CostData, and the render then crashed iterating
+    // data.byService (undefined), taking the whole settings page to the root
+    // error boundary instead of showing an error.
+    apiFetch(url, { cache: "no-store" })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((d) => {
         if (mountedRef.current) {
           setData(d);
+          setLoadError(null);
           setLoading(false);
         }
       })
-      .catch(() => {
-        if (mountedRef.current) setLoading(false);
+      .catch((err) => {
+        if (mountedRef.current) {
+          setLoadError(err instanceof Error ? err.message : "load failed");
+          setLoading(false);
+        }
       });
   }, [period, page, refreshNonce]);
 
@@ -204,6 +217,10 @@ export function CostCenter() {
     <SettingsSection title="Usage" actions={actions}>
       {loading ? (
         <p className="text-muted-foreground text-sm">Loading cost data...</p>
+      ) : loadError ? (
+        <p role="alert" className="text-destructive text-sm">
+          Could not load cost data: {loadError}. Refresh to retry.
+        </p>
       ) : !data || (data.totalCost === 0 && data.byService.length === 0) ? (
         <p className="text-muted-foreground text-sm">
           No API usage recorded yet. Costs will appear here as you use chat,

--- a/src/components/tracking/tracking-table.tsx
+++ b/src/components/tracking/tracking-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import {
   ChevronDown,
   ChevronRight,
@@ -101,7 +102,9 @@ function ExpandableSignalRow({ row }: { row: TrackingRow }) {
   const runNow = async (e: React.MouseEvent) => {
     e.stopPropagation();
     setRunning(true);
-    const res = await fetch(`/api/tracking/${row.id}/run`, { method: "POST" });
+    const res = await apiFetch(`/api/tracking/${row.id}/run`, {
+      method: "POST",
+    });
     setRunning(false);
     if (res.ok) {
       toast.success("Check queued: results land within a minute or two");


### PR DESCRIPTION
Wave-8 cluster (PR-25 of the hardening plan): K14 plus 3. Sequenced after every other cluster merged so the sweep touches nothing twice.

## The K14 class
`apiFetch` exists precisely to attach a freshly minted Clerk Bearer token; a raw `fetch("/api/...")` rides the session cookie alone, which expires in long-open tabs (testing against prod in a day-old tab is the documented workflow here). Seven call sites still used raw fetch, all against auth-protected routes:

- `tracking-table` run-now POST
- `add-person-dialog` orphan search (a 401 rendered as "No unassigned people in your knowledge base": a false data-quality conclusion)
- `embedded-org-chart`: the Refresh-org classify POST and both remove-from-company DELETEs (while the reclassify PATCH in the same file already used apiFetch)
- `classify-button` classify POST
- profile page research POST

All now go through `apiFetch`.

## The crash (`cost-center.tsx:165`)
The costs fetch never checked `res.ok`, so a 401/500 `{error}` JSON body parsed cleanly and was stored as `CostData`; the render's `for (const s of data.byService)` then threw on `undefined` and React unmounted to the root error boundary: the whole settings page replaced by an error screen instead of a re-auth prompt. Now `apiFetch` + `res.ok` + an inline error state with retry.

Suite: 1004 passed, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)