### PR TITLE
feat(profile): meeting link, always sent when a draft asks for a call

### DIFF
--- a/src/__tests__/email-composition-skill.test.ts
+++ b/src/__tests__/email-composition-skill.test.ts
@@ -119,3 +119,29 @@ describe("buildComposeUserPrompt sender fields", () => {
     expect(prompt).not.toContain("Sender notes");
   });
 });
+
+describe("buildComposeUserPrompt meeting link", () => {
+  it("renders the booking URL as its own SENDER line when set", () => {
+    const prompt = buildComposeUserPrompt({
+      ...baseInput,
+      senderProfile: {
+        ...baseInput.senderProfile,
+        bookingUrl: "https://cal.com/jay/15min",
+      },
+    });
+    expect(prompt).toContain("Meeting link");
+    expect(prompt).toContain("https://cal.com/jay/15min");
+  });
+
+  // The system rule says "if SENDER lists a meeting link"; an empty or
+  // whitespace value must not render a line the model could read as one.
+  it("omits the line when the URL is unset or blank", () => {
+    for (const bookingUrl of [undefined, null, "", "   "]) {
+      const prompt = buildComposeUserPrompt({
+        ...baseInput,
+        senderProfile: { ...baseInput.senderProfile, bookingUrl },
+      });
+      expect(prompt).not.toContain("Meeting link");
+    }
+  });
+});

--- a/src/app/api/outreach/regenerate/route.ts
+++ b/src/app/api/outreach/regenerate/route.ts
@@ -88,7 +88,9 @@ export async function POST(request: Request) {
   if (campaign?.profile_id) {
     const { data: profile } = await supabase
       .from("user_profile")
-      .select("id, name, role_title, company_name, offering_summary, notes")
+      .select(
+        "id, name, role_title, company_name, offering_summary, notes, booking_url",
+      )
       .eq("id", campaign.profile_id)
       .single();
     senderProfile = (profile as Record<string, unknown>) ?? null;
@@ -207,6 +209,7 @@ export async function POST(request: Request) {
       company: (senderProfile?.company_name as string) ?? null,
       offeringSummary: (senderProfile?.offering_summary as string) ?? null,
       notes: (senderProfile?.notes as string) ?? null,
+      bookingUrl: (senderProfile?.booking_url as string) ?? null,
     },
     factBank,
     learnings,

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -32,6 +32,7 @@ const emptyForm: ProfileFormData = {
   personal_url: "",
   linkedin_url: "",
   twitter_url: "",
+  booking_url: "",
   offering_summary: "",
   notes: "",
 };
@@ -91,6 +92,7 @@ export default function ProfileDetailPage() {
         personal_url: p.personal_url ?? "",
         linkedin_url: p.linkedin_url ?? "",
         twitter_url: p.twitter_url ?? "",
+        booking_url: p.booking_url ?? "",
         offering_summary: p.offering_summary ?? "",
         notes: p.notes ?? "",
       });
@@ -359,6 +361,25 @@ export default function ProfileDetailPage() {
                 placeholder="https://x.com/yourhandle"
               />
             </div>
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor="booking_url"
+              className="text-sm font-medium leading-none"
+            >
+              Meeting link
+            </label>
+            <Input
+              id="booking_url"
+              type="url"
+              value={form.booking_url ?? ""}
+              onChange={(e) => update("booking_url", e.target.value)}
+              placeholder="https://cal.com/yourname/15min"
+            />
+            <p className="text-muted-foreground text-xs">
+              Calendly, Cal.com, or any booking page. Whenever an email asks for
+              a call, the agent includes this link as the way to book.
+            </p>
           </div>
         </section>
 

--- a/src/lib/email-composition/skill.ts
+++ b/src/lib/email-composition/skill.ts
@@ -53,6 +53,7 @@ Body:
 The ask:
 - A short call is often the genuine offer, but a frictionless one is a documented AI tell. The ask must carry its reason: "15 minutes to compare notes on how you're handling SOC 2 evidence across regions". Never a bare "do you have 15 minutes?" and never a naked calendar link.
 - A specific question they can answer in one line beats a call whenever you have one.
+- MEETING LINK: if SENDER lists a meeting link and the ask is a call or meeting, the link goes in the email as the way to book: in bodyHtml as an <a href> on a short phrase inside the reasoned ask (never the bare URL as anchor text), and in bodyText as the raw URL on its own line right after the ask. Still one ask, still carrying its reason; the link is how they say yes, not the ask itself. Never write it when the ask is a one-line question, never write it more than once, and never invent a link when none is listed.
 
 Never write these. Each one marks the email as machine-written on sight:
 - "I saw you recently..." or "I noticed you're hiring", or any opener that would fit 500 other prospects
@@ -167,6 +168,9 @@ export function buildComposeUserPrompt(input: {
     company: string | null;
     offeringSummary?: string | null;
     notes?: string | null;
+    /** Meeting-booking URL. Rendered as its own SENDER line so the MEETING
+     * LINK rule in the system prompt has something concrete to point at. */
+    bookingUrl?: string | null;
   };
   previousSubject?: string | null;
   triggerReason?: string | null;
@@ -207,6 +211,10 @@ export function buildComposeUserPrompt(input: {
     );
   if (input.senderProfile.notes)
     senderLines.push(`- Sender notes: ${input.senderProfile.notes}`);
+  if (input.senderProfile.bookingUrl?.trim())
+    senderLines.push(
+      `- Meeting link (include when the ask is a call): ${input.senderProfile.bookingUrl.trim()}`,
+    );
   sections.push(`SENDER:\n${senderLines.join("\n")}`);
 
   sections.push(

--- a/src/lib/email-skills/swipe-prompts.ts
+++ b/src/lib/email-skills/swipe-prompts.ts
@@ -297,6 +297,8 @@ export interface SwipeSender {
   /** Free-form profile notes: constraints and corrections the user wrote for
    * the drafter ("solo consultant", "do not use company name in sign-off"). */
   notes?: string | null;
+  /** Meeting-booking URL; drafts that ask for a call include it. */
+  bookingUrl?: string | null;
   /** The rendered SENDER FACT BANK block, already fenced by renderFactBank.
    * Null when the user has no facts, which renders nothing. */
   factBank?: string | null;
@@ -327,6 +329,10 @@ function renderSender(sender: SwipeSender | null | undefined): string {
         field("Company", sender.companyName),
         field("What they sell", sender.offeringSummary),
         field("Sender notes (follow these)", sender.notes),
+        field(
+          "Meeting link (when a draft asks for a call, link it inside the ask; never as the whole ask)",
+          sender.bookingUrl,
+        ),
       ].filter(Boolean) as string[])
     : [];
 

--- a/src/lib/email-skills/swipe-service.ts
+++ b/src/lib/email-skills/swipe-service.ts
@@ -164,6 +164,7 @@ async function loadPromptContext(
           companyName: profile.company_name,
           offeringSummary: profile.offering_summary,
           notes: profile.notes,
+          bookingUrl: profile.booking_url,
           factBank,
         }
       : null,

--- a/src/lib/jobs/executors/outreach-process.ts
+++ b/src/lib/jobs/executors/outreach-process.ts
@@ -313,7 +313,9 @@ async function pickAndDraft(
   if (campaign?.profile_id) {
     const { data: profile } = await supabase
       .from("user_profile")
-      .select("id, name, role_title, company_name, offering_summary, notes")
+      .select(
+        "id, name, role_title, company_name, offering_summary, notes, booking_url",
+      )
       .eq("id", campaign.profile_id)
       .single();
     senderProfile = (profile as Record<string, unknown>) ?? null;
@@ -471,6 +473,7 @@ async function pickAndDraft(
           company: (senderProfile?.company_name as string) ?? null,
           offeringSummary: (senderProfile?.offering_summary as string) ?? null,
           notes: (senderProfile?.notes as string) ?? null,
+          bookingUrl: (senderProfile?.booking_url as string) ?? null,
         },
         factBank,
         learnings,

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -327,6 +327,10 @@ export function buildSystemPrompt(options?: {
     if (p.personal_url) lines.push(`- Website: ${p.personal_url}`);
     if (p.linkedin_url) lines.push(`- LinkedIn: ${p.linkedin_url}`);
     if (p.twitter_url) lines.push(`- Twitter/X: ${p.twitter_url}`);
+    if (p.booking_url)
+      lines.push(
+        `- Meeting link: ${p.booking_url} (whenever an email you write asks for a call or meeting, include this as the way to book: linked on a short phrase inside the ask, never as the whole ask, never more than once)`,
+      );
     if (p.offering_summary) lines.push(`- Offering: ${p.offering_summary}`);
     if (p.notes) lines.push(`- Notes: ${p.notes}`);
 

--- a/src/lib/tools/profile-tools.ts
+++ b/src/lib/tools/profile-tools.ts
@@ -26,6 +26,13 @@ export const updateUserProfile = tool({
     personal_url: z.string().url().optional().describe("Personal website URL"),
     linkedin_url: z.string().optional().describe("LinkedIn profile URL"),
     twitter_url: z.string().optional().describe("Twitter/X profile URL"),
+    booking_url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Meeting-booking link (Calendly, Cal.com, etc.). Once set, every email that asks for a call includes it as the way to book.",
+      ),
     offering_summary: z
       .string()
       .optional()

--- a/src/lib/tools/sequence-tools.ts
+++ b/src/lib/tools/sequence-tools.ts
@@ -358,7 +358,9 @@ export const draftEmailsForSequence = tool({
     const { data: profile } = campaign.profile_id
       ? await supabase
           .from("user_profile")
-          .select("id, name, role_title, company_name, offering_summary, notes")
+          .select(
+            "id, name, role_title, company_name, offering_summary, notes, booking_url",
+          )
           .eq("id", campaign.profile_id)
           .single()
       : { data: null };
@@ -558,6 +560,7 @@ export const draftEmailsForSequence = tool({
               company: profile?.company_name ?? null,
               offeringSummary: profile?.offering_summary ?? null,
               notes: profile?.notes ?? null,
+              bookingUrl: profile?.booking_url ?? null,
             },
             factBank,
             learnings,

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -8,6 +8,9 @@ export interface UserProfile {
   personal_url: string | null;
   linkedin_url: string | null;
   twitter_url: string | null;
+  /** Meeting-booking link (Calendly, Cal.com, ...). Drafts that ask for a
+   * call include it as the way to book. */
+  booking_url: string | null;
   role_title: string | null;
   offering_summary: string | null;
   notes: string | null;

--- a/supabase/migrations/20260816000000_profile_booking_url.sql
+++ b/supabase/migrations/20260816000000_profile_booking_url.sql
@@ -1,0 +1,9 @@
+-- The sender's meeting-booking link (Calendly, Cal.com, SavvyCal, Google
+-- appointment page, ...). Lives on the sender profile, not user_settings:
+-- profiles are the "who is writing" identity that campaigns link to, and a
+-- user with two profiles may book into two calendars.
+--
+-- Read by the compose prompt: whenever a draft's call to action is a call or
+-- meeting, the link goes in the email as the way to book. Nullable; a profile
+-- without one keeps asking for a reply instead.
+alter table user_profile add column if not exists booking_url text;


### PR DESCRIPTION
## Summary
Give Signal your calendar link once and every email that asks for a call includes it as the way to book.

- `user_profile.booking_url` (new migration `20260816000000_profile_booking_url.sql`)
- Compose prompt: SENDER carries a `Meeting link` line; system prompt gains a MEETING LINK rule (link on a short phrase inside the reasoned ask, raw URL in `bodyText`; never the whole ask, never twice, never invented, not when the ask is a one-line question)
- Threaded through all three compose callers (sequence fan-out, cron `outreach-process`, regenerate), the agent system-prompt profile block (ad-hoc `writeEmail`), the `createProfile`/`updateProfile` tools, the Profiles form (Meeting link field), and the voice deck sender context

## ⚠️ Deploy order
Run `supabase db push` for the migration **before** this deploys. The compose callers `select(... booking_url)` by name; without the column the profile lookup errors and drafts lose the sender name/title.

## Test plan
- [x] tsc, eslint clean; compose/swipe/sequence/system-prompt suites pass (73 tests, 2 new)
- [ ] Prod: set Meeting link on the profile, draft a sequence email with a call CTA, confirm the link is in the ask (HTML anchor + raw URL in text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)