### PR TITLE
feat(agent): openPage takes the user to a page instead of naming a path

### DIFF
--- a/src/__tests__/markdown-autolink.test.tsx
+++ b/src/__tests__/markdown-autolink.test.tsx
@@ -27,3 +27,39 @@ describe("Markdown domain auto-linking", () => {
     expect(container.querySelector("code a")).toBeNull();
   });
 });
+
+/**
+ * The agent used to say "head to /outreach/review?sequence=..." as bare prose
+ * the user had to copy into the address bar, and every markdown link opened a
+ * NEW tab, leaving the chat behind. In-app paths are now links that navigate
+ * the current tab; external URLs still open a new tab.
+ */
+describe("Markdown in-app paths", () => {
+  it("links a bare app path in prose, same tab", () => {
+    render(
+      <Markdown>
+        {"Approve them at /outreach/review?sequence=abc-123 when ready."}
+      </Markdown>,
+    );
+    const link = screen.getByRole("link", {
+      name: "/outreach/review?sequence=abc-123",
+    });
+    expect(link).toHaveAttribute("href", "/outreach/review?sequence=abc-123");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("does not link slashes that are not app routes", () => {
+    const { container } = render(
+      <Markdown>{"saved to /tmp/out.csv, ratio 3/4"}</Markdown>,
+    );
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("keeps external markdown links in a new tab", () => {
+    render(<Markdown>{"[docs](https://example.com/docs)"}</Markdown>);
+    expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute(
+      "target",
+      "_blank",
+    );
+  });
+});

--- a/src/__tests__/navigation-paths.test.ts
+++ b/src/__tests__/navigation-paths.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { isNavigablePath } from "@/lib/navigation";
+
+describe("isNavigablePath", () => {
+  it("accepts app routes with query strings", () => {
+    expect(isNavigablePath("/outreach/review?sequence=abc")).toBe(true);
+    expect(isNavigablePath("/campaigns/123")).toBe(true);
+    expect(isNavigablePath("/settings")).toBe(true);
+    expect(isNavigablePath("/")).toBe(true);
+  });
+
+  // The path comes out of model output and lands in router.push and an
+  // <a href>; anything that could leave the app is rejected outright.
+  it("rejects anything that could leave the app", () => {
+    expect(isNavigablePath("https://evil.example")).toBe(false);
+    expect(isNavigablePath("//evil.example/outreach")).toBe(false);
+    expect(isNavigablePath("javascript:alert(1)")).toBe(false);
+    expect(isNavigablePath("/outreach/review?x=<script>")).toBe(false);
+  });
+
+  it("rejects paths the app does not serve", () => {
+    expect(isNavigablePath("/tmp/out.csv")).toBe(false);
+    expect(isNavigablePath("/outreachy")).toBe(false);
+    expect(isNavigablePath("/api/chat")).toBe(false);
+  });
+});

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import type { UIMessage } from "ai";
 import { useChat } from "@ai-sdk/react";
 
@@ -15,6 +15,7 @@ import { useCampaign } from "@/lib/campaign-context";
 import { toTranscript } from "@/lib/email-skills/swipe-run";
 import { useStreaming } from "@/lib/streaming-context";
 import { useVoiceRun } from "@/lib/voice-run-context";
+import { isNavigablePath } from "@/lib/navigation";
 import { saveChat } from "@/lib/services/chat-history";
 import { createClient } from "@/lib/supabase/client";
 
@@ -162,6 +163,7 @@ function AgentPanelInner({
   const startX = useRef(0);
   const startWidth = useRef(0);
   const pathname = usePathname();
+  const router = useRouter();
   const { register } = useStreaming();
   const { consumePendingPrompt, pendingPrompt } = useCampaign();
   const {
@@ -192,6 +194,15 @@ function AgentPanelInner({
     transport,
     onData(part) {
       if (part.type === "data-turn-paused") turnPausedRef.current = true;
+      // openPage: the agent takes the user to a page instead of naming a
+      // path. Client-side push, so this panel and its chat stay exactly as
+      // they are. Transient, so a reloaded chat never re-navigates.
+      if (part.type === "data-navigate") {
+        const d = (part as { data?: { path?: unknown } }).data;
+        if (d && typeof d.path === "string" && isNavigablePath(d.path)) {
+          router.push(d.path);
+        }
+      }
       // Voice drafts and saves ride the stream as transient parts; the run
       // provider applies them so the deck updates while the agent talks.
       if (part.type.startsWith("data-voice-")) {

--- a/src/components/chat/tool-call-card.tsx
+++ b/src/components/chat/tool-call-card.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import {
   Activity,
   AlertCircle,
+  ArrowUpRight,
   BarChart3,
   Bookmark,
   Building2,
@@ -26,6 +28,8 @@ import {
 } from "lucide-react";
 
 import { ContactCards } from "./contact-card";
+import { buttonVariants } from "@/components/ui/button";
+import { isNavigablePath } from "@/lib/navigation";
 
 export interface ToolCallCardProps {
   toolName: string;
@@ -114,6 +118,8 @@ const TOOL_CONFIG: Record<
   draftSequenceEmails: { label: "Drafting sequence emails", icon: Mail },
   draftEmailsForSequence: { label: "Drafting sequence emails", icon: Mail },
   getSequenceStatus: { label: "Loading sequence status", icon: List },
+  // Navigation
+  openPage: { label: "Opening page", icon: ArrowUpRight },
   // Voice
   startVoiceRun: { label: "Starting voice drafting", icon: Mic },
   rewriteVoiceDrafts: { label: "Rewriting drafts", icon: Mic },
@@ -186,6 +192,27 @@ export function ToolCallCard({
   const hasOutput = state === "output-available";
   const hasError = state === "output-error";
   const isInline = INLINE_TOOLS.has(toolName);
+
+  // openPage already navigated the tab when it ran; what stays in the
+  // transcript is a button back to the page, so the destination is one click
+  // away after the turn ends or the chat is reloaded. Same-tab Next link:
+  // the chat panel lives in the shell and survives client-side navigation.
+  if (toolName === "openPage" && hasOutput && output != null) {
+    const nav = output as { path?: unknown; label?: unknown; error?: unknown };
+    if (typeof nav.path === "string" && isNavigablePath(nav.path)) {
+      return (
+        <div className="my-1">
+          <Link
+            href={nav.path}
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            <ArrowUpRight className="h-3.5 w-3.5" />
+            Open {typeof nav.label === "string" ? nav.label : "page"}
+          </Link>
+        </div>
+      );
+    }
+  }
 
   // Inline tools render their results directly below the status bar
   if (isInline && hasOutput && output != null) {

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -1,7 +1,9 @@
+import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
+import { isNavigablePath } from "@/lib/navigation";
 
 interface MarkdownProps {
   children: string;
@@ -10,6 +12,24 @@ interface MarkdownProps {
 
 const DOMAIN_RE =
   /(?<=^|[\s|])([a-z0-9][-a-z0-9]*(?:\.[a-z0-9][-a-z0-9]*)*\.(?:co\.uk|com|org|net|io|dev|ai|uk|app|xyz|biz|me|co|tech|agency|info|us|ca|de|fr|eu|property|estate|house|homes|realty))(?=[\s|,)]|$)/gim;
+
+/**
+ * Bare in-app paths in prose ("approve them at /outreach/review?sequence=...")
+ * become links. Only paths the app actually serves (isNavigablePath), so a
+ * stray "/tmp/x" or a slash inside a sentence is left alone. Fenced code is
+ * skipped by the same segment split as autoLinkDomains.
+ */
+const APP_PATH_RE =
+  /(?<=^|[\s(])(\/[a-z][a-z0-9\-\/]*(?:\?[^\s)<>"']*)?)(?=[\s.,;:)]|$)/gim;
+
+function autoLinkAppPaths(text: string): string {
+  return text.replace(APP_PATH_RE, (match) => {
+    // A trailing "." or "," is sentence punctuation, not the path.
+    const trimmed = match.replace(/[.,;:]+$/, "");
+    if (!isNavigablePath(trimmed) || trimmed === "/") return match;
+    return `[${trimmed}](${trimmed})${match.slice(trimmed.length)}`;
+  });
+}
 
 function autoLinkDomains(text: string): string {
   // Fenced code blocks are left byte-for-byte alone: this rewrite runs on the
@@ -21,8 +41,10 @@ function autoLinkDomains(text: string): string {
     .map((segment, i) =>
       i % 2 === 1
         ? segment
-        : segment.replace(DOMAIN_RE, (match) =>
-            match.includes(":") ? match : `[${match}](https://${match})`,
+        : autoLinkAppPaths(
+            segment.replace(DOMAIN_RE, (match) =>
+              match.includes(":") ? match : `[${match}](https://${match})`,
+            ),
           ),
     )
     .join("");
@@ -39,11 +61,23 @@ export function Markdown({ children, className }: MarkdownProps) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          a: ({ children, href, ...props }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
-              {children}
-            </a>
-          ),
+          // In-app paths navigate the tab the user is in, chat panel and
+          // all; only real external URLs open a new tab.
+          a: ({ children, href, ...props }) =>
+            href && isNavigablePath(href) ? (
+              <Link href={href} {...props}>
+                {children}
+              </Link>
+            ) : (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                {...props}
+              >
+                {children}
+              </a>
+            ),
           p: ({ children, ...props }) => (
             <p className="mb-2 last:mb-0" {...props}>
               {children}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,31 @@
+/**
+ * Which in-app paths the agent (and chat markdown) may navigate to. Pure, no
+ * dependencies, so the client bundle can import it without dragging in the
+ * tool runtime.
+ *
+ * Paths only: no scheme, no host, no protocol-relative `//`, so nothing that
+ * reads a path out of model output can become an open redirect.
+ */
+
+/** Top-level app routes the agent may open. Keep in step with src/app/. */
+export const NAVIGABLE_PREFIXES = [
+  "/",
+  "/campaigns",
+  "/companies",
+  "/outreach",
+  "/signals",
+  "/tracking",
+  "/profile",
+  "/email-skills",
+  "/settings",
+  "/chat",
+] as const;
+
+export function isNavigablePath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (/[\s<>"'\\]/.test(path)) return false;
+  const pathname = path.split(/[?#]/)[0];
+  return NAVIGABLE_PREFIXES.some(
+    (p) => pathname === p || (p !== "/" && pathname.startsWith(`${p}/`)),
+  );
+}

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -145,7 +145,7 @@ Every contact carries evidence for *why* we believe they work where we say they 
 ### Writing & Sending Emails
 - Use \`writeEmail\` to compose an email draft. This saves it to the database -- it does NOT send.
 - ALL drafts (including ad-hoc writeEmail drafts) start pending and must be approved by the user in /outreach/review before they can be sent. \`sendEmail\` refuses drafts that have not been approved there, and rejected drafts can never be sent.
-- After calling writeEmail, present the full draft to the user: To, Subject, and Body -- and point them to /outreach/review to approve it
+- After calling writeEmail, present the full draft to the user: To, Subject, and Body -- then call \`openPage\` with /outreach/review so they can approve it without leaving the chat
 - Wait for the user to explicitly confirm ("send it", "looks good", "go ahead") before calling \`sendEmail\`. Chat confirmation is required on top of review approval; it does not replace it.
 - If the user wants changes, call \`writeEmail\` again with the updated content (old draft stays as-is)
 - Use \`sendEmail\` with the draft ID only after the draft is approved and the user confirms
@@ -184,7 +184,7 @@ When the user asks to set up outreach, email a campaign, create a sequence, or d
 1. Call \`createSequence\` with the sequence name, campaign, trigger signal, and steps
 2. Call \`draftEmailsForSequence\` with the sequenceId. This is a SERVER-SIDE fan-out: it loads each contact's enrichment and composes all drafts in parallel via sub-agents. You do NOT loop through contacts or call writeEmail yourself; one tool call handles the entire batch.
 3. The tool returns \`{drafted, skipped, failed, reviewUrl}\`. Report those counts to the user.
-4. Tell the user to go to /outreach/review?sequence=ID to review and approve.
+4. Call \`openPage\` with path /outreach/review?sequence=ID and a label naming the sequence. That opens the review queue in the user's tab with this chat still beside it. Never tell them to "head to" or "go to" a path instead.
 5. Do NOT paste full email bodies in chat, just the summary counts.
 6. The user reviews and approves/rejects/edits emails in the review UI, not in chat.
 
@@ -262,7 +262,12 @@ Deleting a company or contact from a campaign only unlinks it from that campaign
 ## Formatting
 - NEVER use emojis in any response
 - **NEVER use em dashes (\u2014) in anything you write**: chat replies, email subjects and bodies, campaign names, sequence names, signal descriptions, notes, or any text you save to the database. Rewrite with a comma, colon, semicolon, parentheses, or a full stop. This holds even when the user's own message uses them, and even when you are quoting your own earlier phrasing. En dashes (\u2013) in prose are out too; a plain hyphen in a numeric range (50-125) or a compound word (spray-and-pray) is fine.
-- **Never print internal IDs in your prose.** Campaign IDs, organization IDs, person IDs, sequence IDs and draft IDs are plumbing you pass between tools; they mean nothing to the user and make a reply look like a debug log. Refer to things by name ("Granola is in the campaign"), not by UUID. The only exceptions are URLs the user is meant to click (e.g. /outreach/review?sequence=ID) and a case where the user explicitly asks for an ID.
+- **Never print internal IDs in your prose.** Campaign IDs, organization IDs, person IDs, sequence IDs and draft IDs are plumbing you pass between tools; they mean nothing to the user and make a reply look like a debug log. Refer to things by name ("Granola is in the campaign"), not by UUID. The only exceptions are the path you pass to \`openPage\` and a case where the user explicitly asks for an ID.
+
+### Taking the user to a page
+- You can navigate the app for the user: \`openPage\` opens any in-app path (review queue, a campaign, a sequence, Settings, the email voice deck) in the tab they are in, with this chat still open beside it, and leaves a button in the transcript.
+- Whenever you would otherwise write "go to", "head to", "navigate to" or "visit" followed by a path, call \`openPage\` instead and refer to the page by name ("The review queue is open on the left").
+- Do it once per destination per turn, after the work that makes the page worth looking at (drafts landed, sequence created), not before.
 - Always use markdown tables when presenting multiple companies OR contacts, never bullet lists for structured data
 - For contacts: use a table with columns like Name, Title, Company, LinkedIn
 - For companies: use a table with columns like Company, Size, Key Info, Priority

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -92,9 +92,11 @@ import {
   suppressContact,
   getOutreachPerformance,
 } from "./learning-tools";
+import { openPage } from "./navigation-tools";
 import { getPostHogClient } from "@/lib/posthog-server";
 
 const rawTools = {
+  openPage,
   saveCampaign,
   getCampaign,
   listCampaigns,

--- a/src/lib/tools/navigation-tools.ts
+++ b/src/lib/tools/navigation-tools.ts
@@ -1,0 +1,74 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { isNavigablePath, NAVIGABLE_PREFIXES } from "@/lib/navigation";
+
+/**
+ * openPage: the agent takes the user to a page in the app instead of telling
+ * them to go there.
+ *
+ * "Head to /outreach/review to approve" was the whole hand-off before: a bare
+ * path in prose, not even a link, that the user had to copy into the address
+ * bar (leaving the chat behind). The tool writes a transient `data-navigate`
+ * part that the agent panel turns into a client-side router.push, so the page
+ * opens in the SAME tab with the chat still beside it. The tool result renders
+ * as a button, so the destination stays one click away after the turn ends
+ * and after a reload (transient parts are never persisted, so a rehydrated
+ * chat never re-navigates on its own).
+ *
+ * Paths are validated against the app's own routes, and only paths: no
+ * scheme, no host, no protocol-relative `//`, so this can never become an
+ * open redirect driven by tool output.
+ */
+
+interface NavToolCtx {
+  writer?: { write: (chunk: unknown) => void };
+}
+
+export const openPage = tool({
+  description:
+    "Open a page of this app for the user, in the tab they are already in, with " +
+    "this chat still open beside it. Use it INSTEAD of telling the user to 'go to' " +
+    "or 'head to' a path: after drafts land, open the review queue; after a " +
+    "sequence is created, open it; when they need a setting, open Settings. The " +
+    "result also renders as a button so they can come back to the page later. " +
+    "Paths only (e.g. '/outreach/review?sequence=<id>'), never full URLs.",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .min(1)
+      .max(500)
+      .describe(
+        "In-app path, starting with '/'. Query strings are fine: '/outreach/review?sequence=<uuid>'.",
+      ),
+    label: z
+      .string()
+      .min(1)
+      .max(60)
+      .describe(
+        "Short button label naming the destination, e.g. 'Review queue', 'Founder Outreach sequence', 'Email settings'.",
+      ),
+  }),
+  execute: async (input, { experimental_context }) => {
+    const path = input.path.trim();
+    if (!isNavigablePath(path)) {
+      return {
+        error:
+          "Not an app path. Pass a path under one of: " +
+          NAVIGABLE_PREFIXES.join(", "),
+      };
+    }
+    const ctx = (experimental_context as NavToolCtx | undefined) ?? {};
+    ctx.writer?.write({
+      type: "data-navigate",
+      data: { path, label: input.label },
+      transient: true,
+    });
+    return {
+      ok: true,
+      path,
+      label: input.label,
+      note: "The page is now open beside this chat, and a button to it is in the transcript. Do not paste the path in your reply; refer to the page by name.",
+    };
+  },
+});


### PR DESCRIPTION
## Summary
The agent no longer says "head to /outreach/review". It opens the page for you, in the tab you're in, with the chat still beside it, and leaves a button in the transcript.

- **`openPage` tool** (`src/lib/tools/navigation-tools.ts`): emits a transient `data-navigate` part → agent panel does a client-side `router.push`. Result renders as an "Open <label>" button. Transient parts aren't persisted, so a reloaded chat never re-navigates on its own.
- **Path safety** (`src/lib/navigation.ts`): only the app's own routes; rejects schemes, hosts, `//`, and script-ish characters, so tool output can't become an open redirect. Shared by the tool, the card, the panel and the markdown renderer.
- **Markdown**: in-app links render as same-tab Next links, bare app paths in prose (`/outreach/review?sequence=…`) become links, external URLs still open a new tab.
- **System prompt**: use `openPage` wherever it would have said go/head/navigate to a path; refer to the page by name; once per destination per turn, after the work that makes it worth looking at.

## Test plan
- [x] tsc, eslint clean; full vitest suite 1016 passing (new: navigation-paths, markdown in-app paths)
- [ ] Prod: draft a sequence; the review queue opens in the same tab with the chat panel still there, and the transcript shows an "Open … sequence" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)