### PR TITLE
feat(outreach): bucket the outreach page by campaign

### DIFF
--- a/src/__tests__/outreach-activity-panel.test.tsx
+++ b/src/__tests__/outreach-activity-panel.test.tsx
@@ -27,6 +27,8 @@ function item(over: Partial<ActivityItem> = {}): ActivityItem {
     id: "se_1",
     source: "sent",
     state: "replied",
+    campaign_id: null,
+    campaign_name: null,
     person_name: "Dana Whitfield",
     person_title: "VP Engineering",
     company_name: "Fernpath",

--- a/src/__tests__/outreach-drafts-panel.test.tsx
+++ b/src/__tests__/outreach-drafts-panel.test.tsx
@@ -32,6 +32,8 @@ function draft(over: Partial<DraftRow> = {}): DraftRow {
     company_name: "Trig",
     sequence_id: null,
     sequence_name: null,
+    campaign_id: null,
+    campaign_name: null,
     next_send_at: null,
     step_number: 1,
     total_steps: 1,

--- a/src/app/api/outreach/activity/route.ts
+++ b/src/app/api/outreach/activity/route.ts
@@ -49,8 +49,14 @@ interface PersonJoin {
  * two-level embed and widen the whole result to an error type, which then
  * hides every real field access behind a single unhelpful error.
  */
+interface CampaignJoin {
+  name: string | null;
+}
+
 interface SentRow {
   id: string;
+  campaign_id: string | null;
+  campaign: CampaignJoin | CampaignJoin[] | null;
   subject: string;
   to_email: string;
   from_email: string | null;
@@ -67,6 +73,8 @@ interface SentRow {
 
 interface PendingRow {
   id: string;
+  campaign_id: string | null;
+  campaign: CampaignJoin | CampaignJoin[] | null;
   subject: string;
   to_email: string;
   status: string;
@@ -106,7 +114,8 @@ export async function GET(request: Request) {
   let sentQuery = supabase
     .from("sent_emails")
     .select(
-      "id, subject, to_email, from_email, status, sent_at, message_id, " +
+      "id, campaign_id, subject, to_email, from_email, status, sent_at, message_id, " +
+        "campaign:campaigns(name), " +
         "person:people(name, title, organizations!people_organization_id_fkey(name)), " +
         "email_replies(kind, from_email, subject, received_at, body_text)",
     )
@@ -118,7 +127,8 @@ export async function GET(request: Request) {
   let pendingQuery = supabase
     .from("email_drafts")
     .select(
-      "id, subject, to_email, status, created_at, last_error, last_error_at, last_error_kind, " +
+      "id, campaign_id, subject, to_email, status, created_at, last_error, last_error_at, last_error_kind, " +
+        "campaign:campaigns(name), " +
         "person:people(name, title, organizations!people_organization_id_fkey(name)), " +
         "enrollment:sequence_enrollments(next_send_at)",
     )
@@ -152,6 +162,8 @@ export async function GET(request: Request) {
       id: row.id,
       source: "sent",
       state: classifySent(row.status),
+      campaign_id: row.campaign_id,
+      campaign_name: one(row.campaign)?.name ?? null,
       person_name: person?.name ?? null,
       person_title: person?.title ?? null,
       company_name: one(person?.organizations ?? null)?.name ?? null,
@@ -177,6 +189,8 @@ export async function GET(request: Request) {
     items.push({
       id: `draft:${row.id}`,
       source: "pending",
+      campaign_id: row.campaign_id,
+      campaign_name: one(row.campaign)?.name ?? null,
       state: classifyPending({
         status: row.status,
         last_error_kind: row.last_error_kind,

--- a/src/app/outreach/page.tsx
+++ b/src/app/outreach/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
@@ -10,6 +10,10 @@ import {
 } from "@/components/outreach/outreach-drafts-panel";
 import { ReadyToSendHero } from "@/components/outreach/ready-to-send-hero";
 import { OutreachTabs } from "@/components/outreach/outreach-tabs";
+import {
+  CampaignPicker,
+  type CampaignBucket,
+} from "@/components/outreach/campaign-picker";
 import { apiFetch } from "@/lib/api-fetch";
 import type { ActivityItem } from "@/lib/outreach/activity";
 import type { ActivityFilter } from "@/components/outreach/outreach-activity-panel";
@@ -41,6 +45,8 @@ export interface EnrollmentCard {
   company_name: string | null;
   outreach_status: string | null;
   sequence_name: string;
+  campaign_id: string | null;
+  campaign_name: string | null;
 }
 
 export default function OutreachPage() {
@@ -49,6 +55,13 @@ export default function OutreachPage() {
   const [drafts, setDrafts] = useState<DraftRow[]>([]);
   const [activity, setActivity] = useState<ActivityItem[]>([]);
   const [activityFilter, setActivityFilter] = useState<ActivityFilter>("all");
+  const [campaigns, setCampaigns] = useState<{ id: string; name: string }[]>(
+    [],
+  );
+  // null = every campaign; otherwise a campaign id and every tab is scoped
+  // to it. One picker for the whole page, not one per tab, so Inbox, Sent
+  // and Pipeline never disagree about which campaign you are looking at.
+  const [selectedCampaign, setSelectedCampaign] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const mountedRef = useRef(true);
 
@@ -63,6 +76,7 @@ export default function OutreachPage() {
       settingsRes,
       stepRowsRes,
       activityRes,
+      campaignsRes,
     ] = await Promise.all([
       supabase
         .from("sequences")
@@ -79,7 +93,7 @@ export default function OutreachPage() {
             current_step, status, next_send_at,
             people(name, title, organization_id, organizations!organization_id(name)),
             campaign_people(outreach_status),
-            sequences(name)
+            sequences(name, campaign_id, campaigns(name))
           `,
         )
         .in("status", ["waiting", "queued", "active", "replied"])
@@ -89,7 +103,8 @@ export default function OutreachPage() {
         .select(
           `
             id, subject, to_email, review_status, status, sent_at,
-            enrollment_id, sequence_id, sequence_step_id,
+            enrollment_id, sequence_id, sequence_step_id, campaign_id,
+            campaigns(name),
             sequence_enrollments(next_send_at, sequence_id),
             sequence_steps(step_number),
             sequences(name),
@@ -113,6 +128,7 @@ export default function OutreachPage() {
         .then((r) => r.json())
         // A failed activity fetch must not blank the rest of the page.
         .catch(() => ({ items: [] as ActivityItem[] })),
+      supabase.from("campaigns").select("id, name").order("name"),
     ]);
 
     if (!mountedRef.current) return;
@@ -184,7 +200,11 @@ export default function OutreachPage() {
       const cp = c.campaign_people as unknown as {
         outreach_status: string;
       } | null;
-      const seq = c.sequences as unknown as { name: string } | null;
+      const seq = c.sequences as unknown as {
+        name: string;
+        campaign_id: string | null;
+        campaigns: { name: string } | null;
+      } | null;
       return {
         id: c.id,
         sequence_id: c.sequence_id,
@@ -198,6 +218,8 @@ export default function OutreachPage() {
         company_name: person?.organizations?.name ?? null,
         outreach_status: cp?.outreach_status ?? null,
         sequence_name: seq?.name ?? "",
+        campaign_id: seq?.campaign_id ?? null,
+        campaign_name: seq?.campaigns?.name ?? null,
       };
     });
 
@@ -215,6 +237,7 @@ export default function OutreachPage() {
         step_number: number;
       } | null;
       const seq = d.sequences as unknown as { name: string } | null;
+      const campaign = d.campaigns as unknown as { name: string } | null;
       // The draft's own column, not just the enrollment embed: a draft
       // written into a sequence before (or without) enrollment still
       // belongs to that sequence's review queue.
@@ -230,6 +253,8 @@ export default function OutreachPage() {
         company_name: person?.organizations?.name ?? null,
         sequence_id: sequenceId,
         sequence_name: seq?.name ?? null,
+        campaign_id: d.campaign_id ?? null,
+        campaign_name: campaign?.name ?? null,
         next_send_at: enrollment?.next_send_at ?? null,
         step_number: step?.step_number ?? 1,
         total_steps: sequenceId ? (totalStepsBySeq.get(sequenceId) ?? 1) : 1,
@@ -238,6 +263,7 @@ export default function OutreachPage() {
       };
     });
 
+    setCampaigns(campaignsRes.data ?? []);
     setSequences(sequenceRows);
     setEnrollments(enrollmentCards);
     setDrafts(draftRows);
@@ -248,6 +274,65 @@ export default function OutreachPage() {
     );
     setLoading(false);
   }, []);
+
+  // Bucket counts per campaign, computed from the unfiltered sets so the
+  // picker always shows the whole picture no matter which chip is active.
+  const buckets = useMemo<CampaignBucket[]>(() => {
+    const byId = new Map<string, CampaignBucket>();
+    for (const c of campaigns) {
+      byId.set(c.id, {
+        id: c.id,
+        name: c.name,
+        drafts: 0,
+        ready: 0,
+        replied: 0,
+      });
+    }
+    // Campaigns that only exist on rows (e.g. deleted from the list but a
+    // draft still points at one) still get a chip so nothing is unreachable.
+    const ensure = (id: string | null, name: string | null) => {
+      if (!id) return null;
+      let b = byId.get(id);
+      if (!b) {
+        b = { id, name: name ?? "Unknown", drafts: 0, ready: 0, replied: 0 };
+        byId.set(id, b);
+      }
+      return b;
+    };
+    for (const d of drafts) {
+      const b = ensure(d.campaign_id, d.campaign_name);
+      if (!b) continue;
+      b.drafts++;
+      if (classifyDraft(d) === "ready") b.ready++;
+    }
+    for (const a of activity) {
+      const b = ensure(a.campaign_id, a.campaign_name);
+      if (b && a.state === "replied") b.replied++;
+    }
+    for (const s of sequences) ensure(s.campaign_id, s.campaign_name);
+    return Array.from(byId.values());
+  }, [campaigns, drafts, activity, sequences]);
+
+  // If the selected campaign vanishes (deleted, or its rows all drained and
+  // it was never in the campaigns table), behave as All rather than showing
+  // an empty page with no way out. Derived, not reset in an effect.
+  const activeCampaign =
+    selectedCampaign && buckets.some((b) => b.id === selectedCampaign)
+      ? selectedCampaign
+      : null;
+
+  const scoped = useMemo(() => {
+    if (!activeCampaign) {
+      return { drafts, enrollments, sequences, activity };
+    }
+    const id = activeCampaign;
+    return {
+      drafts: drafts.filter((d) => d.campaign_id === id),
+      enrollments: enrollments.filter((e) => e.campaign_id === id),
+      sequences: sequences.filter((s) => s.campaign_id === id),
+      activity: activity.filter((a) => a.campaign_id === id),
+    };
+  }, [activeCampaign, drafts, enrollments, sequences, activity]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -316,16 +401,24 @@ export default function OutreachPage() {
           </div>
         ) : (
           <>
+            {buckets.length > 1 && (
+              <CampaignPicker
+                buckets={buckets}
+                selectedId={activeCampaign}
+                onSelect={setSelectedCampaign}
+              />
+            )}
+
             <ReadyToSendHero
-              drafts={drafts.filter((d) => classifyDraft(d) === "ready")}
+              drafts={scoped.drafts.filter((d) => classifyDraft(d) === "ready")}
               onRefresh={load}
             />
 
             <OutreachTabs
-              drafts={drafts}
-              sequences={sequences}
-              enrollments={enrollments}
-              activity={activity}
+              drafts={scoped.drafts}
+              sequences={scoped.sequences}
+              enrollments={scoped.enrollments}
+              activity={scoped.activity}
               activityFilter={activityFilter}
               onActivityFilterChange={setActivityFilter}
               activityLoading={loading}

--- a/src/components/outreach/campaign-picker.tsx
+++ b/src/components/outreach/campaign-picker.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { TogglePill } from "@/components/ui/toggle-pill";
+
+/**
+ * One bucket per campaign, with the numbers that decide whether it is worth
+ * clicking into: how many drafts are in flight, how many are ready to go,
+ * and how many replies are sitting there.
+ */
+export interface CampaignBucket {
+  id: string;
+  name: string;
+  drafts: number;
+  ready: number;
+  replied: number;
+}
+
+interface CampaignPickerProps {
+  buckets: CampaignBucket[];
+  /** null means every campaign. */
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+/**
+ * Scopes the whole outreach page to one campaign. Lives above the tabs, not
+ * inside one of them, so Inbox, Sent, Pipeline and Sequences all agree on
+ * which campaign is on screen.
+ */
+export function CampaignPicker({
+  buckets,
+  selectedId,
+  onSelect,
+}: CampaignPickerProps) {
+  const totalDrafts = buckets.reduce((n, b) => n + b.drafts, 0);
+  const totalReplied = buckets.reduce((n, b) => n + b.replied, 0);
+
+  return (
+    <div
+      role="group"
+      aria-label="Campaign"
+      className="flex flex-wrap items-center gap-1.5"
+    >
+      <TogglePill active={selectedId === null} onClick={() => onSelect(null)}>
+        All campaigns
+        <Counts drafts={totalDrafts} replied={totalReplied} />
+      </TogglePill>
+      {buckets.map((b) => (
+        <TogglePill
+          key={b.id}
+          active={selectedId === b.id}
+          onClick={() => onSelect(b.id)}
+          className="max-w-[16rem] truncate"
+          title={b.name}
+        >
+          {b.name}
+          <Counts drafts={b.drafts} replied={b.replied} />
+        </TogglePill>
+      ))}
+    </div>
+  );
+}
+
+function Counts({ drafts, replied }: { drafts: number; replied: number }) {
+  if (drafts === 0 && replied === 0) return null;
+  return (
+    <span className="ml-1.5 opacity-70 tabular-nums">
+      {drafts > 0 && <span>{drafts}</span>}
+      {drafts > 0 && replied > 0 && <span> · </span>}
+      {replied > 0 && <span>{replied} replied</span>}
+    </span>
+  );
+}

--- a/src/components/outreach/outreach-activity-panel.tsx
+++ b/src/components/outreach/outreach-activity-panel.tsx
@@ -133,6 +133,11 @@ export function OutreachActivityPanel({
                         <div className="text-muted-foreground truncate text-xs">
                           {item.subject}
                         </div>
+                        {item.campaign_name && (
+                          <div className="text-muted-foreground/80 truncate text-[11px]">
+                            {item.campaign_name}
+                          </div>
+                        )}
                         {/* The reply, visible without opening anything and
                             without filtering. Replies being findable is the
                             entire point of this surface. */}

--- a/src/components/outreach/outreach-drafts-panel.tsx
+++ b/src/components/outreach/outreach-drafts-panel.tsx
@@ -26,6 +26,8 @@ export interface DraftRow {
   company_name: string | null;
   sequence_id: string | null;
   sequence_name: string | null;
+  campaign_id: string | null;
+  campaign_name: string | null;
   next_send_at: string | null;
   step_number: number;
   total_steps: number;
@@ -256,6 +258,11 @@ export function OutreachDraftsPanel({
                           <p className="text-muted-foreground mt-0.5 truncate text-xs">
                             {firstDraft.subject || "(no subject)"}
                           </p>
+                          {firstDraft.campaign_name && (
+                            <p className="text-muted-foreground/80 mt-0.5 truncate text-[11px]">
+                              {firstDraft.campaign_name}
+                            </p>
+                          )}
                         </div>
 
                         <div className="flex shrink-0 items-center gap-2">

--- a/src/lib/outreach/activity.ts
+++ b/src/lib/outreach/activity.ts
@@ -34,6 +34,8 @@ export interface ActivityItem {
   id: string;
   source: "sent" | "pending";
   state: ActivityState;
+  campaign_id: string | null;
+  campaign_name: string | null;
   person_name: string | null;
   person_title: string | null;
   company_name: string | null;


### PR DESCRIPTION
## Summary
- Adds a campaign picker above the tabs on /outreach: "All campaigns" plus one pill per campaign with draft and reply counts. Picking one scopes Inbox, Sent, Pipeline, Sequences and the Ready-to-send hero together.
- Draft and activity rows now show their campaign name so the All view still says where each email came from.
- No schema change: email_drafts and sent_emails already carry campaign_id. /api/outreach/activity returns campaign_id/name; the page threads campaign through DraftRow and EnrollmentCard.

## Test plan
- [x] tsc clean, eslint clean on touched files
- [x] 78 outreach tests pass (fixtures updated for new fields)
- [ ] Open /outreach with 2+ campaigns: picker appears, each tab narrows to the chosen campaign, counts match

🤖 Generated with [Claude Code](https://claude.com/claude-code)