### PR TITLE
fix(voice): opening batch rejected every time on persona.signals max(2)

### DIFF
--- a/src/__tests__/salvage-object.test.ts
+++ b/src/__tests__/salvage-object.test.ts
@@ -107,6 +107,22 @@ describe("generateWithRetry", () => {
     expect(run).toHaveBeenCalledTimes(3);
   });
 
+  // The voice deck failed three attempts in a row with the bare "response did
+  // not match schema" and nobody could tell which field. Bounds never reach the
+  // model (apiSafeSchema strips them), so a deterministic mismatch has to be
+  // named in the error or it reads as a flake forever.
+  it("names the failing schema path in the reported error", async () => {
+    const Bounded = z.object({ tags: z.array(z.string()).max(2) });
+    const run = vi
+      .fn()
+      .mockRejectedValue(
+        schemaError(JSON.stringify({ tags: ["a", "b", "c"] })),
+      );
+    const result = await generateWithRetry(run, Bounded, 2);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("tags: too_big");
+  });
+
   it("stops at `attempts` and reports the last error", async () => {
     const run = vi.fn().mockRejectedValue(new Error("overloaded"));
     const result = await generateWithRetry(run, Draft, 3);

--- a/src/__tests__/swipe-service-schema.test.ts
+++ b/src/__tests__/swipe-service-schema.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { TranscriptSchema } from "@/lib/email-skills/swipe-service";
-import { buildBatchPrompt } from "@/lib/email-skills/swipe-prompts";
+import {
+  BatchSchema,
+  buildBatchPrompt,
+} from "@/lib/email-skills/swipe-prompts";
 import type { SwipeTranscript } from "@/lib/email-skills/swipe-prompts";
 
 /**
@@ -51,5 +54,41 @@ describe("TranscriptSchema personaLabel round-trip", () => {
       instructions: [],
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("BatchSchema persona bounds", () => {
+  const draft = {
+    subject: "s",
+    body: "b",
+    axes: {
+      opener: "signal",
+      tone: "blunt",
+      close: "question",
+      greeting: "hi",
+      signoff: "name",
+    },
+  };
+
+  // apiSafeSchema strips maxItems from the wire schema, so the model never
+  // sees the bound. Opus reliably invents three specifics for the persona; a
+  // cap of 2 rejected every opening batch on the voice deck as "response did
+  // not match schema", three retries in a row, with six good drafts inside.
+  it("accepts a persona with three invented signals", () => {
+    const parsed = BatchSchema.safeParse({
+      drafts: [draft, draft],
+      persona: {
+        name: "Priya Raman",
+        title: "VP Sales",
+        company: "Ledgerloop",
+        situation: "Just closed a Series B.",
+        signals: [
+          "Raised a Series B",
+          "Posted three AE roles",
+          "Dropped an agency",
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
   });
 });

--- a/src/lib/ai/salvage-object.ts
+++ b/src/lib/ai/salvage-object.ts
@@ -57,6 +57,36 @@ export function salvageObject<T>(err: unknown, schema: z.ZodType<T>): T | null {
   return null;
 }
 
+/**
+ * "No object generated: response did not match schema." names no field, so a
+ * deterministic mismatch (a bound the wire schema could not carry, an enum
+ * the prompt contradicts) is indistinguishable from a flake until someone
+ * reproduces it by hand. Re-derives the Zod issues from the raw text rather
+ * than digging through the SDK's cause chain, whose shape is not stable.
+ *
+ * Returns e.g. "persona.signals: too_big", or null when there is nothing to
+ * say (not a schema rejection, or the text is not JSON).
+ */
+export function schemaIssueSummary<T>(
+  err: unknown,
+  schema: z.ZodType<T>,
+): string | null {
+  if (!NoObjectGeneratedError.isInstance(err) || !err.text) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(err.text);
+  } catch {
+    return null;
+  }
+  const parsed = schema.safeParse(raw);
+  if (parsed.success) return null;
+  const issues = parsed.error.issues.slice(0, 5).map((i) => {
+    const path = i.path.map(String).join(".") || "(root)";
+    return `${path}: ${i.code}`;
+  });
+  return issues.join("; ");
+}
+
 /** Matches the three names the AI SDK treats as an abort rather than a failure. */
 function isAbort(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -90,7 +120,10 @@ export async function generateWithRetry<T>(
     } catch (err) {
       const salvaged = salvageObject(err, schema);
       if (salvaged) return { ok: true, value: salvaged };
-      if (err instanceof Error) lastError = err.message;
+      if (err instanceof Error) {
+        const issues = schemaIssueSummary(err, schema);
+        lastError = issues ? `${err.message} (${issues})` : err.message;
+      }
       // An aborted call is a deadline, not a flake — retrying burns the budget
       // the timeout exists to protect, and four 90s attempts overrun every
       // route's maxDuration.

--- a/src/lib/email-skills/swipe-prompts.ts
+++ b/src/lib/email-skills/swipe-prompts.ts
@@ -72,10 +72,16 @@ export const PersonaSchema = z.object({
     .string()
     .max(300)
     .describe("One line: what is going on for them right now."),
+  // Bounds here never reach the model: apiSafeSchema strips minItems /
+  // maxItems from the wire schema, so this array is validated only after
+  // the fact. Opus reliably invents THREE specifics when asked for "1-2",
+  // and a cap of 2 rejected every batch (six good drafts, thrown away as
+  // "response did not match schema", three retries in a row). Generous on
+  // purpose: the prompt steers the count, the schema only stops abuse.
   signals: z
     .array(z.string().max(200))
     .min(1)
-    .max(2)
+    .max(6)
     .describe("Invented but plausible specifics the drafts may reference."),
 });
 export type Persona = z.infer<typeof PersonaSchema>;
@@ -341,7 +347,7 @@ function renderSender(sender: SwipeSender | null | undefined): string {
  * than a lie, which is what lets the variation rule spread across data-led and
  * signal-led openers without fabricating claims about somebody who exists.
  */
-const INVENT_RECIPIENT = `WHO THESE ARE TO: INVENT THE RECIPIENT. Before writing the drafts, invent one fictional but plausible person squarely inside the campaign's ICP (or a plausible generic B2B buyer when no campaign context is given): name, title, company, situation, and 1-2 invented specifics. Every draft in this batch is written to that same person, and you return the persona with the drafts. Recipient details are yours to invent: the person is fictional, so a made-up signal is not a lie, it is the exercise. Never reuse a persona that already appears in the judged drafts below.
+const INVENT_RECIPIENT = `WHO THESE ARE TO: INVENT THE RECIPIENT. Before writing the drafts, invent one fictional but plausible person squarely inside the campaign's ICP (or a plausible generic B2B buyer when no campaign context is given): name, title, company, situation, and 2-3 invented specifics. Every draft in this batch is written to that same person, and you return the persona with the drafts. Recipient details are yours to invent: the person is fictional, so a made-up signal is not a lie, it is the exercise. Never reuse a persona that already appears in the judged drafts below.
 
 THE SENDER IS REAL. Never invent facts about the sender: everything the drafts claim about who is writing (their offer, their numbers, their story) must come from the sender context above.`;
 


### PR DESCRIPTION
## Summary
The email-voice run failed to start with "The agent came back without drafts"; the tool card showed `No object generated: response did not match schema.` on every attempt.

Reproduced live against claude-opus-5: the model invents **three** persona specifics on every batch, `PersonaSchema.signals` capped it at 2, and `apiSafeSchema` strips `maxItems` from the wire schema so the model never sees the bound. Salvage can't help (a real bound violation, not a wrapper), so six good drafts were discarded three times per run.

- Loosen `persona.signals` to `max(6)` and ask the model for 2-3 specifics (what it does anyway). Verified: 2/2 live batches now succeed where 2/2 failed before.
- `generateWithRetry` appends Zod issue paths to the reported error (`persona.signals: too_big`) so the next mismatch is diagnosable from the tool card.
- Regression tests for both.

## Test plan
- [x] Live repro before/after against the real model
- [x] tsc, eslint, salvage + swipe test suites pass
- [ ] Prod: start a voice run on /email-skills, drafts land on the deck

🤖 Generated with [Claude Code](https://claude.com/claude-code)