### PR TITLE
perf(tools): paginate list tools, slim DB reads, compact MCP results

### DIFF
--- a/src/__tests__/companies-list-shape.test.ts
+++ b/src/__tests__/companies-list-shape.test.ts
@@ -27,7 +27,8 @@ const fakeRows = [
 const mockRange = vi
   .fn()
   .mockResolvedValue({ data: fakeRows, error: null, count: fakeRows.length });
-const mockOrder = vi.fn(() => ({ range: mockRange }));
+const mockOrderTiebreak = vi.fn(() => ({ range: mockRange }));
+const mockOrder = vi.fn(() => ({ order: mockOrderTiebreak }));
 const mockEq = vi.fn(() => ({ order: mockOrder }));
 const mockSelect = vi.fn(() => ({ eq: mockEq }));
 const mockFrom = vi.fn((_table?: string) => ({ select: mockSelect }));
@@ -64,6 +65,16 @@ describe("getCompanies return shape", () => {
     const selectArg = String((mockSelect.mock.calls.at(-1) as unknown[])[0]);
     expect(selectArg).not.toContain("*");
     expect(selectArg).not.toContain("enrichment_data");
+  });
+
+  it("orders by id after relevance so pages never drift on ties", async () => {
+    await getCompanies.execute!({ campaignId: "c1" }, {} as never);
+    expect(mockOrder).toHaveBeenLastCalledWith("relevance_score", {
+      ascending: false,
+    });
+    expect(mockOrderTiebreak).toHaveBeenLastCalledWith("id", {
+      ascending: true,
+    });
   });
 
   it("pages with limit/offset and reports total + hasMore", async () => {

--- a/src/__tests__/companies-list-shape.test.ts
+++ b/src/__tests__/companies-list-shape.test.ts
@@ -24,7 +24,10 @@ const fakeRows = [
   },
 ];
 
-const mockOrder = vi.fn().mockResolvedValue({ data: fakeRows, error: null });
+const mockRange = vi
+  .fn()
+  .mockResolvedValue({ data: fakeRows, error: null, count: fakeRows.length });
+const mockOrder = vi.fn(() => ({ range: mockRange }));
 const mockEq = vi.fn(() => ({ order: mockOrder }));
 const mockSelect = vi.fn(() => ({ eq: mockEq }));
 const mockFrom = vi.fn((_table?: string) => ({ select: mockSelect }));
@@ -54,5 +57,46 @@ describe("getCompanies return shape", () => {
       domain: "acme.com",
       relevance_score: 9,
     });
+  });
+
+  it("selects named columns only, never organizations(*)", async () => {
+    await getCompanies.execute!({ campaignId: "c1" }, {} as never);
+    const selectArg = String((mockSelect.mock.calls.at(-1) as unknown[])[0]);
+    expect(selectArg).not.toContain("*");
+    expect(selectArg).not.toContain("enrichment_data");
+  });
+
+  it("pages with limit/offset and reports total + hasMore", async () => {
+    mockRange.mockResolvedValueOnce({ data: fakeRows, error: null, count: 7 });
+    const result = (await getCompanies.execute!(
+      { campaignId: "c1", limit: 1, offset: 2 },
+      {} as never,
+    )) as { total: number; limit: number; offset: number; hasMore: boolean };
+    expect(mockRange).toHaveBeenLastCalledWith(2, 2);
+    expect(result).toMatchObject({
+      total: 7,
+      limit: 1,
+      offset: 2,
+      hasMore: true,
+    });
+  });
+
+  it("clips long descriptions in list rows", async () => {
+    const long = "x".repeat(1000);
+    mockRange.mockResolvedValueOnce({
+      data: [
+        {
+          ...fakeRows[0],
+          organization: { ...fakeRows[0].organization, description: long },
+        },
+      ],
+      error: null,
+      count: 1,
+    });
+    const result = (await getCompanies.execute!(
+      { campaignId: "c1" },
+      {} as never,
+    )) as { companies: Array<{ description: string }> };
+    expect(result.companies[0].description.length).toBeLessThan(300);
   });
 });

--- a/src/__tests__/contacts-list-shape.test.ts
+++ b/src/__tests__/contacts-list-shape.test.ts
@@ -27,7 +27,8 @@ const fakeRows = [
   },
 ];
 
-const mockOrder2 = vi.fn().mockResolvedValue({ data: fakeRows, error: null });
+const mockOrder3 = vi.fn().mockResolvedValue({ data: fakeRows, error: null });
+const mockOrder2 = vi.fn(() => ({ order: mockOrder3 }));
 const mockOrder1 = vi.fn(() => ({ order: mockOrder2 }));
 const mockEq = vi.fn(() => ({ order: mockOrder1 }));
 const mockSelect = vi.fn(() => ({ eq: mockEq }));

--- a/src/__tests__/mcp-registry.test.ts
+++ b/src/__tests__/mcp-registry.test.ts
@@ -12,7 +12,7 @@ describe("mcp registry", () => {
     const names = mcpToolList().map((t) => t.name);
     expect(names).toContain("searchCompanies");
     expect(names).toContain("deleteCompanies");
-    expect(names).toContain("openPage");
+    expect(names).not.toContain("openPage");
     // Voice tools need the chat UI's swipe run; useless over MCP.
     expect(names).not.toContain("startVoiceRun");
     expect(names).not.toContain("rewriteVoiceDrafts");

--- a/src/__tests__/mcp-registry.test.ts
+++ b/src/__tests__/mcp-registry.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { mcpToolList, toMcpResult } from "@/lib/mcp/registry";
+import {
+  MCP_RESULT_MAX_CHARS,
+  mcpToolList,
+  toMcpResult,
+} from "@/lib/mcp/registry";
 
 describe("mcp registry", () => {
   it("exposes every agent tool except the UI-only exclusions", () => {
@@ -21,12 +25,20 @@ describe("mcp registry", () => {
     }
   });
 
-  it("serialises results as a single JSON text block", () => {
+  it("serialises results as a single compact JSON text block", () => {
     expect(toMcpResult({ ok: 1 })).toEqual({
-      content: [{ type: "text", text: JSON.stringify({ ok: 1 }, null, 2) }],
+      content: [{ type: "text", text: '{"ok":1}' }],
     });
     expect(toMcpResult("plain")).toEqual({
       content: [{ type: "text", text: "plain" }],
     });
+  });
+
+  it("truncates oversized results with a paging hint", () => {
+    const big = { rows: "y".repeat(MCP_RESULT_MAX_CHARS + 500) };
+    const { text } = toMcpResult(big).content[0];
+    expect(text.length).toBeLessThan(MCP_RESULT_MAX_CHARS + 300);
+    expect(text).toContain("Result truncated");
+    expect(text).toContain("limit/offset");
   });
 });

--- a/src/lib/mcp/registry.ts
+++ b/src/lib/mcp/registry.ts
@@ -6,12 +6,13 @@ import { allTools } from "@/lib/tools";
  * Tools that only make sense with the web chat's UI attached. The voice tools
  * read the active swipe run from experimental_context.voiceRun, which only the
  * chat route supplies; over MCP they could only ever answer "no active run".
- * openPage is fine: without a writer it degrades to returning the path.
  */
 const MCP_EXCLUDE = new Set<string>([
   "startVoiceRun",
   "rewriteVoiceDrafts",
   "saveVoiceProfile",
+  // Promises to navigate the user's browser tab; over MCP there is none.
+  "openPage",
 ]);
 
 export type McpTool = {

--- a/src/lib/mcp/registry.ts
+++ b/src/lib/mcp/registry.ts
@@ -39,12 +39,25 @@ export function mcpToolList(): McpTool[] {
     });
 }
 
+/**
+ * Largest result handed back to an MCP client, in characters. Past this the
+ * client would have to spill the payload to disk anyway; the note tells the
+ * model to page or narrow instead of retrying the same call.
+ */
+export const MCP_RESULT_MAX_CHARS = 100_000;
+
 export function toMcpResult(result: unknown): {
   content: Array<{ type: "text"; text: string }>;
 } {
-  const text =
-    typeof result === "string"
-      ? result
-      : JSON.stringify(result ?? null, null, 2);
+  // Compact JSON: indentation was a quarter of every payload for nothing.
+  let text =
+    typeof result === "string" ? result : JSON.stringify(result ?? null);
+  if (text.length > MCP_RESULT_MAX_CHARS) {
+    const full = text.length;
+    text =
+      text.slice(0, MCP_RESULT_MAX_CHARS) +
+      `\n\n[Result truncated: ${MCP_RESULT_MAX_CHARS} of ${full} characters shown. ` +
+      "Use limit/offset or a narrower filter and call again.]";
+  }
   return { content: [{ type: "text", text }] };
 }

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -50,6 +50,7 @@ import {
 } from "@/lib/services/hiring-scraper";
 import type { CompanyClaim } from "@/lib/types/claims";
 import { withTimeout } from "@/lib/utils/timeout";
+import { clipText, LIST_DEFAULT_LIMIT, LIST_MAX_LIMIT } from "./search-tools";
 
 /** Ceiling for one company's full enrichment chain. */
 const PER_COMPANY_TIMEOUT_MS = 150_000;
@@ -1909,7 +1910,7 @@ export const findContacts = tool({
 
 export const getContacts = tool({
   description:
-    "Fetch stored contacts for a campaign with optional filtering. Returns a THIN list (no enrichment_data) so context stays small. For deep detail on one contact (bio, Twitter, etc.), call getContactDetail(personId).",
+    "Fetch stored contacts for a campaign, highest priority first, with optional filters. Paginated: default 50 rows, pass offset for the next page (hasMore tells you). Thin rows only (no enrichment_data); for deep detail on one contact call getContactDetail(personId).",
   inputSchema: z.object({
     campaignId: z.string().uuid().describe("Campaign ID"),
     enrichmentStatus: z
@@ -1921,9 +1922,26 @@ export const getContacts = tool({
       .uuid()
       .optional()
       .describe("Filter by campaign-organization link ID"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(LIST_MAX_LIMIT)
+      .optional()
+      .describe(
+        `Rows per page, default ${LIST_DEFAULT_LIMIT}, max ${LIST_MAX_LIMIT}.`,
+      ),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Rows to skip (for paging). Default 0."),
   }),
   execute: async (input) => {
     const supabase = await createClient();
+    const limit = input.limit ?? LIST_DEFAULT_LIMIT;
+    const offset = input.offset ?? 0;
 
     const query = supabase
       .from("campaign_people")
@@ -1982,6 +2000,11 @@ export const getContacts = tool({
       );
     }
 
+    // Filters above run in memory (they live on the joined person row), so
+    // page after filtering; the select is already thin.
+    const total = results.length;
+    results = results.slice(offset, offset + limit);
+
     // Flatten for backwards compat
     const contacts = results.map((row) => {
       const person = row.person as unknown as Record<string, unknown>;
@@ -1998,7 +2021,7 @@ export const getContacts = tool({
         enrichment_status: person.enrichment_status,
         outreach_status: row.outreach_status,
         priority_score: row.priority_score,
-        score_reason: row.score_reason,
+        score_reason: clipText(row.score_reason),
         source: person.source,
         company: person.organization || null,
         created_at: row.created_at,
@@ -2006,7 +2029,13 @@ export const getContacts = tool({
       };
     });
 
-    return { contacts };
+    return {
+      contacts,
+      total,
+      limit,
+      offset,
+      hasMore: offset + contacts.length < total,
+    };
   },
 });
 

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -1950,7 +1950,9 @@ export const getContacts = tool({
       )
       .eq("campaign_id", input.campaignId)
       .order("priority_score", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false });
+      .order("created_at", { ascending: false })
+      // Each page is its own fetch; a total order keeps pages consistent.
+      .order("id", { ascending: true });
 
     const { data, error } = await query;
 

--- a/src/lib/tools/enrichment-tools.ts
+++ b/src/lib/tools/enrichment-tools.ts
@@ -1952,6 +1952,10 @@ export const getContacts = tool({
       .order("priority_score", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false })
       // Each page is its own fetch; a total order keeps pages consistent.
+      // Offset paging still drifts if scores are rewritten between pages
+      // (a rescored row can cross the boundary). Accepted: the window is
+      // one agent turn and the cost is a repeated or skipped list row.
+      // Keyset paging would fix it at the price of a cursor in the API.
       .order("id", { ascending: true });
 
     const { data, error } = await query;

--- a/src/lib/tools/search-tools.ts
+++ b/src/lib/tools/search-tools.ts
@@ -35,6 +35,16 @@ import {
 } from "@/lib/prompt-safety";
 
 /** Parallel website lookups per batch. One paid lookup each, so keep it low. */
+/** Paging defaults for the list tools; shared with getContacts. */
+export const LIST_DEFAULT_LIMIT = 50;
+export const LIST_MAX_LIMIT = 200;
+/** Long free text is clipped in list rows; the detail tools return it whole. */
+export const LIST_TEXT_CLIP = 240;
+export function clipText(value: unknown): unknown {
+  if (typeof value !== "string" || value.length <= LIST_TEXT_CLIP) return value;
+  return value.slice(0, LIST_TEXT_CLIP - 1) + "\u2026";
+}
+
 const DOMAIN_RESOLVE_CONCURRENCY = 4;
 
 export const searchCompanies = tool({
@@ -175,20 +185,43 @@ export const searchCompanies = tool({
 
 export const getCompanies = tool({
   description:
-    "Fetch stored companies for a campaign, with optional filtering by status. Returns a THIN list (no enrichment_data) so context stays small. For deep detail on one company, call getCompanyDetail(organizationId).",
+    "Fetch stored companies for a campaign, best relevance first, with optional status filter. Paginated: default 50 rows, pass offset for the next page (hasMore tells you). Thin rows only (no enrichment_data); for deep detail on one company call getCompanyDetail(organizationId).",
   inputSchema: z.object({
     campaignId: z.string().uuid().describe("Campaign ID"),
     status: z
       .enum(["discovered", "qualified", "disqualified"])
       .optional()
       .describe("Filter by company status"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(LIST_MAX_LIMIT)
+      .optional()
+      .describe(
+        `Rows per page, default ${LIST_DEFAULT_LIMIT}, max ${LIST_MAX_LIMIT}.`,
+      ),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Rows to skip (for paging). Default 0."),
   }),
   execute: async (input) => {
     const supabase = await createClient();
+    const limit = input.limit ?? LIST_DEFAULT_LIMIT;
+    const offset = input.offset ?? 0;
 
+    // Name the columns: `organizations(*)` used to pull every row's
+    // enrichment_data blob out of Postgres only for the flatten below to
+    // drop it, which made a 145-company campaign a multi-megabyte read.
     let query = supabase
       .from("campaign_organizations")
-      .select("*, organization:organizations(*)")
+      .select(
+        "id, organization_id, campaign_id, relevance_score, score_reason, status, created_at, updated_at, organization:organizations(name, domain, url, industry, location, description, enrichment_status, source)",
+        { count: "exact" },
+      )
       .eq("campaign_id", input.campaignId)
       .order("relevance_score", { ascending: false });
 
@@ -196,13 +229,16 @@ export const getCompanies = tool({
       query = query.eq("status", input.status);
     }
 
-    const { data, error } = await query;
+    const { data, error, count } = await query.range(
+      offset,
+      offset + limit - 1,
+    );
 
     if (error) throw new Error(`Failed to get companies: ${error.message}`);
 
     // Flatten for backwards compat with agent expectations
     const companies = (data || []).map((row) => {
-      const org = row.organization as Record<string, unknown>;
+      const org = row.organization as unknown as Record<string, unknown>;
       return {
         id: row.id,
         organization_id: row.organization_id,
@@ -212,10 +248,10 @@ export const getCompanies = tool({
         url: org.url,
         industry: org.industry,
         location: org.location,
-        description: org.description,
+        description: clipText(org.description),
         enrichment_status: org.enrichment_status,
         relevance_score: row.relevance_score,
-        score_reason: row.score_reason,
+        score_reason: clipText(row.score_reason),
         status: row.status,
         source: org.source,
         created_at: row.created_at,
@@ -223,7 +259,14 @@ export const getCompanies = tool({
       };
     });
 
-    return { companies };
+    const total = count ?? offset + companies.length;
+    return {
+      companies,
+      total,
+      limit,
+      offset,
+      hasMore: offset + companies.length < total,
+    };
   },
 });
 

--- a/src/lib/tools/search-tools.ts
+++ b/src/lib/tools/search-tools.ts
@@ -223,7 +223,10 @@ export const getCompanies = tool({
         { count: "exact" },
       )
       .eq("campaign_id", input.campaignId)
-      .order("relevance_score", { ascending: false });
+      .order("relevance_score", { ascending: false })
+      // Ties on score would otherwise drift between pages; id makes the
+      // order total so range() never repeats or skips a row.
+      .order("id", { ascending: true });
 
     if (input.status) {
       query = query.eq("status", input.status);

--- a/src/lib/tools/search-tools.ts
+++ b/src/lib/tools/search-tools.ts
@@ -225,7 +225,9 @@ export const getCompanies = tool({
       .eq("campaign_id", input.campaignId)
       .order("relevance_score", { ascending: false })
       // Ties on score would otherwise drift between pages; id makes the
-      // order total so range() never repeats or skips a row.
+      // order total so range() never repeats or skips a row. Rescoring
+      // between pages can still move a row across the boundary; see the
+      // note on getContacts, same trade-off.
       .order("id", { ascending: true });
 
     if (input.status) {


### PR DESCRIPTION
Follow-up to #110, from the prod E2E where getCompanies returned 159 KB for one campaign.

**getCompanies** (`src/lib/tools/search-tools.ts`): selected `organizations(*)`, pulling every enrichment_data blob out of Postgres only to drop it in the flatten. Now names its columns, pages (`limit` default 50, max 200; `offset`), returns `total`/`hasMore`, and clips description/score_reason to 240 chars. Faster for the web chat too.

**getContacts** (`src/lib/tools/enrichment-tools.ts`): same paging + clip; pages after its in-memory filters since select was already thin.

**MCP results** (`src/lib/mcp/registry.ts`): compact JSON instead of 2-space indented (about a quarter of every payload); results over 100 KB are truncated with a paging hint. `openPage` excluded from MCP: it promises to navigate a browser tab that MCP clients do not have.

**Deliberately not done:** rewriting tool descriptions to save context. They steer the web agent and a rewrite is where a silent regression would come from; the saving (~2k tokens/turn) is not worth it.

**Regression checks:** result keys `companies`/`contacts` unchanged (new fields only additive); no consumer outside the tools reads those shapes (tool-call-card only uses labels). 1039 unit tests pass, typecheck and lint clean, `pnpm build` OK. New queries live-probed against local Supabase via the RLS path (PostgREST accepts the named embedded select + count + range).

No env or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)