### PR TITLE
fix(errors): the K7 sweep, failures stop rendering as data

### DIFF
--- a/src/__tests__/email-test.test.ts
+++ b/src/__tests__/email-test.test.ts
@@ -7,6 +7,7 @@ import {
   checkTestCooldown,
   matchTestReply,
   validateTestRecipient,
+  stripQuotedReply,
 } from "@/lib/services/email-test";
 
 describe("validateTestRecipient", () => {
@@ -162,5 +163,32 @@ On Thu, 30 Jul 2026 at 22:48, <jay@sahnan.co> wrote:
 
   it("returns empty string for a body that is entirely quoted", () => {
     expect(extractReplyText("> only quoted\n> lines here")).toBe("");
+  });
+});
+
+describe("stripQuotedReply wrapped attributions", () => {
+  it("drops a Gmail attribution wrapped across two lines", () => {
+    // Gmail wraps the attribution at ~78 chars, so the single-line test let
+    // both fragments through into stored reply bodies and the Settings
+    // test-send snippet.
+    const raw = [
+      "Sounds good, let's talk Tuesday.",
+      "",
+      "On Thu, 30 Jul 2026 at 22:48, Jay Sahnan",
+      "<jay@sahnan.co> wrote:",
+      "> This is a test send from Signal.",
+    ].join("\n");
+
+    expect(stripQuotedReply(raw)).toBe("Sounds good, let's talk Tuesday.");
+  });
+
+  it("still drops a single-line attribution", () => {
+    const raw = [
+      "Yes please.",
+      "On Thu, 30 Jul 2026 at 22:48, <jay@sahnan.co> wrote:",
+      "> old text",
+    ].join("\n");
+
+    expect(stripQuotedReply(raw)).toBe("Yes please.");
   });
 });

--- a/src/app/api/people/orphans/route.ts
+++ b/src/app/api/people/orphans/route.ts
@@ -29,10 +29,18 @@ export async function GET(request: Request) {
   // Surface only orphans the user has touched: any person with no
   // organization_id whose campaign_people row points to one of the
   // user's campaigns.
-  const { data: ownedPersonIds } = await supabase
+  // A failed read must not render as "no unassigned people": that empty
+  // state is a data-quality claim the user acts on.
+  const { data: ownedPersonIds, error: ownedError } = await supabase
     .from("campaign_people")
     .select("person_id, campaign:campaigns!inner(user_id)")
     .eq("campaign.user_id", user.id);
+  if (ownedError) {
+    return Response.json(
+      { error: `Could not load people: ${ownedError.message}` },
+      { status: 500 },
+    );
+  }
 
   const allowedIds = new Set(
     ((ownedPersonIds ?? []) as Array<{ person_id: string }>).map(

--- a/src/app/api/refresh-scores/route.ts
+++ b/src/app/api/refresh-scores/route.ts
@@ -210,18 +210,34 @@ ${wrapUntrusted(JSON.stringify(contactSummaries, null, 2))}`,
         user_id: user.id,
       });
 
-      // Batch update scores on campaign_people junction table
-      const updates = result.object.scores.map((s) =>
-        supabase
-          .from("campaign_people")
-          .update({ priority_score: s.score, score_reason: s.reason })
-          .eq("id", s.id),
+      // Batch update scores on campaign_people junction table. Each write's
+      // outcome is read: query builders never reject, so a bare Promise.all
+      // reported every row scored while failed writes and LLM-hallucinated
+      // link ids (a 0-row match returns no error) silently persisted nothing.
+      const outcomes = await Promise.all(
+        result.object.scores.map(async (s) => {
+          const { data: updated, error } = await supabase
+            .from("campaign_people")
+            .update({ priority_score: s.score, score_reason: s.reason })
+            .eq("id", s.id)
+            .select("id");
+          if (error || !updated || updated.length === 0) {
+            console.error(
+              `[refresh-scores] score write matched nothing for ${s.id}:`,
+              error?.message ?? "0 rows",
+            );
+            return { id: s.id, stored: false };
+          }
+          return { id: s.id, stored: true };
+        }),
       );
 
-      await Promise.all(updates);
+      const stored = outcomes.filter((o) => o.stored).length;
+      const failedIds = outcomes.filter((o) => !o.stored).map((o) => o.id);
 
       return Response.json({
-        scored: result.object.scores.length,
+        scored: stored,
+        ...(failedIds.length > 0 ? { failedIds } : {}),
         scores: result.object.scores,
       });
     },

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -28,6 +28,7 @@ interface CampaignRow {
 export default function CampaignsIndexPage() {
   const [campaigns, setCampaigns] = useState<CampaignRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
@@ -36,13 +37,20 @@ export default function CampaignsIndexPage() {
 
     const fetchCampaigns = async () => {
       const supabase = createClient();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("campaigns")
         .select("id, name, status, created_at")
         .order("updated_at", { ascending: false });
 
       if (mountedRef.current) {
-        setCampaigns(data ?? []);
+        // A failed load is not "No campaigns yet": that empty state invites
+        // creating a duplicate.
+        if (error) {
+          setLoadError(error.message);
+        } else {
+          setLoadError(null);
+          setCampaigns(data ?? []);
+        }
         setLoading(false);
       }
     };
@@ -93,6 +101,11 @@ export default function CampaignsIndexPage() {
             <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
             <div className="bg-muted/40 h-9 w-full animate-pulse rounded" />
           </div>
+        ) : loadError ? (
+          <p role="alert" className="text-destructive text-sm">
+            Could not load campaigns: {loadError}. Your campaigns are likely
+            still there: reload rather than creating a new one.
+          </p>
         ) : campaigns.length === 0 ? (
           <p className="text-muted-foreground text-sm">
             No campaigns yet. Start one from the chat or the Overview page.

--- a/src/app/companies/[id]/page.tsx
+++ b/src/app/companies/[id]/page.tsx
@@ -107,6 +107,16 @@ export default function CompanyPage() {
       return;
     }
 
+    // A failed people or campaigns sub-query must not render the company as
+    // "0 people" with an empty org chart: that reads as a data state, not an
+    // outage.
+    const subError = peopleRes.error || campaignsRes.error;
+    if (subError) {
+      setError(`Failed to load company data: ${subError.message}`);
+      setLoading(false);
+      return;
+    }
+
     setOrg(orgRes.data as OrgRow);
     setPeople((peopleRes.data ?? []) as PersonRow[]);
 

--- a/src/app/email-skills/page.tsx
+++ b/src/app/email-skills/page.tsx
@@ -12,6 +12,7 @@ import { LearningsSection } from "@/components/email-skills/learnings-section";
 import { VoiceProfileView } from "@/components/email-skills/voice-profile-view";
 import { VoiceSwipe } from "@/components/email-skills/voice-swipe";
 import { useCampaign } from "@/lib/campaign-context";
+import { useStreaming } from "@/lib/streaming-context";
 import { useVoiceRun } from "@/lib/voice-run-context";
 import { createClient } from "@/lib/supabase/client";
 import type { VoiceProfile } from "@/lib/types/email-voice";
@@ -45,6 +46,7 @@ function EmailVoiceScope() {
   const searchParams = useSearchParams();
   const campaignId = searchParams.get("campaign");
   const { openAgentWith } = useCampaign();
+  const { isStreaming } = useStreaming();
   const { run, savedTick, discardRun } = useVoiceRun();
 
   const [profiles, setProfiles] = useState<VoiceSummary[]>([]);
@@ -55,6 +57,26 @@ function EmailVoiceScope() {
   const [running, setRunning] = useState(false);
   /** A refinement was handed to the agent; cleared when a save lands. */
   const [refineSent, setRefineSent] = useState(false);
+  const refineWasStreamingRef = useRef(false);
+
+  // refineSent is otherwise cleared only by a successful save (the rules
+  // change remounts the view via key={updated_at}), so a failed or abandoned
+  // refine left the voice page busy forever. When the agent's stream ends
+  // without a rules change, release the busy state after a grace period for
+  // the refetch to land.
+  useEffect(() => {
+    if (!refineSent) {
+      refineWasStreamingRef.current = false;
+      return;
+    }
+    if (isStreaming) {
+      refineWasStreamingRef.current = true;
+      return;
+    }
+    if (!refineWasStreamingRef.current) return;
+    const t = setTimeout(() => setRefineSent(false), 5000);
+    return () => clearTimeout(t);
+  }, [refineSent, isStreaming]);
 
   const mountedRef = useRef(true);
 

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { Loader2, Sparkles, X } from "lucide-react";
@@ -555,7 +556,7 @@ function FactBankSection({
     setResearchNote(null);
     setResearchError(null);
     try {
-      const res = await fetch("/api/profile/research-facts", {
+      const res = await apiFetch("/api/profile/research-facts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ profileId }),

--- a/src/components/company/add-person-dialog.tsx
+++ b/src/components/company/add-person-dialog.tsx
@@ -55,7 +55,7 @@ export function AddPersonDialog({
       setSearching(true);
       try {
         const url = `/api/people/orphans${query ? `?q=${encodeURIComponent(query)}` : ""}`;
-        const res = await fetch(url);
+        const res = await apiFetch(url);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const { people } = (await res.json()) as { people: OrphanRow[] };
         if (seq !== searchSeqRef.current) return;

--- a/src/components/company/classify-button.tsx
+++ b/src/components/company/classify-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import { Loader2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
@@ -22,7 +23,7 @@ export function ClassifyButton({
   async function run() {
     setBusy(true);
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `/api/companies/${companyId}/classify-departments`,
         { method: "POST" },
       );

--- a/src/components/company/embedded-org-chart.tsx
+++ b/src/components/company/embedded-org-chart.tsx
@@ -59,7 +59,7 @@ export function EmbeddedOrgChart({
   async function refresh() {
     setRefreshing(true);
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `/api/companies/${organizationId}/classify-departments`,
         { method: "POST" },
       );
@@ -150,7 +150,7 @@ export function EmbeddedOrgChart({
               const url = campaignId
                 ? `/api/people/${personId}/from-company?campaignId=${campaignId}&organizationId=${organizationId}`
                 : `/api/people/${personId}/from-company?organizationId=${organizationId}`;
-              const res = await fetch(url, { method: "DELETE" });
+              const res = await apiFetch(url, { method: "DELETE" });
               if (!res.ok) {
                 const err = await res.json().catch(() => ({}));
                 throw new Error(err.error ?? `HTTP ${res.status}`);
@@ -189,7 +189,7 @@ export function EmbeddedOrgChart({
             const url = campaignId
               ? `/api/people/${personId}/from-company?campaignId=${campaignId}&organizationId=${organizationId}`
               : `/api/people/${personId}/from-company?organizationId=${organizationId}`;
-            const res = await fetch(url, { method: "DELETE" });
+            const res = await apiFetch(url, { method: "DELETE" });
             if (!res.ok) {
               const err = await res.json().catch(() => ({}));
               throw new Error(err.error ?? `HTTP ${res.status}`);

--- a/src/components/email-skills/learnings-section.tsx
+++ b/src/components/email-skills/learnings-section.tsx
@@ -65,6 +65,7 @@ export function LearningsSection() {
   const [timing, setTiming] = useState<TimingRow[]>([]);
   const [suppressions, setSuppressions] = useState<SuppressionRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState("");
   const mountedRef = useRef(true);
@@ -72,14 +73,22 @@ export function LearningsSection() {
   const load = useCallback(async () => {
     try {
       const res = await apiFetch("/api/learnings");
-      if (!res.ok || !mountedRef.current) return;
+      if (!mountedRef.current) return;
+      // A failed load must not render as the "Nothing yet" empty state.
+      if (!res.ok) {
+        setLoadError(`HTTP ${res.status}`);
+        return;
+      }
       const data = await res.json();
       if (!mountedRef.current) return;
+      setLoadError(null);
       setLearnings(data.learnings ?? []);
       setTiming(data.timing ?? []);
       setSuppressions(data.suppressions ?? []);
-    } catch {
-      // Silent: the section simply stays empty on a load failure.
+    } catch (err) {
+      if (mountedRef.current) {
+        setLoadError(err instanceof Error ? err.message : "load failed");
+      }
     } finally {
       if (mountedRef.current) setLoading(false);
     }
@@ -144,6 +153,16 @@ export function LearningsSection() {
           <Loader2 className="size-4 animate-spin" />
           Loading learnings...
         </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="border-border bg-card rounded-xl border px-5 py-6 md:px-6">
+        <p role="alert" className="text-destructive text-sm">
+          Could not load learnings: {loadError}. Reload to retry.
+        </p>
       </div>
     );
   }

--- a/src/components/settings/cost-center.tsx
+++ b/src/components/settings/cost-center.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import { formatRelative } from "@/components/ui/relative-time";
 
 import { SettingsSection } from "@/components/settings/settings-section";
@@ -131,6 +132,7 @@ export function CostCenter() {
   const [page, setPage] = useState(1);
   const [data, setData] = useState<CostData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const mountedRef = useRef(true);
 
@@ -149,16 +151,27 @@ export function CostCenter() {
     const url =
       `/api/settings/costs?period=${period}&page=${page}&pageSize=${PAGE_SIZE}` +
       (refreshNonce > 0 ? `&_=${refreshNonce}` : "");
-    fetch(url, { cache: "no-store" })
-      .then((r) => r.json())
+    // apiFetch, and res.ok checked: a raw fetch's 401 body ({error}) parsed
+    // fine, was stored as CostData, and the render then crashed iterating
+    // data.byService (undefined), taking the whole settings page to the root
+    // error boundary instead of showing an error.
+    apiFetch(url, { cache: "no-store" })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((d) => {
         if (mountedRef.current) {
           setData(d);
+          setLoadError(null);
           setLoading(false);
         }
       })
-      .catch(() => {
-        if (mountedRef.current) setLoading(false);
+      .catch((err) => {
+        if (mountedRef.current) {
+          setLoadError(err instanceof Error ? err.message : "load failed");
+          setLoading(false);
+        }
       });
   }, [period, page, refreshNonce]);
 
@@ -204,6 +217,10 @@ export function CostCenter() {
     <SettingsSection title="Usage" actions={actions}>
       {loading ? (
         <p className="text-muted-foreground text-sm">Loading cost data...</p>
+      ) : loadError ? (
+        <p role="alert" className="text-destructive text-sm">
+          Could not load cost data: {loadError}. Refresh to retry.
+        </p>
       ) : !data || (data.totalCost === 0 && data.byService.length === 0) ? (
         <p className="text-muted-foreground text-sm">
           No API usage recorded yet. Costs will appear here as you use chat,

--- a/src/components/sidebar-campaigns.tsx
+++ b/src/components/sidebar-campaigns.tsx
@@ -37,6 +37,7 @@ export function SidebarCampaigns({
 }: SidebarCampaignsProps) {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -52,6 +53,12 @@ export function SidebarCampaigns({
       if (mountedRef.current) {
         if (!error && data) {
           setCampaigns(data);
+          setLoadFailed(false);
+        } else if (error) {
+          // Keep any list we already have (this is a 10s poll), but never
+          // render a first-load failure as the "Speak to agent to get
+          // started" empty state.
+          setLoadFailed(true);
         }
         setLoading(false);
       }
@@ -80,7 +87,15 @@ export function SidebarCampaigns({
             </SidebarMenuItem>
           )}
 
-          {!loading && campaigns.length === 0 && (
+          {!loading && loadFailed && campaigns.length === 0 && (
+            <SidebarMenuItem>
+              <SidebarMenuButton disabled className="text-destructive">
+                <span className="text-xs">Campaigns failed to load</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          )}
+
+          {!loading && !loadFailed && campaigns.length === 0 && (
             <SidebarMenuItem>
               <SidebarMenuButton
                 onClick={() => onSelectCampaign(null)}

--- a/src/components/tracking/tracking-table.tsx
+++ b/src/components/tracking/tracking-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { apiFetch } from "@/lib/api-fetch";
 import {
   ChevronDown,
   ChevronRight,
@@ -101,7 +102,9 @@ function ExpandableSignalRow({ row }: { row: TrackingRow }) {
   const runNow = async (e: React.MouseEvent) => {
     e.stopPropagation();
     setRunning(true);
-    const res = await fetch(`/api/tracking/${row.id}/run`, { method: "POST" });
+    const res = await apiFetch(`/api/tracking/${row.id}/run`, {
+      method: "POST",
+    });
     setRunning(false);
     if (res.ok) {
       toast.success("Check queued: results land within a minute or two");

--- a/src/lib/email-composition/save.ts
+++ b/src/lib/email-composition/save.ts
@@ -34,12 +34,21 @@ export async function saveDraft(
   supabase: SupabaseClient,
   input: SaveDraftInput,
 ): Promise<SaveDraftResult> {
-  const { data: person } = await supabase
+  // A failed read is not a missing person. "Person not found. Use findEmail
+  // to discover one first." is a factual claim the agent acts on: it re-runs
+  // discovery or drops the contact, when the right move was to retry.
+  const { data: person, error: personError } = await supabase
     .from("people")
     .select("id, name, work_email, personal_email")
     .eq("id", input.personId)
     .single();
 
+  if (personError && personError.code !== "PGRST116") {
+    return {
+      ok: false,
+      error: `Could not load the contact (${personError.message}). This is a temporary failure: retry, do not re-run discovery.`,
+    };
+  }
   if (!person) {
     return { ok: false, error: "Person not found." };
   }
@@ -53,13 +62,19 @@ export async function saveDraft(
     };
   }
 
-  const { data: cp } = await supabase
+  const { data: cp, error: cpError } = await supabase
     .from("campaign_people")
     .select("id")
     .eq("campaign_id", input.campaignId)
     .eq("person_id", input.personId)
     .single();
 
+  if (cpError && cpError.code !== "PGRST116") {
+    return {
+      ok: false,
+      error: `Could not check the campaign link (${cpError.message}). This is a temporary failure: retry.`,
+    };
+  }
   if (!cp) {
     return {
       ok: false,

--- a/src/lib/jobs/executors/outreach-process.ts
+++ b/src/lib/jobs/executors/outreach-process.ts
@@ -90,12 +90,19 @@ async function handleSignalTrigger(
   // its drafts pending for the reviewer, and the send below goes through
   // sendApprovedDraft, which requires review_status = 'approved'. "paused"
   // and "completed" stay excluded, so pausing still halts a sequence.
-  const { data: sequences } = await supabase
+  const { data: sequences, error: sequencesError } = await supabase
     .from("sequences")
     .select("id, user_id")
     .eq("trigger_signal_id", payload.signalId)
     .eq("campaign_id", payload.campaignId)
     .in("status", ["draft", "active"]);
+
+  // Thrown, not coalesced to "no matching sequences": a failed read made a
+  // signal fire silently do nothing while the job completed clean. A throw
+  // routes through failJob, and the job system retries it.
+  if (sequencesError) {
+    throw new Error(`sequences load failed: ${sequencesError.message}`);
+  }
 
   if (!sequences || sequences.length === 0) {
     return { sent: 0, reason: "no matching sequences" };
@@ -126,10 +133,13 @@ async function handleSignalTrigger(
     .eq("current_step", 1);
 
   if (payload.organizationId) {
-    const { data: people } = await supabase
+    const { data: people, error: peopleError } = await supabase
       .from("people")
       .select("id")
       .eq("organization_id", payload.organizationId);
+    if (peopleError) {
+      throw new Error(`people load failed: ${peopleError.message}`);
+    }
     if (!people || people.length === 0) {
       return {
         sent: 0,
@@ -143,7 +153,10 @@ async function handleSignalTrigger(
     );
   }
 
-  const { data: enrollments } = await enrollmentQuery;
+  const { data: enrollments, error: enrollmentsError } = await enrollmentQuery;
+  if (enrollmentsError) {
+    throw new Error(`enrollments load failed: ${enrollmentsError.message}`);
+  }
 
   if (!enrollments || enrollments.length === 0) {
     return { sent: 0, drafted, reason: "no enrollments" };
@@ -648,14 +661,25 @@ async function handleFollowups(supabase: ReturnType<typeof getAdminClient>) {
       continue;
     }
 
-    // Check condition against outreach status
-    const { data: cp } = await supabase
+    // Check condition against outreach status. A failed read must SKIP this
+    // enrollment, not default to "sent": the default bypasses the replied/
+    // bounced stop checks below, which is exactly the follow-up-after-reply
+    // failure they exist to prevent. The next 15-minute run retries.
+    const { data: cp, error: cpError } = await supabase
       .from("campaign_people")
       .select("outreach_status")
       .eq("id", enrollment.campaign_people_id)
       .single();
+    if (cpError || !cp) {
+      console.error(
+        `[outreach/followups] outreach_status read failed for enrollment ${enrollment.id}:`,
+        cpError?.message ?? "no row",
+      );
+      skipped++;
+      continue;
+    }
 
-    const outreachStatus = cp?.outreach_status ?? "sent";
+    const outreachStatus = cp.outreach_status ?? "sent";
 
     // If they replied, stop the sequence
     if (outreachStatus === "replied") {

--- a/src/lib/services/data-quality.ts
+++ b/src/lib/services/data-quality.ts
@@ -80,17 +80,30 @@ export async function runDataQualityAudit(
 ): Promise<DataQualityReport> {
   const findings: DataQualityFinding[] = [];
 
-  const { data: orgs } = await supabase
+  // An audit run on a failed query is worse than no audit: an empty list
+  // reports a clean bill of health with zero findings, which is a claim
+  // about the data, not about the outage.
+  const { data: orgs, error: orgsError } = await supabase
     .from("organizations")
     .select("id, name, domain")
     .limit(MAX_ROWS);
+  if (orgsError) {
+    throw new Error(
+      `Data-quality audit could not load organizations: ${orgsError.message}. No audit was run: retry.`,
+    );
+  }
 
-  const { data: people } = await supabase
+  const { data: people, error: peopleError } = await supabase
     .from("people")
     .select(
       "id, name, title, linkedin_url, organization_id, work_email, work_email_source, work_email_confidence, work_email_verification, affiliation_source, affiliation_confidence",
     )
     .limit(MAX_ROWS);
+  if (peopleError) {
+    throw new Error(
+      `Data-quality audit could not load people: ${peopleError.message}. No audit was run: retry.`,
+    );
+  }
 
   const orgList = orgs ?? [];
   const peopleList = people ?? [];

--- a/src/lib/services/email-test.ts
+++ b/src/lib/services/email-test.ts
@@ -84,11 +84,23 @@ export function stripQuotedReply(raw: string): string {
   const lines = raw.replace(/\r\n/g, "\n").split("\n");
   const kept: string[] = [];
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     // "On Thu, 30 Jul 2026 at 22:48, <jay@sahnan.co> wrote:" and the many
     // client-specific variants of it. Everything after is quoted history.
     if (/^\s*(on\b.*\bwrote:\s*$|-+\s*original message\s*-+)/i.test(line))
       break;
+    // Gmail wraps the attribution at ~78 chars, splitting it across two
+    // lines ("On Thu, 30 Jul 2026 at 22:48, Jay Sahnan\n<jay@sahnan.co>
+    // wrote:"), so a single-line test let the fragments through into stored
+    // reply bodies. Join the line with the next and re-test.
+    if (
+      i + 1 < lines.length &&
+      /^\s*on\b/i.test(line) &&
+      /\bwrote:\s*$/i.test(`${line} ${lines[i + 1]}`)
+    ) {
+      break;
+    }
     if (/^\s*>/.test(line)) continue;
     kept.push(line);
   }


### PR DESCRIPTION
Wave-8, PR-26: **the final PR of the 26-PR hardening plan.** The repo-wide sweep of the K7 family: places where a failed query still rendered as a data state (empty list, zero count, "not found"), which this codebase has now shipped as a bug class more than a dozen times. Most sites in the original inventory were already fixed inside their cluster PRs; this sweeps what remained on main.

## The ones that touched sending
- `handleFollowups` defaulted a failed `outreach_status` read to `"sent"`, bypassing the replied/bounced stop checks: a follow-up could send after a reply, the exact thing those checks exist to prevent. It now skips the enrollment and retries next run.
- `handleSignalTrigger` treated failed sequence/people/enrollment reads as "no matching sequences" and completed the job clean; the signal fire evaporated with no retry. Failed reads now throw, routing through `failJob` and the queue's retry.
- `saveDraft` mapped any read failure to "Person not found. Use findEmail to discover one first.", a factual claim the agent acted on by re-running discovery or dropping the contact. Transient failures are now named as such.

## Fabricated conclusions
- `runDataQualityAudit` on a failed query reported a clean bill of health with zero findings. Now throws.
- `refresh-scores` awaited `Promise.all` over query builders (which never reject) and answered `scored: N` regardless: failed writes and LLM-hallucinated link ids (0-row matches, no error) persisted nothing. Each write's outcome is now read and misses are reported.
- `/api/people/orphans` rendered a failed read as "no unassigned people". Now a 500 (paired with the apiFetch fix in #102).
- `stripQuotedReply` missed Gmail's two-line wrapped attribution, leaking quoted history into stored reply bodies and the Settings test snippet.

## Empty states that were outages
Campaigns list ("No campaigns yet", inviting a duplicate), company detail ("0 people" with an empty org chart), sidebar campaigns ("Speak to agent to get started"), and the learnings section ("Nothing yet") all render explicit error states now. The email-skills voice page also no longer stays busy forever after a failed or abandoned refine: the busy state releases once the agent's stream ends without a rules change.

Suite: 1006 passed (2 new), tsc and eslint clean.

With this, all 26 planned PRs and all 20 runbook repairs are done or accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)