### PR TITLE
fix(enrichment): namesake results never land on a contact

### DIFF
--- a/src/__tests__/enrich-contact-summary.test.ts
+++ b/src/__tests__/enrich-contact-summary.test.ts
@@ -13,21 +13,21 @@ vi.mock("@/lib/tools/email-tools", () => ({ findEmailForPerson }));
  * Every Exa search in this path returns the same dated archive snapshot, so a
  * test can check the date survives the trip to the summarizer.
  */
+const exaSearch = vi.fn(async () => ({
+  results: [
+    {
+      title: "Archived profile",
+      url: "https://web.archive.org/victor",
+      publishedDate: "2026-03-29",
+      text: "Ann A, Customer Engineer at Browserbase, May 2025 - Present",
+    },
+  ],
+  resultCount: 1,
+}));
 vi.mock("@/lib/services/exa-service", () => ({
   ExaService: class {
-    async search() {
-      return {
-        results: [
-          {
-            title: "Archived profile",
-            url: "https://web.archive.org/victor",
-            publishedDate: "2026-03-29",
-            text: "Customer Engineer at Browserbase, May 2025 - Present",
-          },
-        ],
-        resultCount: 1,
-      };
-    }
+    search = (...args: unknown[]) =>
+      (exaSearch as unknown as (...a: unknown[]) => unknown)(...args);
   },
 }));
 
@@ -78,7 +78,7 @@ const seed = (over: FakeRow = {}) => {
       title: "Engineer",
       linkedin_url: null,
       twitter_url: null,
-      organization_id: null,
+      organization_id: "org-1",
       enrichment_data: null,
       work_email: null,
       personal_email: null,
@@ -106,7 +106,10 @@ const updates: Array<Record<string, unknown>> = [];
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () =>
     createSupabaseFake({
-      tables: { people: () => people, organizations: () => [] },
+      tables: {
+        people: () => people,
+        organizations: () => [{ id: "org-1", name: "Browserbase" }],
+      },
       relations: {
         people: { organization: { localKey: "organization_id" } },
       },
@@ -319,5 +322,75 @@ describe("stuck in_progress recovery", () => {
     )) as { skipped?: boolean };
 
     expect(result.skipped).toBe(true);
+  });
+});
+
+describe("namesake anchoring", () => {
+  beforeEach(async () => {
+    updates.length = 0;
+    summarizePerson.mockClear();
+    exaSearch.mockClear();
+    // The in_progress recovery tests queue a mockResolvedValueOnce(true)
+    // that short-circuiting never consumes; drain it so recency stays false.
+    const { isRecentlyEnriched } =
+      await import("@/lib/services/knowledge-base");
+    vi.mocked(isRecentlyEnriched).mockReset();
+    vi.mocked(isRecentlyEnriched).mockResolvedValue(false);
+    // An address on file keeps email discovery out of the way.
+    seed({ work_email: "ann@browserbase.com" });
+  });
+
+  it("drops results about a namesake at a different company", async () => {
+    // The long-standing namesake bug: Exa is semantic, so a search for
+    // "Ann A" "Browserbase" happily returns an Ann A at Oracle, and her
+    // career used to be stored as this contact's enrichment and woven into
+    // outreach.
+    exaSearch.mockResolvedValue({
+      results: [
+        {
+          title: "Ann A promoted to VP at Oracle",
+          url: "https://news.example.com/oracle-ann",
+          publishedDate: "2026-07-01",
+          text: "Ann A has spent 15 years at Oracle leading databases.",
+        },
+        {
+          title: "Ann A of Browserbase on browser infra",
+          url: "https://news.example.com/bb-ann",
+          publishedDate: "2026-07-02",
+          text: "An interview with Ann A, engineer at Browserbase.",
+        },
+      ],
+      resultCount: 2,
+    });
+
+    await enrichContact.execute!({ contactId: PERSON_ID }, {} as never);
+
+    const input = summarizePerson.mock.calls[0][0] as {
+      news?: Array<{ url: string }> | null;
+    };
+    const urls = (input.news ?? []).map((r) => r.url);
+    expect(urls).toContain("https://news.example.com/bb-ann");
+    expect(urls).not.toContain("https://news.example.com/oracle-ann");
+  });
+
+  it("skips web search entirely for a contact with no company", async () => {
+    // With only a name there is nothing to tie a result to this human, so
+    // searching at all is how strangers' articles got stored. LinkedIn/X
+    // (URL-anchored) still run; the result says why the searches did not.
+    seed({
+      organization_id: null,
+      work_email: "ann@example.com",
+      linkedin_url: null,
+    });
+
+    const result = (await enrichContact.execute!(
+      { contactId: PERSON_ID },
+      {} as never,
+    )) as { errors?: string[] };
+
+    expect(exaSearch).not.toHaveBeenCalled();
+    expect(result.errors?.some((e) => /no company on file/i.test(e))).toBe(
+      true,
+    );
   });
 });

--- a/src/__tests__/namesake-anchor.test.ts
+++ b/src/__tests__/namesake-anchor.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { resultIsAboutPerson } from "@/lib/services/person-enrichment";
+
+/**
+ * The identity gate on per-person web search results. Exa queries carry the
+ * name and company, but Exa is semantic: top results routinely include
+ * namesake strangers whose pages never mention the employer. Stored
+ * unchecked, a stranger's career lands in the contact's enrichment_data and
+ * outreach personalises against someone else's life -- the long-standing
+ * namesake bug.
+ */
+
+const jane = { name: "Jane Doe", companyName: "Browserbase" };
+
+describe("resultIsAboutPerson", () => {
+  it("keeps a result naming both the person and their company", () => {
+    expect(
+      resultIsAboutPerson(
+        {
+          title: "Jane Doe on scaling Browserbase",
+          text: "An interview with Jane Doe, engineer at Browserbase.",
+        },
+        jane,
+      ),
+    ).toBe(true);
+  });
+
+  it("drops a namesake whose page never mentions the company", () => {
+    expect(
+      resultIsAboutPerson(
+        {
+          title: "Jane Doe promoted to VP at Oracle",
+          text: "Jane Doe has spent 15 years at Oracle leading databases.",
+        },
+        jane,
+      ),
+    ).toBe(false);
+  });
+
+  it("drops company news that never names the person", () => {
+    expect(
+      resultIsAboutPerson(
+        {
+          title: "Browserbase raises Series B",
+          text: "The company announced new funding today.",
+        },
+        jane,
+      ),
+    ).toBe(false);
+  });
+
+  it("survives punctuation, casing and legal suffixes", () => {
+    expect(
+      resultIsAboutPerson(
+        {
+          title: "JANE-DOE joins BROWSERBASE, Inc!",
+          text: null,
+        },
+        { name: "Jane Doe", companyName: "Browserbase Inc." },
+      ),
+    ).toBe(true);
+  });
+
+  it("requires only the name when no company is known", () => {
+    // Callers skip web search entirely for company-less people; this branch
+    // exists so the function stays safe if called anyway.
+    expect(
+      resultIsAboutPerson(
+        { title: "Jane Doe's blog", text: "By Jane Doe." },
+        { name: "Jane Doe", companyName: null },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects empty results outright", () => {
+    expect(resultIsAboutPerson({ title: null, text: null }, jane)).toBe(false);
+  });
+});

--- a/src/__tests__/person-location-capture.test.ts
+++ b/src/__tests__/person-location-capture.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/services/exa-service", () => ({
             title: "Profile",
             url: "https://example.com/ann",
             publishedDate: "2026-07-01",
-            text: "Ann A is an engineer based in Berlin, Germany.",
+            text: "Ann A is an engineer at Acme based in Berlin, Germany.",
           },
         ],
         resultCount: 1,
@@ -76,7 +76,7 @@ const personRow = (over: FakeRow = {}): FakeRow => ({
   twitter_url: null,
   work_email: null,
   personal_email: null,
-  organization_id: null,
+  organization_id: ORG_ID,
   enrichment_data: null,
   affiliation_confidence: 0.9,
   ...over,
@@ -89,7 +89,13 @@ const inserts: Array<Record<string, unknown>> = [];
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () =>
     createSupabaseFake({
-      tables: { people: () => people, organizations: () => [] },
+      tables: {
+        people: () => people,
+        // The person under test needs an employer: web search results are
+        // identity-gated on name + company, and company-less people skip
+        // web search entirely.
+        organizations: () => [{ id: ORG_ID, name: "Acme" }],
+      },
       relations: {
         people: { organization: { localKey: "organization_id" } },
       },

--- a/src/lib/services/person-enrichment.ts
+++ b/src/lib/services/person-enrichment.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import { normalizeCompanyName } from "@/lib/services/affiliation";
 import { withAction } from "@/lib/services/cost-tracker";
 import { ExaService } from "@/lib/services/exa-service";
 import { LinkedinService } from "@/lib/services/linkedin-service";
@@ -38,6 +39,63 @@ export interface PersonForEnrichment {
   organization_id?: string | null;
   organization: { name?: string } | null;
 }
+
+/** Lowercase alphanumerics only, so punctuation and spacing stop mattering. */
+function squash(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function nameTokens(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 2);
+}
+
+/**
+ * Is this search result actually about THIS person?
+ *
+ * An Exa query carries the name and company, but Exa is semantic: the top
+ * results routinely include namesake strangers whose pages never mention the
+ * employer. Stored unchecked, a stranger's "15 years at Oracle" lands in the
+ * contact's enrichment_data and the composer personalises outreach against
+ * someone else's life. So a result must name the person AND their company to
+ * be kept: a missing fact costs a blander email, a stranger's fact costs a
+ * wrong one sent to a real prospect.
+ *
+ * Requiring the company is also why callers skip web search entirely for
+ * people with no organization on file: with only a name there is nothing to
+ * tie a result to this specific human.
+ */
+export function resultIsAboutPerson(
+  result: { title: string | null; text: string | null },
+  person: { name: string; companyName: string | null },
+): boolean {
+  const haystack = squash(`${result.title ?? ""} ${result.text ?? ""}`);
+  if (!haystack) return false;
+
+  const tokens = nameTokens(person.name);
+  if (tokens.length === 0) return false;
+  if (!tokens.every((t) => haystack.includes(t))) return false;
+
+  if (person.companyName) {
+    const companyTokens = normalizeCompanyName(person.companyName)
+      .split(" ")
+      .filter((t) => t.length >= 2);
+    if (
+      companyTokens.length > 0 &&
+      !companyTokens.every((t) => haystack.includes(t))
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/** The note callers record when web search is skipped for lack of an anchor. */
+export const NO_COMPANY_SEARCH_NOTE =
+  "Web search skipped: no company on file, so results could not be tied to this specific person. LinkedIn and X profiles (if on file) were still used. Link the contact to their company and re-enrich to add news and articles.";
 
 export async function enrichPerson(
   supabase: SupabaseClient,
@@ -105,7 +163,14 @@ export async function enrichPerson(
         );
       }
 
-      if (contactName !== "Unknown") {
+      if (contactName !== "Unknown" && !companyName) {
+        // With only a name, nothing can tie a result to this specific human:
+        // running the searches anyway is how namesake strangers' articles
+        // ended up stored as facts about a contact.
+        errors.push(NO_COMPANY_SEARCH_NOTE);
+      }
+
+      if (contactName !== "Unknown" && companyName) {
         const exa = new ExaService();
 
         const contactTitle = person.title || null;
@@ -160,7 +225,14 @@ export async function enrichPerson(
             publishedDate: string | null;
             text: string | null;
           }>,
-        ) => results.filter((r) => !companyUrls.has(r.url));
+        ) =>
+          results
+            .filter((r) => !companyUrls.has(r.url))
+            // Identity gate: only results that name the person AND the
+            // company survive. See resultIsAboutPerson.
+            .filter((r) =>
+              resultIsAboutPerson(r, { name: contactName, companyName }),
+            );
 
         const search = (
           key: "news" | "articles" | "background",

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -10,6 +10,10 @@ import {
 } from "@/lib/tools/ownership";
 import { saveOrganizationWebsite } from "@/lib/services/organization-website";
 import { parseLinkedInTitle } from "@/lib/utils";
+import {
+  NO_COMPANY_SEARCH_NOTE,
+  resultIsAboutPerson,
+} from "@/lib/services/person-enrichment";
 import { ExaService } from "@/lib/services/exa-service";
 import { filterRelevantResults } from "@/lib/services/relevance-filter";
 import { LinkedinService } from "@/lib/services/linkedin-service";
@@ -624,11 +628,17 @@ async function enrichContactById(
     );
   }
 
-  if (contactName !== "Unknown") {
+  if (contactName !== "Unknown" && !companyName) {
+    // With only a name, nothing can tie a result to this specific human:
+    // running the searches anyway is how namesake strangers' articles ended
+    // up stored as facts about a contact.
+    errors.push(NO_COMPANY_SEARCH_NOTE);
+  }
+
+  if (contactName !== "Unknown" && companyName) {
     const exa = new ExaService();
     const contactTitle = person?.title || null;
-    const queryParts = [`"${contactName}"`];
-    if (companyName) queryParts.push(`"${companyName}"`);
+    const queryParts = [`"${contactName}"`, `"${companyName}"`];
     if (contactTitle) queryParts.push(contactTitle);
     const specificQuery = queryParts.join(" ");
 
@@ -671,7 +681,13 @@ async function enrichContactById(
     }
 
     const dedup = (results: SummarySource[]) =>
-      results.filter((r) => !companyUrls.has(r.url));
+      results
+        .filter((r) => !companyUrls.has(r.url))
+        // Identity gate: only results that name the person AND the company
+        // survive. See resultIsAboutPerson in person-enrichment.
+        .filter((r) =>
+          resultIsAboutPerson(r, { name: contactName, companyName }),
+        );
 
     promises.push(
       (async () => {


### PR DESCRIPTION
The known namesake-enrichment bug (tracked since the original review, deliberately outside the hardening plan's scope): per-person Exa searches are anchored by name + company **in the query only**, and Exa is semantic, so the top results routinely include namesake strangers whose pages never mention the employer. Stored unchecked, a stranger's career landed in the contact's `enrichment_data`, fed the bio summarizer, and was woven into outreach as claims about someone else's life.

## The fix: an identity gate on results, not just the query
`resultIsAboutPerson` (in `person-enrichment`, shared by both search sites): a result survives only when its title + text mention the person's name **and** their company (token-matched, punctuation/casing/legal-suffix tolerant, reusing `normalizeCompanyName`). The trade is deliberate and matches the affiliation system's philosophy: a dropped legitimate article costs a blander email; a kept stranger's article costs a wrong claim sent to a real prospect.

## Company-less contacts stop collecting strangers
With only a name there is nothing to tie any result to this specific human, so contacts without an organization now skip web search entirely rather than store whatever the name surfaced. LinkedIn and X enrichment (URL-anchored, safe) still run, and the result carries an explicit note: link the contact to their company and re-enrich to add news and articles. This pairs with the earlier fixes that made affiliation the gate for everything else: the same principle now covers enrichment.

Both call paths get the gate: the `/api/enrich` + bulk service path (`enrichPerson`) and the agent's `enrichContact` tool (which carries its own copy of the search block).

This is the last open bug from the original review inventory. Prod note: rows already polluted by namesakes are not repaired by this PR; re-enriching a contact now replaces the polluted keys with gated results.

Suite: 1014 passed (8 new: 6 unit tests on the gate, 2 behavior tests through enrichContact), tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)